### PR TITLE
Improvements for BUML to SQL template generator

### DIFF
--- a/src/generators/sql/templates/sql_dialects.sql.j2
+++ b/src/generators/sql/templates/sql_dialects.sql.j2
@@ -70,7 +70,7 @@ ADD COLUMN {{ generalization.general.name }}_id INT REFERENCES {{ generalization
     {% elif sql_dialect == "mysql" %}
 ALTER TABLE {{ class_name }}
 ADD COLUMN {{ generalization.general.name }}_id INT,
-ADD CONSTRAINT fk_{{ generalization.general.name }}
+ADD CONSTRAINT generalization_{{ generalization.general.name }}
 FOREIGN KEY ({{ generalization.general.name }}_id) REFERENCES {{ generalization.general.name }}(id);
     {% else %}
 ALTER TABLE {{ class_name }}

--- a/src/generators/sql/templates/sql_dialects.sql.j2
+++ b/src/generators/sql/templates/sql_dialects.sql.j2
@@ -4,21 +4,33 @@
 CREATE TABLE IF NOT EXISTS {{ class_name }} (
     {{ class_name }}_id SERIAL PRIMARY KEY,
     {% for attribute in attributes %}
-    {{ attribute.name }} {{ types[attribute.type.name] }},
+        {% if loop.last %}
+    {{ attribute.name }} {{ types[attribute.type.name] }}
+        {% else %}
+    {{ attribute.name }} {{ types[attribute.type.name] }},      
+        {% endif %}
     {% endfor %}
 );
     {% elif sql_dialect == "mysql" %}
 CREATE TABLE IF NOT EXISTS {{ class_name }} (
     {{ class_name }}_id AUTO_INCREMENT INT PRIMARY KEY,
     {% for attribute in attributes %}
-    {{ attribute.name }} {{ types[attribute.type.name] }},
+        {% if loop.last %}
+    {{ attribute.name }} {{ types[attribute.type.name] }}
+        {% else %}
+    {{ attribute.name }} {{ types[attribute.type.name] }},      
+        {% endif %}
     {% endfor %}
 );
     {% else %}
 CREATE TABLE IF NOT EXISTS {{ class_name }} (
     {{ class_name }}_id SERIAL PRIMARY KEY,
     {% for attribute in attributes %}
-    {{ attribute.name }} {{ types[attribute.type.name] }},
+        {% if loop.last %}
+    {{ attribute.name }} {{ types[attribute.type.name] }}
+        {% else %}
+    {{ attribute.name }} {{ types[attribute.type.name] }},      
+        {% endif %}
     {% endfor %}
 );
     {% endif %}

--- a/src/generators/sql/templates/sql_dialects.sql.j2
+++ b/src/generators/sql/templates/sql_dialects.sql.j2
@@ -90,14 +90,14 @@ CREATE TABLE IF NOT EXISTS {{ class1_name }}_{{ class2_name }} (
 {% macro add_generalization(class_name, generalization, sql_dialect) %}
     {% if sql_dialect == "postgres" %}
 ALTER TABLE {{ class_name }}
-ADD COLUMN {{ generalization.general.name }}_id INT REFERENCES {{ generalization.general.name }}(id);
+ADD COLUMN {{ generalization.general.name }}_id INT REFERENCES {{ generalization.general.name }}({{ generalization.general.name }}_id);
     {% elif sql_dialect == "mysql" %}
 ALTER TABLE {{ class_name }}
 ADD COLUMN {{ generalization.general.name }}_id INT,
 ADD CONSTRAINT generalization_{{ generalization.general.name }}
-FOREIGN KEY ({{ generalization.general.name }}_id) REFERENCES {{ generalization.general.name }}(id);
+FOREIGN KEY ({{ generalization.general.name }}_id) REFERENCES {{ generalization.general.name }}({{ generalization.general.name }}_id);
     {% else %}
 ALTER TABLE {{ class_name }}
-ADD COLUMN {{ generalization.general.name }}_id INT REFERENCES {{ generalization.general.name }}(id);
+ADD COLUMN {{ generalization.general.name }}_id INT REFERENCES {{ generalization.general.name }}({{ generalization.general.name }}_id);
     {% endif %}
 {%- endmacro %}

--- a/src/generators/sql/templates/sql_dialects.sql.j2
+++ b/src/generators/sql/templates/sql_dialects.sql.j2
@@ -63,3 +63,17 @@ CREATE TABLE IF NOT EXISTS {{ class1_name }}_{{ class2_name }} (
 );
     {% endif %}
 {%- endmacro %}
+{% macro add_generalization(class_name, generalization, sql_dialect) %}
+    {% if sql_dialect == "postgres" %}
+ALTER TABLE {{ class_name }}
+ADD COLUMN {{ generalization.general.name }}_id INT REFERENCES {{ generalization.general.name }}(id);
+    {% elif sql_dialect == "mysql" %}
+ALTER TABLE {{ class_name }}
+ADD COLUMN {{ generalization.general.name }}_id INT,
+ADD CONSTRAINT fk_{{ generalization.general.name }}
+FOREIGN KEY ({{ generalization.general.name }}_id) REFERENCES {{ generalization.general.name }}(id);
+    {% else %}
+ALTER TABLE {{ class_name }}
+ADD COLUMN {{ generalization.general.name }}_id INT REFERENCES {{ generalization.general.name }}(id);
+    {% endif %}
+{%- endmacro %}

--- a/src/generators/sql/templates/sql_dialects.sql.j2
+++ b/src/generators/sql/templates/sql_dialects.sql.j2
@@ -2,36 +2,48 @@
 {% macro create_table(class_name, attributes, types, sql_dialect) %}
     {% if sql_dialect == "postgres" %}
 CREATE TABLE IF NOT EXISTS {{ class_name }} (
-    {{ class_name }}_id SERIAL PRIMARY KEY,
-    {% for attribute in attributes %}
-        {% if loop.last %}
-    {{ attribute.name }} {{ types[attribute.type.name] }}
+        {% if attributes | length == 0%}
+    {{ class_name }}_id SERIAL PRIMARY KEY
         {% else %}
+    {{ class_name }}_id SERIAL PRIMARY KEY,
+            {% for attribute in attributes %}
+                {% if loop.last %}
+    {{ attribute.name }} {{ types[attribute.type.name] }}
+                {% else %}
     {{ attribute.name }} {{ types[attribute.type.name] }},      
+                {% endif %}
+            {% endfor %}
         {% endif %}
-    {% endfor %}
 );
     {% elif sql_dialect == "mysql" %}
 CREATE TABLE IF NOT EXISTS {{ class_name }} (
-    {{ class_name }}_id AUTO_INCREMENT INT PRIMARY KEY,
-    {% for attribute in attributes %}
-        {% if loop.last %}
-    {{ attribute.name }} {{ types[attribute.type.name] }}
+        {% if attributes | length == 0%}
+    {{ class_name }}_id AUTO_INCREMENT PRIMARY KEY
         {% else %}
+    {{ class_name }}_id AUTO_INCREMENT PRIMARY KEY,
+            {% for attribute in attributes %}
+                {% if loop.last %}
+    {{ attribute.name }} {{ types[attribute.type.name] }}
+                {% else %}
     {{ attribute.name }} {{ types[attribute.type.name] }},      
+                {% endif %}
+            {% endfor %}
         {% endif %}
-    {% endfor %}
 );
     {% else %}
 CREATE TABLE IF NOT EXISTS {{ class_name }} (
-    {{ class_name }}_id SERIAL PRIMARY KEY,
-    {% for attribute in attributes %}
-        {% if loop.last %}
-    {{ attribute.name }} {{ types[attribute.type.name] }}
+        {% if attributes | length == 0%}
+    {{ class_name }}_id SERIAL PRIMARY KEY
         {% else %}
+    {{ class_name }}_id SERIAL PRIMARY KEY,
+            {% for attribute in attributes %}
+                {% if loop.last %}
+    {{ attribute.name }} {{ types[attribute.type.name] }}
+                {% else %}
     {{ attribute.name }} {{ types[attribute.type.name] }},      
+                {% endif %}
+            {% endfor %}
         {% endif %}
-    {% endfor %}
 );
     {% endif %}
 {%- endmacro %}

--- a/src/generators/sql/templates/sql_template.sql.j2
+++ b/src/generators/sql/templates/sql_template.sql.j2
@@ -2,7 +2,7 @@
 {# Iterate over classes and generate CREATE TABLE statements #}
 {% for class_obj in model.classes_sorted_by_inheritance() %}
     {% set class_name = class_obj.name %}
-    {% set attributes = class_obj.all_attributes() %}
+    {% set attributes = class_obj.attributes %}
     {{- sql_templates.create_table(class_name, attributes, types, sql_dialect) }}
     {# Handling generalizations (inheritance) #}
     {% if class_obj.generalizations %}

--- a/src/generators/sql/templates/sql_template.sql.j2
+++ b/src/generators/sql/templates/sql_template.sql.j2
@@ -16,27 +16,30 @@
 {# Iterate over associations and generate SQL statements based on association type #}
 {% for association in model.associations %}
     {% if association.ends|length == 2 -%}
-        {% set end1 = association.ends.pop() %}
-        {% set end2 = association.ends.pop() %}
-        {% set class1_name = end1.type.name|lower %}
-        {% set class2_name = end2.type.name|lower %}
+        {% set ns = namespace(end1=None, end2=None) %}
+        {% for end in association.ends %}
+            {% set ns.end1=end if loop.index == 1 else ns.end1 %}
+            {% set ns.end2=end if loop.index == 2 else ns.end2 %}
+        {% endfor %}
+        {% set class1_name = ns.end1.type.name %}
+        {% set class2_name = ns.end2.type.name %}
         {# Check multiplicity and generate appropriate SQL statement #}
-        {% if end1.multiplicity.max > 1 and end2.multiplicity.max > 1 %}
+        {% if ns.end1.multiplicity.max > 1 and ns.end2.multiplicity.max > 1 %}
         {# N:M Relationship: Create intermediate table #}
             {{- sql_templates.create_nm_table(class1_name, class2_name, sql_dialect) }}
-        {% elif end1.multiplicity.max > 1 and end2.multiplicity.max == 1 %}
+        {% elif ns.end1.multiplicity.max > 1 and ns.end2.multiplicity.max == 1 %}
         {# N:1 Relationship: Add reference to Nary end #}
             {{- sql_templates.alter_table(class1_name, class2_name, class2_name, class2_name, sql_dialect) }}
-        {% elif end1.multiplicity.max == 1 and end2.multiplicity.max > 1 %}
+        {% elif ns.end1.multiplicity.max == 1 and ns.end2.multiplicity.max > 1 %}
         {# 1:N Relationship: Add reference to Nary end #}
             {{- sql_templates.alter_table(class2_name, class1_name, class1_name, class1_name, sql_dialect) }}
-        {% elif end1.multiplicity.max == 1 and end2.multiplicity.max == 1 %}
+        {% elif ns.end1.multiplicity.max == 1 and ns.end2.multiplicity.max == 1 %}
         {# 1:1 Relationship: Add unique reference to one of the ends #}
             {{- sql_templates.alter_table(class1_name, class2_name, class2_name, class2_name, sql_dialect) }}
         {% endif %}
     {% else %}
     {# Convert Nary relationship to Binary relationships and intermediate table #}
-        {% set intermediate_class = association.name|lower %}
+        {% set intermediate_class = association.name %}
         {{- sql_templates.create_table(intermediate_class, [], types, sql_dialect) }}
         {% set end_intermediate_multiplicity_max = 9999 %}
         {% for end in association.ends %}

--- a/src/generators/sql/templates/sql_template.sql.j2
+++ b/src/generators/sql/templates/sql_template.sql.j2
@@ -1,9 +1,17 @@
 {% import "sql_dialects.sql.j2" as sql_templates %}
 {# Iterate over classes and generate CREATE TABLE statements #}
-{% for class_obj in model.get_classes() %}
-    {% set class_name = class_obj.name|lower %}
+{% for class_obj in model.classes_sorted_by_inheritance() %}
+    {% set class_name = class_obj.name %}
     {% set attributes = class_obj.all_attributes() %}
     {{- sql_templates.create_table(class_name, attributes, types, sql_dialect) }}
+    {# Handling generalizations (inheritance) #}
+    {% if class_obj.generalizations %}
+        {% for generalization in class_obj.generalizations %}
+            {% if generalization.specific.name == class_name %}
+                {{- sql_templates.add_generalization(class_name, generalization, sql_dialect) }}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
 {% endfor %}
 {# Iterate over associations and generate SQL statements based on association type #}
 {% for association in model.associations %}


### PR DESCRIPTION
Fixed some errors which were missed in previous versions:
- Trailing commas at the end of table definitions caused errors while creating a table
- Generalizations: added sorting by inheritance
- Associations: changed ends processing, ends assignment
- CamelCase or snake_case: as most of dbms are case insensitive, names are preserved as they've been defined in BUML description