### PR TITLE
release: v7.1.1 — BAF 4.3.2 + Render agent deploy pipeline fixes

### DIFF
--- a/besser/generators/agents/templates/readme.txt.j2
+++ b/besser/generators/agents/templates/readme.txt.j2
@@ -11,7 +11,7 @@ Requirements
 To start the agent, run:
     python {{agent.name}}.py
 
-In case your agent uses an LLM, you will need to configure the LLM credentials in the config.ini file.
+In case your agent uses an LLM, you will need to configure the LLM credentials in the config.yaml file.
 
 Check out the official BAF repository and documentation for detailed information: 
 https://github.com/BESSER-PEARL/BESSER-Agentic-Framework

--- a/besser/utilities/web_modeling_editor/backend/services/deployment/github_deploy_api.py
+++ b/besser/utilities/web_modeling_editor/backend/services/deployment/github_deploy_api.py
@@ -503,16 +503,37 @@ def _add_deployment_configs(
             # Classical IC needs PyTorch CPU + scikit-learn, plus [llms] for unconditional imports in generated code
             # Single pip call with --extra-index-url so PyTorch CPU resolves from the wheel index while the rest comes from PyPI
             build_cmd = (
-                "pip install torch==2.6.0+cpu scikit-learn==1.6.1 besser-agentic-framework[llms]==4.2.3 "
+                "pip install torch==2.6.0+cpu scikit-learn==1.6.1 besser-agentic-framework[llms]==4.3.2 "
                 "--extra-index-url https://download.pytorch.org/whl/cpu "
                 '&& python -c "import nltk; nltk.download(\'punkt\', quiet=True); nltk.download(\'punkt_tab\', quiet=True)"'
             )
         else:
             # LLM-based IC (default)
             build_cmd = (
-                "pip install besser-agentic-framework[llms]==4.2.3 "
+                "pip install besser-agentic-framework[llms]==4.3.2 "
                 '&& python -c "import nltk; nltk.download(\'punkt\', quiet=True); nltk.download(\'punkt_tab\', quiet=True)"'
             )
+
+        # Patch config.yaml + agent script at container start.
+        # - Bind websocket to 0.0.0.0:$PORT so Render's port scanner sees it
+        # - Disable monitoring + streamlit DB (no external DB on free tier, template ships with YOUR-DB-HOST placeholder)
+        # - Inject OPENAI_API_KEY into config.yaml only when present (classical IC path has no env var)
+        # - Flip use_ui=True → use_ui=False in the agent script so the embedded Streamlit thread doesn't spin up
+        #   (unreachable on free tier since only $PORT is exposed, and it wastes RAM on the 512 MB instance).
+        yaml_patch = (
+            "import yaml, os, re, pathlib; "
+            "c = yaml.safe_load(open('config.yaml')); "
+            "c['platforms']['websocket']['host'] = '0.0.0.0'; "
+            "c['platforms']['websocket']['port'] = int(os.environ['PORT']); "
+            "c['db']['monitoring']['enabled'] = False; "
+            "c['db']['streamlit']['enabled'] = False; "
+            "c['nlp']['openai']['api_key'] = os.environ.get('OPENAI_API_KEY') or c['nlp']['openai'].get('api_key', ''); "
+            "yaml.safe_dump(c, open('config.yaml','w')); "
+            f"p = pathlib.Path('{agent_script}'); "
+            "p.write_text(re.sub(r'use_ui=True', 'use_ui=False', p.read_text()))"
+        )
+        start_cmd = f'cd agent && python -c "{yaml_patch}" && python -u {agent_script}'
+        extra_env_vars = "" if ic_tech == "classical" else "\n      - key: OPENAI_API_KEY\n        sync: false"
 
         agent_service_config = f"""
   # Agent Service (Free tier - WebSocket-based AI agent)
@@ -521,12 +542,10 @@ def _add_deployment_configs(
     runtime: python
     plan: free
     buildCommand: {build_cmd}
-    startCommand: cd agent && sed -i 's/^websocket\\.host = .*/websocket.host = 0.0.0.0/' config.ini && sed -i "s/^websocket\\.port = .*/websocket.port = $PORT/" config.ini && sed -i "s/^nlp\\.openai\\.api_key = .*/nlp.openai.api_key = $OPENAI_API_KEY/" config.ini && python -u {agent_script}
+    startCommand: {start_cmd}
     envVars:
       - key: PYTHON_VERSION
-        value: 3.11.9
-      - key: OPENAI_API_KEY
-        sync: false
+        value: 3.11.9{extra_env_vars}
 """
         render_config += agent_service_config
 

--- a/docs/source/releases/v7.rst
+++ b/docs/source/releases/v7.rst
@@ -4,5 +4,6 @@ Version 7
 .. toctree::
    :maxdepth: 1
 
+   v7/v7.1.1
    v7/v7.1.0
    v7/v7.0.0

--- a/docs/source/releases/v7/v7.1.1.rst
+++ b/docs/source/releases/v7/v7.1.1.rst
@@ -1,0 +1,39 @@
+Version 7.1.1
+=============
+
+Patch release: fixes the Render deployment pipeline for WebApps that include an agent. All changes are scoped to the agent generator, its templates, and the GitHub/Render deploy integration — no metamodel or API changes.
+
+Highlights
+----------
+
+- **BAF upgrade**: generated agents now target ``besser-agentic-framework==4.3.2``, which ships the new ``baf.*`` import namespace that the agent template already uses.
+- **Config format migration**: generated agents read ``config.yaml`` instead of ``config.ini`` (BAF 4.3.x dropped INI support).
+- **Render deploy fixes**: agents deployed via the editor's GitHub integration now start cleanly on Render free tier — WebSocket binds to ``0.0.0.0:$PORT``, placeholder monitoring DB is disabled, embedded Streamlit UI is disabled, and OpenAI key handling matches the selected intent recognition technology.
+
+Bug Fixes
+---------
+
+Agent Generator & Templates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **BAF 4.3.2 upgrade**: the generated agent's ``requirements`` / Render ``buildCommand`` now pins ``besser-agentic-framework[llms]==4.3.2``. The template-side import rename from ``besser.agent.*`` to ``baf.*`` was already in place but was broken on 4.2.3 because that version still shipped the old namespace, causing ``ModuleNotFoundError: No module named 'baf'`` at agent startup.
+- **config.yaml migration**: the agent README template (``readme.txt.j2``) and the BAF generator tests now reference ``config.yaml`` instead of ``config.ini``, matching the file that ``baf_config_template.py.j2`` actually emits.
+
+Render Deployment Pipeline
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``github_deploy_api.py`` service that generates ``render.yaml`` for agent-enabled WebApps had several issues that are now fixed:
+
+- **WebSocket port binding**: the previous ``startCommand`` used ``sed`` patterns anchored to flat ``key = value`` lines (``^websocket\.host = ...``), but the real config file is nested YAML. The sed calls silently matched zero lines, so BAF started on ``localhost:8765`` and Render's port scanner killed the service with ``No open ports detected on 0.0.0.0``. Replaced the sed chain with a single inline Python patcher that loads ``config.yaml`` with PyYAML (already a BAF dependency), rewrites ``platforms.websocket.host`` to ``0.0.0.0`` and ``platforms.websocket.port`` to ``$PORT``, then writes it back.
+- **Monitoring DB crash on startup**: the default config template ships with ``db.monitoring.enabled: True`` and ``db.monitoring.host: YOUR-DB-HOST``. On Render with no external Postgres attached, BAF tried to resolve the literal host and crashed with ``psycopg2.OperationalError: could not translate host name "YOUR-DB-HOST" to address``. The patcher now flips ``db.monitoring.enabled`` and ``db.streamlit.enabled`` to ``False`` at container start.
+- **Embedded Streamlit UI disabled**: ``use_websocket_platform(use_ui=True)`` was hardcoded in ``baf_agent_template.py.j2``, spawning a Streamlit subprocess on port 5000. Render free tier only exposes the one ``$PORT`` per service, so the embedded UI was both unreachable and wasting ~200 MB on the 512 MB free instance. The patcher rewrites ``use_ui=True`` to ``use_ui=False`` in the generated agent script at container start.
+- **OpenAI key handling split by intent recognition technology**: classical intent recognition does not call OpenAI, so the Render deploy no longer prompts for an ``OPENAI_API_KEY`` env var when ``intentRecognitionTechnology == 'classical'``. The LLM IC path still injects ``OPENAI_API_KEY`` into ``config.yaml`` at container start. The classical IC build still pre-installs ``torch==2.6.0+cpu`` from the PyTorch CPU wheel index so the build fits within Render free tier's disk budget.
+
+Upgrade Notes
+-------------
+
+If you are regenerating and redeploying an existing agent-enabled WebApp:
+
+- Any ``config.ini`` files in old exports are no longer used — delete them and let the generator emit a fresh ``config.yaml``.
+- Existing Render services stuck on BAF 4.2.3 will need a fresh deploy to pick up both the 4.3.2 upgrade and the new ``startCommand``. The ``render.yaml`` file in your GitHub repo will be rewritten on the next ``deploy-app`` call from the editor.
+- Render free tier still exposes only one port per service. If you rely on the embedded Streamlit chat UI locally, it still works — the rewrite only takes effect inside the container at deploy time, not in the generated source tree.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = besser
-version = 7.1.0
+version = 7.1.1
 author = Luxembourg Institute of Science and Technology
 description = BESSER
 long_description = file: README.md

--- a/tests/generators/agents/test_baf_generator.py
+++ b/tests/generators/agents/test_baf_generator.py
@@ -74,7 +74,7 @@ def test_baf_generator_generate(agent_model, tmpdir):
 
 
 def test_baf_generator_creates_config(agent_model, tmpdir):
-    """Test that generate() creates a config.ini file."""
+    """Test that generate() creates a config.yaml file."""
     output_dir = tmpdir.mkdir("output")
     generator = BAFGenerator(
         model=agent_model,


### PR DESCRIPTION
This PR brings `development` to `master`, shipping two releases in a single merge:

- **v7.1.0** — bug fixes and validation improvements (previously merged to `development` only; full notes: `docs/source/releases/v7/v7.1.0.rst`)
- **v7.1.1** — BAF 4.3.2 upgrade + Render agent deploy pipeline fixes (notes below)

---

# Version 7.1.1

Patch release: fixes the Render deployment pipeline for WebApps that include an agent. All changes are scoped to the agent generator, its templates, and the GitHub/Render deploy integration — no metamodel or API changes.

## Highlights

- **BAF upgrade**: generated agents now target `besser-agentic-framework==4.3.2`, which ships the new `baf.*` import namespace that the agent template already uses.
- **Config format migration**: generated agents read `config.yaml` instead of `config.ini` (BAF 4.3.x dropped INI support).
- **Render deploy fixes**: agents deployed via the editor's GitHub integration now start cleanly on Render free tier — WebSocket binds to `0.0.0.0:$PORT`, placeholder monitoring DB is disabled, embedded Streamlit UI is disabled, and OpenAI key handling matches the selected intent recognition technology.

## Bug Fixes

### Agent Generator & Templates

- **BAF 4.3.2 upgrade**: the generated agent's Render `buildCommand` now pins `besser-agentic-framework[llms]==4.3.2`. The template-side import rename from `besser.agent.*` to `baf.*` was already in place but was broken on 4.2.3 because that version still shipped the old namespace, causing `ModuleNotFoundError: No module named 'baf'` at agent startup.
- **config.yaml migration**: the agent README template (`readme.txt.j2`) and the BAF generator tests now reference `config.yaml` instead of `config.ini`, matching the file that `baf_config_template.py.j2` actually emits.

### Render Deployment Pipeline

The `github_deploy_api.py` service that generates `render.yaml` for agent-enabled WebApps had several issues that are now fixed:

- **WebSocket port binding**: the previous `startCommand` used `sed` patterns anchored to flat `key = value` lines (`^websocket\.host = ...`), but the real config file is nested YAML. The sed calls silently matched zero lines, so BAF started on `localhost:8765` and Render's port scanner killed the service with `No open ports detected on 0.0.0.0`. Replaced the sed chain with a single inline Python patcher that loads `config.yaml` with PyYAML (already a BAF dependency), rewrites `platforms.websocket.host` to `0.0.0.0` and `platforms.websocket.port` to `$PORT`, then writes it back.
- **Monitoring DB crash on startup**: the default config template ships with `db.monitoring.enabled: True` and `db.monitoring.host: YOUR-DB-HOST`. On Render with no external Postgres attached, BAF tried to resolve the literal host and crashed with `psycopg2.OperationalError: could not translate host name "YOUR-DB-HOST" to address`. The patcher now flips `db.monitoring.enabled` and `db.streamlit.enabled` to `False` at container start.
- **Embedded Streamlit UI disabled**: `use_websocket_platform(use_ui=True)` was hardcoded in `baf_agent_template.py.j2`, spawning a Streamlit subprocess on port 5000. Render free tier only exposes the one `$PORT` per service, so the embedded UI was both unreachable and wasting ~200 MB on the 512 MB free instance. The patcher rewrites `use_ui=True` to `use_ui=False` in the generated agent script at container start.
- **OpenAI key handling split by intent recognition technology**: classical intent recognition does not call OpenAI, so the Render deploy no longer prompts for an `OPENAI_API_KEY` env var when `intentRecognitionTechnology == 'classical'`. The LLM IC path still injects `OPENAI_API_KEY` into `config.yaml` at container start. The classical IC build still pre-installs `torch==2.6.0+cpu` from the PyTorch CPU wheel index so the build fits within Render free tier's disk budget.

## Upgrade Notes

If you are regenerating and redeploying an existing agent-enabled WebApp:

- Any `config.ini` files in old exports are no longer used — delete them and let the generator emit a fresh `config.yaml`.
- Existing Render services stuck on BAF 4.2.3 will need a fresh deploy to pick up both the 4.3.2 upgrade and the new `startCommand`. The `render.yaml` file in your GitHub repo will be rewritten on the next `deploy-app` call from the editor.
- Render free tier still exposes only one port per service. If you rely on the embedded Streamlit chat UI locally, it still works — the rewrite only takes effect inside the container at deploy time, not in the generated source tree.

## Test plan

- [ ] Regenerate an agent-enabled WebApp from the editor with **classical** intent recognition, deploy to Render free tier, verify WebSocket binds on `0.0.0.0:$PORT` and the service goes live without an `OPENAI_API_KEY` prompt
- [ ] Regenerate an agent-enabled WebApp with **LLM** intent recognition, deploy to Render, verify `OPENAI_API_KEY` env var is required and gets injected into `config.yaml` at container start
- [ ] Confirm `Running Streamlit UI in another thread` no longer appears in Render logs (proves the `use_ui=True → False` rewrite hit)
- [ ] Confirm no `psycopg2.OperationalError: could not translate host name "YOUR-DB-HOST"` error at startup
- [ ] Run `pytest tests/generators/agents/` locally to cover the `config.yaml` test rename