### PR TITLE
release: v7.1.2 — multi-agent support in the Full Web App generator

### DIFF
--- a/besser/generators/react/templates/src/components/AgentComponent.tsx.j2
+++ b/besser/generators/react/templates/src/components/AgentComponent.tsx.j2
@@ -44,16 +44,40 @@ export const AgentComponent: React.FC<Props> = ({
   }, [agentName]);
 
   useEffect(() => {
-    setIsConnecting(true);
-    try {
-      const ws = new WebSocket(agentUrl);
+    // Auto-reconnect with linear-then-capped backoff. Needed because Render
+    // free-tier services sleep after 15 min of idle and take 1–5 minutes to
+    // cold-start (classical intent classifiers retrain on every boot). Without
+    // a retry loop, the first WebSocket attempt during a cold start fails
+    // immediately and the component stays "Disconnected" until the user
+    // manually refreshes.
+    //
+    // Schedule: 2s, 4s, 6s, ... capped at 30s per attempt. Up to 60 attempts
+    // (~26 min total) before we give up — comfortably longer than any real
+    // BAF cold start. ``cancelled`` flips on cleanup so we stop retrying
+    // after unmount (including React strict-mode double-mount).
+    let cancelled = false;
+    let retry = 0;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const connect = () => {
+      if (cancelled) return;
+      setIsConnecting(true);
+
+      let ws: WebSocket;
+      try {
+        ws = new WebSocket(agentUrl);
+      } catch (error) {
+        console.error("Failed to open WebSocket:", error);
+        scheduleRetry();
+        return;
+      }
       wsRef.current = ws;
 
       ws.onopen = () => {
+        retry = 0;
         setIsConnected(true);
         setIsConnecting(false);
         console.log("Connected to agent:", agentName, "at", agentUrl);
-        console.log("WebSocket readyState:", ws.readyState);
       };
 
       ws.onmessage = (event) => {
@@ -63,7 +87,7 @@ export const AgentComponent: React.FC<Props> = ({
           // Handle BESSER agent message format
           // Expected format: { action: 'agent_reply_str', message: '...' }
           let messageText = '';
-          
+
           if (payload.action === 'agent_reply_str' && payload.message) {
             messageText = payload.message;
           } else if (payload.action === 'agent_reply_markdown' && payload.message) {
@@ -77,7 +101,7 @@ export const AgentComponent: React.FC<Props> = ({
             // If no recognized format, stringify the whole payload
             messageText = JSON.stringify(payload);
           }
-          
+
           setMessages((prev) => [
             ...prev,
             {
@@ -102,25 +126,48 @@ export const AgentComponent: React.FC<Props> = ({
 
       ws.onerror = (error) => {
         console.error("WebSocket error:", error);
-        console.log("WebSocket readyState on error:", ws.readyState);
-        setIsConnecting(false);
       };
 
       ws.onclose = (event) => {
         setIsConnected(false);
-        setIsConnecting(false);
-        console.log("Disconnected from agent. Code:", event.code, "Reason:", event.reason, "Clean:", event.wasClean);
-      };
-
-      return () => {
-        if (wsRef.current) {
-          wsRef.current.close();
+        console.log(
+          "Disconnected from agent. Code:",
+          event.code,
+          "Reason:",
+          event.reason,
+          "Clean:",
+          event.wasClean,
+        );
+        if (!cancelled) {
+          scheduleRetry();
+        } else {
+          setIsConnecting(false);
         }
       };
-    } catch (error) {
-      console.error("Failed to connect to agent:", error);
-      setIsConnecting(false);
-    }
+    };
+
+    const scheduleRetry = () => {
+      retry += 1;
+      if (retry > 60) {
+        // Give up after ~30 minutes of backoff — well past any realistic cold start.
+        setIsConnecting(false);
+        return;
+      }
+      const delay = Math.min(30000, 2000 * retry);
+      setIsConnecting(true);
+      retryTimer = setTimeout(connect, delay);
+    };
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
   }, [agentName, agentUrl]);
 
   // Scroll to bottom when new messages arrive

--- a/besser/generators/react/templates/src/components/AgentComponent.tsx.j2
+++ b/besser/generators/react/templates/src/components/AgentComponent.tsx.j2
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useEffect, useState, useRef } from "react";
+import React, { CSSProperties, useEffect, useMemo, useState, useRef } from "react";
 
 interface Props {
   id: string;
@@ -20,8 +20,28 @@ export const AgentComponent: React.FC<Props> = ({
   const wsRef = useRef<WebSocket | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // Get agent URL from environment or use default
-  const agentUrl = import.meta.env.VITE_AGENT_URL || "ws://localhost:8765";
+  // GUI components store ``agent-name`` verbatim from the diagram title (e.g.
+  // "Library Agent"), but BUML Agent names — and therefore the JSON map keys
+  // — are Python-safe identifiers ("Library_Agent"). We do one normalization:
+  // space→underscore. Backend emits exactly one canonical key per agent, so
+  // this lookup is deterministic.
+  const agentUrl = useMemo(() => {
+    const raw = import.meta.env.VITE_AGENT_URLS as string | undefined;
+    if (raw && agentName) {
+      try {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === "object") {
+          const key = agentName in parsed ? agentName : agentName.replace(/\s+/g, "_");
+          if (parsed[key]) {
+            return parsed[key] as string;
+          }
+        }
+      } catch {
+        // Fall through to the single-URL variable if the map can't be parsed.
+      }
+    }
+    return import.meta.env.VITE_AGENT_URL || "ws://localhost:8765";
+  }, [agentName]);
 
   useEffect(() => {
     setIsConnecting(true);

--- a/besser/generators/web_app/templates/docker-compose.yml.j2
+++ b/besser/generators/web_app/templates/docker-compose.yml.j2
@@ -7,20 +7,25 @@ services:
       dockerfile: Dockerfile
       args:
         VITE_API_URL: http://localhost:8000
-{% if agent_model %}
+{% if agent_models %}
         VITE_AGENT_URL: ws://localhost:8765
+        # JSON map keyed by agent name so each AgentComponent in the React app
+        # can connect to its own backing service. Quoted so the YAML parser
+        # treats it as a literal string, not an inline mapping.
+        VITE_AGENT_URLS: '{ {%- for agent in agent_models %}"{{ agent.name }}":"ws://localhost:{{ 8765 + loop.index0 }}"{% if not loop.last %},{% endif %}{% endfor %} }'
 {% endif %}
     ports:
       - "3000:3000"
     depends_on:
       - backend
-{% if agent_model %}
-      - agent
-{% endif %}
+{% for agent in agent_models %}
+      - {{ agent | agent_slug }}_agent
+{% endfor %}
     environment:
       - VITE_API_URL=http://localhost:8000
-{% if agent_model %}
+{% if agent_models %}
       - VITE_AGENT_URL=ws://localhost:8765
+      - 'VITE_AGENT_URLS={ {%- for agent in agent_models %}"{{ agent.name }}":"ws://localhost:{{ 8765 + loop.index0 }}"{% if not loop.last %},{% endif %}{% endfor %} }'
 {% endif %}
 
   backend:
@@ -33,27 +38,29 @@ services:
       - DATABASE_URL=sqlite:///./data/{{ name }}.db
     volumes:
       - sqlite_data:/app/data
-{% if agent_model %}
+{% if agent_models %}
     depends_on:
-      - agent
+{% for agent in agent_models %}
+      - {{ agent | agent_slug }}_agent
+{% endfor %}
 {% endif %}
 
-{% if agent_model %}
-  agent:
+{% for agent in agent_models %}
+  {{ agent | agent_slug }}_agent:
     build:
-      context: ./agent
+      context: ./agents/{{ agent | agent_slug }}
       dockerfile: Dockerfile
     ports:
-      - "8765:8765"
-      - "5000:5000"
+      - "{{ 8765 + loop.index0 }}:8765"
+      - "{{ 5000 + loop.index0 }}:5000"
     volumes:
-      - agent_data:/app/data
+      - {{ agent | agent_slug }}_agent_data:/app/data
     environment:
       - PYTHONUNBUFFERED=1
-{% endif %}
 
+{% endfor %}
 volumes:
   sqlite_data:
-{% if agent_model %}
-  agent_data:
-{% endif %}
+{% for agent in agent_models %}
+  {{ agent | agent_slug }}_agent_data:
+{% endfor %}

--- a/besser/generators/web_app/web_app_generator.py
+++ b/besser/generators/web_app/web_app_generator.py
@@ -5,6 +5,19 @@ from besser.BUML.metamodel.structural import DomainModel
 from besser.generators.backend import BackendGenerator
 from besser.generators.react import ReactGenerator
 from besser.generators import GeneratorInterface
+from besser.utilities.buml_code_builder.common import safe_var_name
+
+
+def agent_slug(name) -> str:
+    """Canonical filesystem slug for an agent.
+
+    Reused across the web-app generator (``agents/<slug>/`` directories,
+    docker-compose build contexts) and the GitHub/Render deploy pipeline.
+    Accepts either a string or an object exposing ``.name``.
+    """
+    raw = getattr(name, "name", name) if not isinstance(name, str) else name
+    return safe_var_name(raw) if raw else "agent"
+
 
 ##############################
 #   Web Application Generator
@@ -19,29 +32,55 @@ class WebAppGenerator(GeneratorInterface):
         model (DomainModel): The B-UML model representing the application's domain.
         gui_model (GUIModel): The GUI model instance containing necessary configurations.
         output_dir (str, optional): Directory where generated code will be saved. Defaults to None.
+        agent_models (list, optional): List of agent models. Each agent is generated into
+            ``agents/<name>/`` under the output directory.
+        agent_configs (dict, optional): Mapping of ``agent.name`` -> config dict, passed
+            per agent to the underlying :class:`BAFGenerator`.
+        agent_model: **Deprecated.** Single-agent back-compat shim. Prefer ``agent_models``.
+        agent_config: **Deprecated.** Single-agent back-compat shim. Prefer ``agent_configs``.
     """
 
-    def __init__(self, model: DomainModel, gui_model: GUIModel, output_dir: str = None, agent_model=None, agent_config=None):
+    def __init__(self, model: DomainModel, gui_model: GUIModel, output_dir: str = None,
+                 agent_models=None, agent_configs=None,
+                 agent_model=None, agent_config=None):
         super().__init__(model, output_dir)
         self.gui_model = gui_model
-        self.agent_model = agent_model
-        self.agent_config = agent_config
+        if agent_model is not None and not agent_models:
+            agent_models = [agent_model]
+        if agent_config is not None and not agent_configs:
+            name = getattr(agent_model, "name", "agent") if agent_model is not None else "agent"
+            agent_configs = {name: agent_config}
+        self.agent_models = list(agent_models or [])
+        self.agent_configs = dict(agent_configs or {})
         # Jinja environment configuration
         templates_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")
         self.env = Environment(loader=FileSystemLoader(templates_path), trim_blocks=True,
                                lstrip_blocks=True, extensions=['jinja2.ext.do'])
+        self.env.filters['agent_slug'] = agent_slug
+
+    @property
+    def agent_model(self):
+        """Deprecated: returns the first agent model, if any."""
+        return self.agent_models[0] if self.agent_models else None
+
+    @property
+    def agent_config(self):
+        """Deprecated: returns the config of the first agent, if any."""
+        if not self.agent_models:
+            return None
+        return self.agent_configs.get(getattr(self.agent_models[0], "name", None))
 
     def generate(self):
         """
         Generates web application code based on the provided B-UML and GUI models.
-        If agent_model is provided, also generates agent code.
+        If any agent models are provided, also generates agent code (one per agent).
 
         Returns:
             None, but store the generated code in the specified output directory.
         """
         self._generate_frontend(self.env)
         self._generate_backend(self.env)
-        if self.agent_model:
+        if self.agent_models:
             self._generate_agent(self.env)
         self._generate_docker_files(self.env)
 
@@ -58,20 +97,31 @@ class WebAppGenerator(GeneratorInterface):
         backend_gen.generate()
 
     def _generate_agent(self, env):
-        """Generate agent code if agent model is provided."""
+        """Generate agent code for every configured agent model.
+
+        Each agent is emitted into ``agents/<slug>/`` under the output directory
+        so that multi-agent projects don't collide.
+        """
         from besser.generators.agents.baf_generator import BAFGenerator
 
-        # Generate agent code in 'agent' subfolder
-        agent_dir = os.path.join(self.output_dir, "agent") if self.output_dir else "agent"
-        os.makedirs(agent_dir, exist_ok=True)
+        agents_root = os.path.join(self.output_dir, "agents") if self.output_dir else "agents"
+        os.makedirs(agents_root, exist_ok=True)
 
-        # # Generate agent model file
-        # agent_file = os.path.join(agent_dir, "agent_model.py")
-        # agent_model_to_code(self.agent_model, agent_file)
+        seen_slugs = set()
+        for agent in self.agent_models:
+            slug = agent_slug(agent)
+            # Defensive dedupe in case the upstream uniqueness guards fail.
+            base = slug
+            suffix = 2
+            while slug in seen_slugs:
+                slug = f"{base}_{suffix}"
+                suffix += 1
+            seen_slugs.add(slug)
 
-        # Generate agent files using BAFGenerator
-        agent_gen = BAFGenerator(self.agent_model, output_dir=agent_dir, config=self.agent_config)
-        agent_gen.generate()
+            agent_dir = os.path.join(agents_root, slug)
+            os.makedirs(agent_dir, exist_ok=True)
+            cfg = self.agent_configs.get(getattr(agent, "name", None))
+            BAFGenerator(agent, output_dir=agent_dir, config=cfg).generate()
 
     def _generate_docker_files(self, env):
         """
@@ -84,7 +134,13 @@ class WebAppGenerator(GeneratorInterface):
         docker_compose_template = env.get_template('docker-compose.yml.j2')
         docker_compose_path = os.path.join(self.output_dir, 'docker-compose.yml')
         with open(docker_compose_path, 'w') as f:
-            f.write(docker_compose_template.render(agent_model=self.agent_model, name=self.model.name))
+            f.write(docker_compose_template.render(
+                agent_models=self.agent_models,
+                # Back-compat: keep the scalar variable populated so any out-of-tree
+                # template fork that still reads ``agent_model`` keeps working.
+                agent_model=self.agent_models[0] if self.agent_models else None,
+                name=self.model.name,
+            ))
 
         # Generate frontend Dockerfile
         frontend_dockerfile_template = env.get_template('frontend.Dockerfile.j2')
@@ -100,10 +156,12 @@ class WebAppGenerator(GeneratorInterface):
         with open(backend_dockerfile_path, 'w') as f:
             f.write(backend_dockerfile_template.render())
 
-        # Generate agent Dockerfile if agent model exists
-        if self.agent_model:
+        # Generate one Dockerfile per agent under agents/<slug>/Dockerfile
+        if self.agent_models:
             agent_dockerfile_template = env.get_template('agent.Dockerfile.j2')
-            agent_dockerfile_path = os.path.join(self.output_dir, 'agent', 'Dockerfile')
-            os.makedirs(os.path.dirname(agent_dockerfile_path), exist_ok=True)
-            with open(agent_dockerfile_path, 'w') as f:
-                f.write(agent_dockerfile_template.render(agent_model=self.agent_model))
+            for agent in self.agent_models:
+                slug = agent_slug(agent)
+                agent_dockerfile_path = os.path.join(self.output_dir, 'agents', slug, 'Dockerfile')
+                os.makedirs(os.path.dirname(agent_dockerfile_path), exist_ok=True)
+                with open(agent_dockerfile_path, 'w') as f:
+                    f.write(agent_dockerfile_template.render(agent_model=agent))

--- a/besser/utilities/web_modeling_editor/backend/routers/generation_router.py
+++ b/besser/utilities/web_modeling_editor/backend/routers/generation_router.py
@@ -47,6 +47,7 @@ from besser.utilities.web_modeling_editor.backend.constants.user_buml_model impo
 
 # Backend services - Other services
 from besser.utilities.web_modeling_editor.backend.services.utils.agent_generation_utils import (
+    collect_agents_from_diagrams,
     extract_openai_api_key,
     normalize_personalization_mapping,
     handle_multi_language_generation,
@@ -381,34 +382,37 @@ async def _handle_web_app_project_generation(input_data: ProjectInput, generator
 
         gui_model = process_gui_diagram(gui_diagram.model, class_diagram.model, buml_model)
 
-        # Check if GUI model contains agent components
-        agent_diagram = None
-        agent_model = None
+        # Collect every AgentDiagram in the project if the GUI uses agent components.
+        # The frontend dropdown enumerates all agents, so the generator must
+        # satisfy any binding — we don't filter to the active reference here.
+        agent_models = []
+        agent_configs = {}
         has_agent_components = _check_for_agent_components(gui_model)
 
-        agent_config = None
         if has_agent_components:
-            # Use the GUI diagram's per-diagram reference for AgentDiagram
-            agent_diagram = input_data.get_referenced_diagram(gui_diagram, "AgentDiagram")
-            if agent_diagram and agent_diagram.model:
-                # Process agent diagram to BUML
-                # process_agent_diagram expects the full diagram structure with title, config, and model
-                agent_diagram_dict = agent_diagram.model_dump()
-                if agent_diagram_dict and isinstance(agent_diagram_dict, dict):
-                    agent_model = process_agent_diagram(agent_diagram_dict)
-                    # Try diagram-level config first, then project-level agentConfig, then project config
-                    project_agent_config = config.get('agentConfig') if isinstance(config, dict) else None
-                    agent_config = agent_diagram_dict.get('config') or agent_diagram.config or project_agent_config or config
-                    logger.debug("[WebApp agent] resolved agent_config: %s", json.dumps(sanitize_config(agent_config), indent=2, default=str) if agent_config else 'None')
-                else:
-                    logger.warning("AgentDiagram data is invalid. Agent components will not be functional.")
-            else:
-                logger.warning("GUI contains agent components but no AgentDiagram found. Agent components will not be functional.")
+            project_agent_config = config.get('agentConfig') if isinstance(config, dict) else None
+            default_cfg = project_agent_config or config
+            agent_models, agent_configs = collect_agents_from_diagrams(
+                input_data.diagrams.get("AgentDiagram", []),
+                default_config=default_cfg,
+            )
+            for name, cfg in agent_configs.items():
+                logger.debug("[WebApp agent] resolved config for %s: %s",
+                             name,
+                             json.dumps(sanitize_config(cfg), indent=2, default=str) if cfg else 'None')
+            if not agent_models:
+                logger.warning(
+                    "GUI contains agent components but no AgentDiagram was found. "
+                    "Agent components will not be functional."
+                )
 
         # Generate Web App TypeScript project
         generator_class = generator_info.generator_class
 
-        return await _generate_web_app(buml_model, gui_model, generator_class, config, temp_dir, agent_model, agent_config)
+        return await _generate_web_app(
+            buml_model, gui_model, generator_class, config, temp_dir,
+            agent_models=agent_models, agent_configs=agent_configs,
+        )
 
 
 def _streaming_zip(zip_buffer: io.BytesIO, file_name: str) -> StreamingResponse:
@@ -926,9 +930,17 @@ def _check_container_for_agent_components(container):
                 return True
     return False
 
-async def _generate_web_app(buml_model, gui_model, generator_class, config: dict, temp_dir: str, agent_model=None, agent_config=None):
-    """Generate web application files. Optionally includes agent model if agent components are present."""
-    generator_instance = generator_class(buml_model, gui_model, output_dir=temp_dir, agent_model=agent_model, agent_config=agent_config)
+async def _generate_web_app(buml_model, gui_model, generator_class, config: dict, temp_dir: str,
+                            agent_models=None, agent_configs=None):
+    """Generate web application files.
+
+    Supports multi-agent projects: ``agent_models`` is a list and each is emitted
+    under ``agents/<slug>/`` in the generated output.
+    """
+    generator_instance = generator_class(
+        buml_model, gui_model, output_dir=temp_dir,
+        agent_models=agent_models, agent_configs=agent_configs,
+    )
     await asyncio.to_thread(generator_instance.generate)
     return _create_zip_response(temp_dir, "web_app")
 

--- a/besser/utilities/web_modeling_editor/backend/services/deployment/github_deploy_api.py
+++ b/besser/utilities/web_modeling_editor/backend/services/deployment/github_deploy_api.py
@@ -337,9 +337,10 @@ async def deploy_webapp_to_github(
                 deployment_urls["live_backend"] = (
                     f"https://{app_host}-backend-{existing_suffix}.onrender.com"
                 )
-                # Render auto-sync handles the redeploy; no need to send the user
-                # back through "Create Blueprint". Point them at the dashboard.
-                deployment_urls["render_dashboard"] = "https://dashboard.render.com/"
+                # Point the user at the blueprint list so they can click into
+                # their project's blueprint and hit "Manual Sync" — the single
+                # reliable button that redeploys every service at once.
+                deployment_urls["render_dashboard"] = "https://dashboard.render.com/blueprints"
 
             action = "updated" if reused_repo else "created"
             return DeployToGitHubResponse(

--- a/besser/utilities/web_modeling_editor/backend/services/deployment/github_deploy_api.py
+++ b/besser/utilities/web_modeling_editor/backend/services/deployment/github_deploy_api.py
@@ -5,6 +5,7 @@ This endpoint generates a web app and pushes it to a GitHub repository
 in the user's account, enabling one-click deployment to platforms like Render.
 """
 
+import hashlib
 import logging
 import os
 import re
@@ -476,13 +477,38 @@ async def _export_buml_files_to_repo(
             logger.warning("Failed to push %s to GitHub", repo_path, exc_info=True)
 
 
+# Render caps service hostnames at this many characters; longer names are
+# silently truncated at dash boundaries, dropping the trailing suffix and
+# breaking the URLs we bake into ``.env.production``.
+_RENDER_HOSTNAME_MAX = 40
+
 # Matches the ``name: <app>-backend-<suffix>`` line emitted by
 # ``_add_deployment_configs`` so redeploys can recover the prior suffix and
-# avoid minting a fresh set of Render services on every push.
+# avoid minting a fresh set of Render services on every push. Also matches the
+# ``besser-<hash>`` fallback form so overflow repos still reuse stable names.
 _RENDER_BACKEND_NAME_RE = re.compile(
     r"^\s*name:\s*\S+-backend-([a-f0-9]{4,16})\s*$",
     re.MULTILINE,
 )
+
+
+def _fit_service_name(readable: str, stable_key: str, max_length: int = _RENDER_HOSTNAME_MAX) -> str:
+    """Return a Render-safe service name derived from ``readable``.
+
+    Render caps service hostnames at 40 chars and truncates longer ones at
+    dash boundaries — which silently eats the random suffix we rely on for
+    uniqueness, so two agents in the same project end up at the same URL.
+
+    When ``readable`` is over budget we fall back to ``besser-<12 hex chars>``
+    where the hex is ``sha1(stable_key)``. ``stable_key`` must not include the
+    per-deploy random suffix: it's a function of ``(app_name, role, slug)`` so
+    the hashed name stays identical across redeploys of the same repo, which
+    is what lets Render update the existing service in place.
+    """
+    if len(readable) <= max_length:
+        return readable
+    digest = hashlib.sha1(stable_key.encode("utf-8")).hexdigest()[:12]
+    return f"besser-{digest}"
 
 
 async def _read_existing_service_suffix(github, owner: str, repo_name: str) -> Optional[str]:
@@ -573,8 +599,14 @@ def _add_deployment_configs(
     # same conversion here — otherwise the ``VITE_API_URL`` / ``VITE_AGENT_URLS``
     # values baked into ``.env.production`` point at hostnames that don't resolve.
     app_host = app_name.replace("_", "-")
-    backend_service_name = f"{app_host}-backend-{service_suffix}"
-    frontend_service_name = f"{app_host}-frontend-{service_suffix}"
+    backend_service_name = _fit_service_name(
+        f"{app_host}-backend-{service_suffix}",
+        stable_key=f"{app_name}:backend",
+    )
+    frontend_service_name = _fit_service_name(
+        f"{app_host}-frontend-{service_suffix}",
+        stable_key=f"{app_name}:frontend",
+    )
 
     render_config = f"""services:
   # Backend API (Free tier - 750 hours/month, spins down after 15 min idle)
@@ -626,7 +658,10 @@ def _add_deployment_configs(
     for agent in agent_models:
         slug = agent_slug(agent.name)           # underscores, filesystem-safe
         host_slug = slug.replace("_", "-")               # dashes, Render-hostname-safe
-        agent_service_name = f"{app_host}-{host_slug}-agent-{service_suffix}"
+        agent_service_name = _fit_service_name(
+            f"{app_host}-{host_slug}-agent-{service_suffix}",
+            stable_key=f"{app_name}:agent:{slug}",
+        )
         agent_service_names.append(agent_service_name)
         agent_script = f"{agent.name}.py"
 

--- a/besser/utilities/web_modeling_editor/backend/services/deployment/github_deploy_api.py
+++ b/besser/utilities/web_modeling_editor/backend/services/deployment/github_deploy_api.py
@@ -7,6 +7,7 @@ in the user's account, enabling one-click deployment to platforms like Render.
 
 import logging
 import os
+import re
 import uuid
 import tempfile
 import json
@@ -73,6 +74,10 @@ class DeployToGitHubResponse(BaseModel):
     deployment_urls: dict
     files_uploaded: int
     message: str
+    # True on the very first deploy to a repo (no previous ``render.yaml`` found),
+    # False on every subsequent deploy. The frontend uses this to pick the right
+    # "next action" button — create-blueprint vs. open-live-site.
+    is_first_deploy: bool = True
 
 
 @router.post("/deploy-webapp", response_model=DeployToGitHubResponse)
@@ -189,6 +194,14 @@ async def deploy_webapp_to_github(
                     json.dumps(cfg, indent=2, default=str) if cfg else 'None',
                 )
 
+        # Try to reuse the service suffix from a previous deployment so
+        # redeploys don't create a fresh set of zombie Render services.
+        # On a brand-new repo (or if the existing render.yaml can't be read)
+        # ``_add_deployment_configs`` will fall back to a random UUID suffix —
+        # that's the right behavior for a first deploy since the hostname is
+        # not yet taken on Render.
+        existing_suffix = await _read_existing_service_suffix(github, username, repo_name)
+
         # Generate web app
         with tempfile.TemporaryDirectory(prefix=f"besser_github_{uuid.uuid4().hex}_") as temp_dir:
             generator_info = get_generator_info("web_app")
@@ -208,6 +221,7 @@ async def deploy_webapp_to_github(
                 repo_name,
                 agent_models=agent_models,
                 agent_configs=agent_configs,
+                service_suffix=existing_suffix,
             )
 
             # Determine whether to reuse an existing repo or create a new one
@@ -303,8 +317,29 @@ async def deploy_webapp_to_github(
                     detail="Failed to create GitHub commit for generated files."
                 )
 
-            # Get deployment URLs
+            # Build deployment URLs. On a redeploy (existing_suffix was reused)
+            # Render's blueprint webhook picks up the push automatically — the
+            # user doesn't need to click "Create Blueprint" again. In that case
+            # we also surface a direct link to the live frontend so the dialog
+            # can jump straight there instead of sending them back through the
+            # blueprint-creation flow.
             deployment_urls = github.get_deployment_urls(username, repo_name)
+            is_first_deploy = existing_suffix is None
+            app_host = repo_name.replace("_", "-")
+            # Mirror the suffix fallback used inside ``_add_deployment_configs``:
+            # if this was a first deploy we can't know the suffix the generator
+            # rolled, so we only populate the live URL on redeploys where it's
+            # stable. The frontend falls back to the ``render`` URL otherwise.
+            if existing_suffix:
+                deployment_urls["live_frontend"] = (
+                    f"https://{app_host}-frontend-{existing_suffix}.onrender.com"
+                )
+                deployment_urls["live_backend"] = (
+                    f"https://{app_host}-backend-{existing_suffix}.onrender.com"
+                )
+                # Render auto-sync handles the redeploy; no need to send the user
+                # back through "Create Blueprint". Point them at the dashboard.
+                deployment_urls["render_dashboard"] = "https://dashboard.render.com/"
 
             action = "updated" if reused_repo else "created"
             return DeployToGitHubResponse(
@@ -314,7 +349,8 @@ async def deploy_webapp_to_github(
                 owner=username,
                 deployment_urls=deployment_urls,
                 files_uploaded=push_results["total_files"],
-                message=f"Successfully {action} repository and pushed {push_results['total_files']} files"
+                message=f"Successfully {action} repository and pushed {push_results['total_files']} files",
+                is_first_deploy=is_first_deploy,
             )
 
     except HTTPException:
@@ -439,6 +475,44 @@ async def _export_buml_files_to_repo(
             logger.warning("Failed to push %s to GitHub", repo_path, exc_info=True)
 
 
+# Matches the ``name: <app>-backend-<suffix>`` line emitted by
+# ``_add_deployment_configs`` so redeploys can recover the prior suffix and
+# avoid minting a fresh set of Render services on every push.
+_RENDER_BACKEND_NAME_RE = re.compile(
+    r"^\s*name:\s*\S+-backend-([a-f0-9]{4,16})\s*$",
+    re.MULTILINE,
+)
+
+
+async def _read_existing_service_suffix(github, owner: str, repo_name: str) -> Optional[str]:
+    """Return the suffix used by the repo's current render.yaml, if any.
+
+    Tries ``main`` then ``master`` as the default branch. Any failure
+    (repo not found, render.yaml absent, parse miss, network error) returns
+    ``None`` so the caller falls back to minting a fresh suffix.
+    """
+    for branch in ("main", "master"):
+        try:
+            result = await github.get_file_content(owner, repo_name, "render.yaml", branch=branch)
+        except Exception:
+            logger.debug(
+                "[GitHub deploy] error reading render.yaml from %s/%s@%s",
+                owner, repo_name, branch, exc_info=True,
+            )
+            continue
+        if not result or not result.get("content"):
+            continue
+        match = _RENDER_BACKEND_NAME_RE.search(result["content"])
+        if match:
+            suffix = match.group(1)
+            logger.info(
+                "[GitHub deploy] reusing existing service suffix %s from %s/%s@%s",
+                suffix, owner, repo_name, branch,
+            )
+            return suffix
+    return None
+
+
 def _has_agent_components(gui_model) -> bool:
     """Check if the GUI model contains any agent components."""
     from besser.BUML.metamodel.gui.dashboard import AgentComponent
@@ -486,7 +560,12 @@ def _add_deployment_configs(
     agent_configs = dict(agent_configs or {})
     has_agent = bool(agent_models)
 
-    # Render configuration - Full stack (backend + frontend + optional agents)
+    # Render configuration - Full stack (backend + frontend + optional agents).
+    # ``service_suffix`` should be a stable token per repo so redeploys update
+    # the existing services instead of creating a fresh set every time.
+    # Callers are expected to pass a reused suffix extracted from the repo's
+    # previous render.yaml; if they don't, we fall back to a random UUID here
+    # (first-deploy path — no preexisting Render hostname to collide with).
     if not service_suffix:
         service_suffix = uuid.uuid4().hex[:6]
     # Render rewrites underscores to dashes in service hostnames, so we do the

--- a/besser/utilities/web_modeling_editor/backend/services/deployment/github_deploy_api.py
+++ b/besser/utilities/web_modeling_editor/backend/services/deployment/github_deploy_api.py
@@ -35,6 +35,10 @@ from besser.utilities.buml_code_builder import (
     gui_model_to_code,
     agent_model_to_code,
 )
+from besser.generators.web_app.web_app_generator import agent_slug
+from besser.utilities.web_modeling_editor.backend.services.utils.agent_generation_utils import (
+    collect_agents_from_diagrams,
+)
 
 
 # Create router
@@ -134,6 +138,15 @@ async def deploy_webapp_to_github(
                 return value[idx] if 0 <= idx < len(value) else (value[0] if value else {})
             return value or {}
 
+        def _get_all(diagram_type: str) -> list:
+            """Return every diagram dict of the given type (normalized to a list)."""
+            value = diagrams.get(diagram_type)
+            if isinstance(value, list):
+                return [v for v in value if v]
+            if value:
+                return [value]
+            return []
+
         class_diagram_data = _get_active("ClassDiagram")
         gui_diagram_data = _get_active("GUINoCodeDiagram")
 
@@ -157,20 +170,24 @@ async def deploy_webapp_to_github(
             buml_model
         )
 
-        # Only process agent diagram if the GUI actually uses agent components
-        agent_model = None
-        agent_config = None
+        # Collect every AgentDiagram in the project (multi-agent support).
+        # Uniqueness enforcement and BUML conversion live in the shared helper.
+        agent_models: list = []
+        agent_configs: dict = {}
         has_agent_components = _has_agent_components(gui_model)
         if has_agent_components:
-            agent_diagram_data = _get_active("AgentDiagram")
-            agent_model_data = agent_diagram_data.get("model", {}) if agent_diagram_data else {}
-            if agent_model_data and agent_model_data.get("elements"):
-                agent_model = process_agent_diagram(agent_diagram_data)
-                # Try diagram-level config first, fall back to project settings config
-                settings = body.get("settings", {}) or {}
-                settings_config = settings.get("config") or {}
-                agent_config = agent_diagram_data.get("config") or settings_config
-                logger.debug("Resolved agent_config: %s", json.dumps(agent_config, indent=2, default=str) if agent_config else 'None')
+            settings = body.get("settings", {}) or {}
+            settings_config = settings.get("config") or {}
+            agent_models, agent_configs = collect_agents_from_diagrams(
+                _get_all("AgentDiagram"),
+                default_config=settings_config,
+            )
+            for name, cfg in agent_configs.items():
+                logger.debug(
+                    "Resolved agent_config for %s: %s",
+                    name,
+                    json.dumps(cfg, indent=2, default=str) if cfg else 'None',
+                )
 
         # Generate web app
         with tempfile.TemporaryDirectory(prefix=f"besser_github_{uuid.uuid4().hex}_") as temp_dir:
@@ -180,8 +197,8 @@ async def deploy_webapp_to_github(
                 buml_model,
                 gui_model,
                 output_dir=temp_dir,
-                agent_model=agent_model,
-                agent_config=agent_config
+                agent_models=agent_models,
+                agent_configs=agent_configs,
             )
             generator.generate()
 
@@ -189,9 +206,8 @@ async def deploy_webapp_to_github(
             _add_deployment_configs(
                 temp_dir,
                 repo_name,
-                has_agent=agent_model is not None,
-                agent_entrypoint=agent_model.name if agent_model is not None else None,
-                agent_config=agent_config
+                agent_models=agent_models,
+                agent_configs=agent_configs,
             )
 
             # Determine whether to reuse an existing repo or create a new one
@@ -241,8 +257,9 @@ async def deploy_webapp_to_github(
             try:
                 domain_model_to_code(model=buml_model, file_path=os.path.join(buml_dir, "domain_model.py"))
                 gui_model_to_code(model=gui_model, file_path=os.path.join(buml_dir, "gui_model.py"), domain_model=buml_model)
-                if agent_model:
-                    agent_model_to_code(agent_model, os.path.join(buml_dir, "agent_model.py"))
+                for ag in agent_models:
+                    slug = agent_slug(ag.name)
+                    agent_model_to_code(ag, os.path.join(buml_dir, f"agent_model_{slug}.py"))
             except Exception:
                 logger.warning("Failed to export B-UML models — continuing without them", exc_info=True)
 
@@ -384,13 +401,25 @@ async def _export_buml_files_to_repo(
         logger.warning("Failed to export domain model B-UML", exc_info=True)
 
     try:
-        agent_data = _get_active("AgentDiagram")
-        if agent_data and agent_data.get("model", {}).get("elements"):
+        # Walk every AgentDiagram (not just the active one) so a multi-agent project
+        # exports one buml/agent_model_<slug>.py per agent.
+        agent_diagrams_raw = diagrams.get("AgentDiagram")
+        if isinstance(agent_diagrams_raw, list):
+            agent_diagrams = [a for a in agent_diagrams_raw if a]
+        elif agent_diagrams_raw:
+            agent_diagrams = [agent_diagrams_raw]
+        else:
+            agent_diagrams = []
+
+        for agent_data in agent_diagrams:
+            if not (agent_data and agent_data.get("model", {}).get("elements")):
+                continue
             agent_model = process_agent_diagram(agent_data)
+            slug = agent_slug(agent_model.name)
             with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False, encoding="utf-8") as f:
                 agent_model_to_code(agent_model, f.name)
             with open(f.name, "r", encoding="utf-8") as fh:
-                exports.append((f"{buml_dir}/agent_model.py", fh.read()))
+                exports.append((f"{buml_dir}/agent_model_{slug}.py", fh.read()))
             os.unlink(f.name)
     except Exception:
         logger.warning("Failed to export agent model B-UML", exc_info=True)
@@ -436,10 +465,9 @@ def _has_agent_components(gui_model) -> bool:
 def _add_deployment_configs(
     directory: str,
     app_name: str,
-    has_agent: bool = False,
-    agent_entrypoint: str | None = None,
+    agent_models: list | None = None,
+    agent_configs: dict | None = None,
     service_suffix: str | None = None,
-    agent_config: dict | None = None
 ):
     """
     Add Render deployment configuration (only free platform for full-stack auto-deploy).
@@ -447,14 +475,26 @@ def _add_deployment_configs(
     Args:
         directory: Path to generated app directory
         app_name: Application name
-        has_agent: Whether the app includes an agent service
+        agent_models: List of BUML Agent models; one Render service block is emitted
+            per entry, matching the ``agents/<slug>/`` directory layout produced by
+            :class:`WebAppGenerator`.
+        agent_configs: Mapping of ``agent.name`` -> config dict. Used to pick the
+            intent-recognition technology per agent.
+        service_suffix: Optional override for the 6-char unique suffix in service names.
     """
-    # Render configuration - Full stack (backend + frontend + optional agent)
+    agent_models = list(agent_models or [])
+    agent_configs = dict(agent_configs or {})
+    has_agent = bool(agent_models)
+
+    # Render configuration - Full stack (backend + frontend + optional agents)
     if not service_suffix:
         service_suffix = uuid.uuid4().hex[:6]
-    backend_service_name = f"{app_name}-backend-{service_suffix}"
-    frontend_service_name = f"{app_name}-frontend-{service_suffix}"
-    agent_service_name = f"{app_name}-agent-{service_suffix}"
+    # Render rewrites underscores to dashes in service hostnames, so we do the
+    # same conversion here — otherwise the ``VITE_API_URL`` / ``VITE_AGENT_URLS``
+    # values baked into ``.env.production`` point at hostnames that don't resolve.
+    app_host = app_name.replace("_", "-")
+    backend_service_name = f"{app_host}-backend-{service_suffix}"
+    frontend_service_name = f"{app_host}-frontend-{service_suffix}"
 
     render_config = f"""services:
   # Backend API (Free tier - 750 hours/month, spins down after 15 min idle)
@@ -490,18 +530,33 @@ def _add_deployment_configs(
         destination: /index.html
 """
 
-    # Add agent service if the app includes an agent
-    if has_agent:
-        agent_script = f"{agent_entrypoint}.py" if agent_entrypoint else "Agent_Diagram.py"
+    # Build one Render service block per agent. Each agent lives under ``agents/<slug>/``
+    # in the generated repo, so the startCommand cd's into that directory.
+    #
+    # Slug vs hostname: Render silently rewrites underscores to dashes in service
+    # hostnames (e.g. ``my_agent`` → ``my-agent.onrender.com``). If we put an
+    # underscore-slug straight into ``name:`` the DNS record ends up on a dashed
+    # URL while our generated ``VITE_AGENT_URLS`` map still points at the
+    # underscored one — every WebSocket connection then fails even though the
+    # service is happily running. So we keep the underscore slug for the
+    # filesystem layout (Python-friendly directory / script names) and build a
+    # separate dash-slug for the Render service name and the URLs we hand to the
+    # React frontend.
+    agent_service_names: list[str] = []
+    for agent in agent_models:
+        slug = agent_slug(agent.name)           # underscores, filesystem-safe
+        host_slug = slug.replace("_", "-")               # dashes, Render-hostname-safe
+        agent_service_name = f"{app_host}-{host_slug}-agent-{service_suffix}"
+        agent_service_names.append(agent_service_name)
+        agent_script = f"{agent.name}.py"
 
-        # Determine IC technology from agent config
-        ic_tech = None
-        if agent_config and isinstance(agent_config, dict):
-            ic_tech = agent_config.get("intentRecognitionTechnology")
+        cfg = agent_configs.get(agent.name) or {}
+        ic_tech = cfg.get("intentRecognitionTechnology") if isinstance(cfg, dict) else None
 
         if ic_tech == "classical":
             # Classical IC needs PyTorch CPU + scikit-learn, plus [llms] for unconditional imports in generated code
-            # Single pip call with --extra-index-url so PyTorch CPU resolves from the wheel index while the rest comes from PyPI
+            # Single pip call with --extra-index-url so PyTorch CPU resolves from the wheel index while the rest comes from PyPI.
+            # BAFGenerator does NOT emit a requirements.txt, so everything has to be pinned inline here.
             build_cmd = (
                 "pip install torch==2.6.0+cpu scikit-learn==1.6.1 besser-agentic-framework[llms]==4.3.2 "
                 "--extra-index-url https://download.pytorch.org/whl/cpu "
@@ -532,11 +587,11 @@ def _add_deployment_configs(
             f"p = pathlib.Path('{agent_script}'); "
             "p.write_text(re.sub(r'use_ui=True', 'use_ui=False', p.read_text()))"
         )
-        start_cmd = f'cd agent && python -c "{yaml_patch}" && python -u {agent_script}'
+        start_cmd = f'cd agents/{slug} && python -c "{yaml_patch}" && python -u {agent_script}'
         extra_env_vars = "" if ic_tech == "classical" else "\n      - key: OPENAI_API_KEY\n        sync: false"
 
-        agent_service_config = f"""
-  # Agent Service (Free tier - WebSocket-based AI agent)
+        render_config += f"""
+  # Agent Service: {agent.name} (Free tier - WebSocket-based AI agent)
   - type: web
     name: {agent_service_name}
     runtime: python
@@ -547,25 +602,38 @@ def _add_deployment_configs(
       - key: PYTHON_VERSION
         value: 3.11.9{extra_env_vars}
 """
-        render_config += agent_service_config
 
     render_path = os.path.join(directory, "render.yaml")
     with open(render_path, "w") as f:
         f.write(render_config)
 
-    # Create .env.production for frontend with backend URL (and agent URL if applicable)
+    # Build a per-agent URL map keyed by the BUML ``agent.name`` (Python-safe
+    # identifier, e.g. "Library_Agent"). The generated React AgentComponent
+    # normalizes its ``agent-name`` prop with a single space→underscore pass
+    # before lookup, so one canonical key per agent is enough.
+    # ``VITE_AGENT_URL`` stays as a back-compat pointer at the first agent.
+    prod_agent_urls: dict[str, str] = {}
+    local_agent_urls: dict[str, str] = {}
+    for i, (agent, svc_name) in enumerate(zip(agent_models, agent_service_names)):
+        prod_agent_urls[agent.name] = f"wss://{svc_name}.onrender.com"
+        local_agent_urls[agent.name] = f"ws://localhost:{8765 + i}"
+
     env_production = f"""# Production environment variables
 # Backend API URL - Update this with your deployed backend URL
 VITE_API_URL=https://{backend_service_name}.onrender.com
 """
 
     if has_agent:
-        env_production += f"""# Agent WebSocket URL - Update this with your deployed agent URL
-VITE_AGENT_URL=wss://{agent_service_name}.onrender.com
+        first_agent = agent_models[0].name
+        # Wrap the JSON map in single quotes so dotenv treats the whole thing as
+        # a literal string regardless of the inner double quotes in the JSON.
+        env_production += f"""# Agent WebSocket URLs
+VITE_AGENT_URL={prod_agent_urls[first_agent]}
+VITE_AGENT_URLS='{json.dumps(prod_agent_urls)}'
 """
 
     env_production += """
-# For local development, use: http://localhost:8000 (backend) and ws://localhost:8765 (agent)
+# For local development, use: http://localhost:8000 (backend) and ws://localhost:8765+ (agents)
 """
 
     env_prod_path = os.path.join(directory, "frontend", ".env.production")
@@ -578,7 +646,9 @@ VITE_API_URL=http://localhost:8000
 """
 
     if has_agent:
-        env_local += """VITE_AGENT_URL=ws://localhost:8765
+        first_agent = agent_models[0].name
+        env_local += f"""VITE_AGENT_URL={local_agent_urls[first_agent]}
+VITE_AGENT_URLS='{json.dumps(local_agent_urls)}'
 """
 
     env_local_path = os.path.join(directory, "frontend", ".env")

--- a/besser/utilities/web_modeling_editor/backend/services/deployment/github_service.py
+++ b/besser/utilities/web_modeling_editor/backend/services/deployment/github_service.py
@@ -356,7 +356,7 @@ A full-stack web application generated from visual models using the [BESSER Web 
 ```
 frontend/          React + TypeScript frontend (Vite)
 backend/           FastAPI Python backend
-agent/             BESSER conversational agent (if included)
+agents/<name>/     BESSER conversational agents (one subfolder per agent, if any)
 render.yaml        Render deployment config
 docker-compose.yml Local development setup
 ```

--- a/besser/utilities/web_modeling_editor/backend/services/utils/agent_generation_utils.py
+++ b/besser/utilities/web_modeling_editor/backend/services/utils/agent_generation_utils.py
@@ -337,3 +337,67 @@ def handle_personalized_agent(
         generation_mode=GenerationMode.CODE_ONLY,
     )
     return zip_buffer, file_name
+
+
+def collect_agents_from_diagrams(
+    agent_diagrams: List[Any],
+    default_config: Any = None,
+) -> Tuple[List[Any], Dict[str, Any]]:
+    """Process every AgentDiagram in a project into BUML Agent models.
+
+    Used by both the ``/generate-output-from-project`` route and the
+    ``/github/deploy-webapp`` deploy pipeline so they stay in lock-step.
+
+    Args:
+        agent_diagrams: List of diagram entries. Each may be a dict (raw request
+            payload) or a Pydantic ``DiagramInput`` — anything exposing
+            ``.model_dump()`` or already behaving like a dict works.
+        default_config: Fallback config applied when a diagram has no per-diagram
+            ``config`` entry.
+
+    Returns:
+        ``(agent_models, agent_configs)`` where ``agent_configs`` is keyed by
+        ``agent.name``.
+
+    Raises:
+        HTTPException(400): if two agents share the same ``.name`` — the
+        downstream generator would silently overwrite one with the other.
+    """
+    agent_models: List[Any] = []
+    agent_configs: Dict[str, Any] = {}
+    seen: Set[str] = set()
+    duplicates: Set[str] = set()
+
+    for entry in agent_diagrams or []:
+        entry_dict = entry.model_dump() if hasattr(entry, "model_dump") else entry
+        if not isinstance(entry_dict, dict):
+            continue
+        model = entry_dict.get("model")
+        if not model:
+            continue
+        # The deploy endpoint additionally required a non-empty ``elements`` map;
+        # treat that as the unified contract so both paths reject blank diagrams.
+        if isinstance(model, dict) and not model.get("elements"):
+            continue
+        agent_model = process_agent_diagram(entry_dict)
+        if agent_model is None:
+            continue
+
+        name = agent_model.name
+        if name in seen:
+            duplicates.add(name)
+            continue
+        seen.add(name)
+        agent_models.append(agent_model)
+        agent_configs[name] = entry_dict.get("config") or default_config
+
+    if duplicates:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Agent names must be unique within a project. "
+                f"Duplicates: {sorted(duplicates)}"
+            ),
+        )
+
+    return agent_models, agent_configs

--- a/docs/source/generators/full_web_app.rst
+++ b/docs/source/generators/full_web_app.rst
@@ -51,7 +51,54 @@ reference each other by ID through the ``references`` field. This allows stable 
 resolution even when diagrams are reordered or deleted.
 
 When generating from the web editor, the backend resolves the active ``ClassDiagram`` and
-``GUINoCodeDiagram`` (and optionally an ``AgentDiagram``) from the project payload.
+``GUINoCodeDiagram`` from the project payload and collects **every** ``AgentDiagram`` in the
+project — not just the one referenced by the active GUI. This lets a single web app bind
+individual ``AgentComponent``\ s to different agents (see *Multi-agent projects* below).
+
+
+Multi-agent projects
+--------------------
+
+A project may contain several ``AgentDiagram``\ s. Each becomes one generated agent under
+``agents/<slug>/`` in the output zip, and the web-app deploys all of them as independent
+WebSocket services.
+
+* **GUI binding** — each ``AgentComponent`` in a GUI diagram has an ``agent-name`` attribute
+  that is matched against the BUML ``Agent.name``. The editor's component-property panel lists
+  every agent in the project so different components can talk to different agents.
+* **Uniqueness** — agent names must be unique within a project. The editor blocks duplicate
+  renames in the UI, and the generation endpoint returns HTTP 400 on duplicates as a
+  safety net.
+* **Runtime routing** — the generated React ``AgentComponent`` reads a ``VITE_AGENT_URLS``
+  JSON map (``{"Alpha": "ws://localhost:8765", ...}``) and opens the WebSocket matching its
+  own ``agent-name`` prop. A legacy ``VITE_AGENT_URL`` variable is still emitted and used as a
+  fallback for single-agent back-compat.
+* **Local docker-compose** — one service block per agent with port offsets
+  (``8765``, ``8766``, ...) and a build-time ``VITE_AGENT_URLS`` argument injected into the
+  frontend image.
+* **Render deployment** — the GitHub-deployment pipeline emits one ``type: web`` block per
+  agent in ``render.yaml`` and a ``frontend/.env.production`` with the same ``VITE_AGENT_URLS``
+  JSON map pointing at each service's ``*.onrender.com`` URL.
+
+On the Python API side:
+
+.. code-block:: python
+
+    from besser.generators.web_app import WebAppGenerator
+
+    WebAppGenerator(
+        model=domain_model,
+        gui_model=gui_model,
+        output_dir="out/",
+        agent_models=[alpha_agent, beta_agent],
+        agent_configs={
+            "Alpha": {"intentRecognitionTechnology": "classical"},
+            "Beta":  {"intentRecognitionTechnology": "llm"},
+        },
+    ).generate()
+
+The legacy scalar parameters ``agent_model=`` and ``agent_config=`` are still accepted as
+deprecated back-compat shims but map to a one-element list under the hood.
 
 
 How It Works
@@ -92,6 +139,17 @@ Generated Output Structure
    │   ├── package.json
    │   ├── Dockerfile           # Frontend container
    │   └── README.md
+   ├── agents/                  # One subfolder per BUML Agent (if any)
+   │   ├── alpha/
+   │   │   ├── Alpha.py
+   │   │   ├── config.yaml
+   │   │   ├── Dockerfile
+   │   │   └── requirements.txt
+   │   └── beta/
+   │       ├── Beta.py
+   │       ├── config.yaml
+   │       ├── Dockerfile
+   │       └── requirements.txt
    ├── docker-compose.yml       # Container orchestration
 
 

--- a/docs/source/releases/v7.rst
+++ b/docs/source/releases/v7.rst
@@ -4,6 +4,7 @@ Version 7
 .. toctree::
    :maxdepth: 1
 
+   v7/v7.1.2
    v7/v7.1.1
    v7/v7.1.0
    v7/v7.0.0

--- a/docs/source/releases/v7/v7.1.2.rst
+++ b/docs/source/releases/v7/v7.1.2.rst
@@ -1,0 +1,14 @@
+Version 7.1.2
+=============
+
+Patch release: **multi-agent support in the Full Web App generator**. Projects with several ``AgentDiagram``\ s now end up with one generated agent per diagram, and GUI ``AgentComponent``\ s can be bound to different agents individually. Changes span the web modeling editor frontend, the web-app generator, its templates, and the GitHub/Render deploy integration — no metamodel or API-level contract changes.
+
+Highlights
+----------
+
+- **All agents are now generated**: ``WebAppGenerator`` accepts an ``agent_models`` list (plus a per-agent ``agent_configs`` mapping) and emits one subdirectory under ``agents/<slug>/`` per agent. The scalar ``agent_model=``/``agent_config=`` parameters are kept as deprecated back-compat shims.
+- **Every agent is selectable in the editor**: the GUI ``AgentComponent`` property panel now lists *every* ``AgentDiagram`` in the project, not just the one referenced by the active GUI diagram. Previously the dropdown returned a single option and silently collapsed multi-agent projects to one agent.
+- **Per-agent WebSocket routing at runtime**: the generated React ``AgentComponent`` reads a new ``VITE_AGENT_URLS`` JSON map keyed by agent name and opens the WebSocket matching its own ``agent-name`` prop. The legacy single-URL ``VITE_AGENT_URL`` variable is still emitted as a fallback for back-compat.
+- **docker-compose rewrite**: one service block per agent with port offsets (``8765+i``, ``5000+i``), per-agent volume, and a JSON ``VITE_AGENT_URLS`` build arg injected into the frontend image.
+- **Render deployment rewrite**: one ``type: web`` service block per agent in ``render.yaml`` with unique per-agent service names (``<app>-<slug>-agent-<suffix>``). ``frontend/.env.production`` now carries the same JSON URL map so the React app resolves each component to its own deployed ``*.onrender.com`` WebSocket.
+- **Name-uniqueness invariant**: agent names must now be unique within a project. The frontend hard-blocks rename and add operations that would cause a collision; the generation endpoint returns ``HTTP 400`` with the duplicate list as a safety net. This replaces the previous silent-overwrite behavior where two agents named ``"Alpha"`` would clobber each other.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = besser
-version = 7.1.1
+version = 7.1.2
 author = Luxembourg Institute of Science and Technology
 description = BESSER
 long_description = file: README.md

--- a/tests/generators/conftest.py
+++ b/tests/generators/conftest.py
@@ -8,12 +8,66 @@ Fixtures defined here are automatically available to all tests under
 the ``tests/generators/`` directory without explicit imports.
 """
 
+import importlib
+import sys
+import types
+
 import pytest
 from besser.BUML.metamodel.structural import (
     Class, DomainModel, Property, BinaryAssociation, Multiplicity,
     Generalization, Enumeration, EnumerationLiteral,
     StringType, IntegerType, DateType,
 )
+
+
+# ---------------------------------------------------------------------------
+# Break the BAFGenerator import cycle before any generator test module loads.
+#
+# Chain: baf_generator -> services.converters -> services.__init__
+#        -> deployment -> github_deploy_api -> config.generators
+#        -> baf_generator   (CYCLE)
+#
+# We stub the converters module, trigger the BAFGenerator import, then restore
+# the real services modules. Safe to run twice (agents/ has a sibling conftest
+# from an earlier era; both end up exercising the same idempotent path).
+# ---------------------------------------------------------------------------
+
+def _stub_converters():
+    _SERVICES = "besser.utilities.web_modeling_editor.backend.services"
+    _CONVERTERS = _SERVICES + ".converters"
+
+    saved = {}
+    for key in list(sys.modules.keys()):
+        if key.startswith(_SERVICES):
+            saved[key] = sys.modules.pop(key)
+
+    svc = types.ModuleType(_SERVICES)
+    svc.__package__ = _SERVICES
+    svc.__path__ = []
+    sys.modules[_SERVICES] = svc
+
+    conv = types.ModuleType(_CONVERTERS)
+    conv.__package__ = _CONVERTERS
+    conv.__path__ = []
+    conv.agent_buml_to_json = lambda code: {}
+    sys.modules[_CONVERTERS] = conv
+    svc.converters = conv
+
+    try:
+        importlib.import_module("besser.generators.agents.baf_generator")
+    except Exception:
+        pass
+
+    for key in list(sys.modules.keys()):
+        if key.startswith(_SERVICES) and key not in saved:
+            if "baf_generator" not in key:
+                del sys.modules[key]
+
+    for key, mod in saved.items():
+        sys.modules[key] = mod
+
+
+_stub_converters()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/generators/web_app/test_web_app_generator_multi_agent.py
+++ b/tests/generators/web_app/test_web_app_generator_multi_agent.py
@@ -1,0 +1,294 @@
+"""Tests for multi-agent support in WebAppGenerator.
+
+Covers:
+    - Multi-agent: each agent lands under ``agents/<slug>/`` with its own Dockerfile.
+    - docker-compose.yml emits one service block per agent with distinct ports.
+    - Backward compatibility with the deprecated ``agent_model=``/``agent_config=`` scalars.
+    - ``agent_slug`` normalization (spaces, casing, punctuation).
+
+BAFGenerator is patched so tests don't depend on its runtime behavior — we only
+verify the WebAppGenerator wiring around it.
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from besser.BUML.metamodel.structural import (
+    Class, DomainModel, Property, StringType,
+    BinaryAssociation, Multiplicity,
+)
+from besser.BUML.metamodel.gui import GUIModel, Module, Screen, Text
+from besser.generators.web_app import WebAppGenerator
+from besser.generators.web_app.web_app_generator import agent_slug
+
+
+def _make_domain_model():
+    name_prop = Property(name="name", type=StringType)
+    user = Class(name="User", attributes={name_prop})
+    item = Class(name="Item", attributes={Property(name="title", type=StringType)})
+    user_end = Property(name="user_end", type=user, multiplicity=Multiplicity(1, 1))
+    item_end = Property(name="item_end", type=item, multiplicity=Multiplicity(0, "*"))
+    assoc = BinaryAssociation(name="UserItem", ends={user_end, item_end})
+    return DomainModel(name="TestModel", types={user, item}, associations={assoc})
+
+
+def _make_gui_model():
+    text1 = Text(name="title_text", content="Welcome")
+    screen1 = Screen(
+        name="Dashboard",
+        description="Main dashboard",
+        view_elements={text1},
+        is_main_page=True,
+    )
+    module1 = Module(name="AppModule", screens={screen1})
+    return GUIModel(
+        name="TestApp",
+        package="com.test.app",
+        versionCode="1",
+        versionName="1.0",
+        modules={module1},
+        description="Test web application",
+    )
+
+
+def _fake_agent(name):
+    """Minimal Agent-shaped object.
+
+    We can't instantiate ``besser.BUML.metamodel.state_machine.agent.Agent``
+    cleanly in a unit test (it drags in its own validation), and anyway we
+    only need ``.name`` for WebAppGenerator's slug + template logic —
+    BAFGenerator is patched in these tests.
+    """
+    return SimpleNamespace(name=name)
+
+
+@pytest.fixture
+def domain_model():
+    return _make_domain_model()
+
+
+@pytest.fixture
+def gui_model():
+    return _make_gui_model()
+
+
+@pytest.fixture
+def mock_baf_generator():
+    """Patch BAFGenerator so tests don't depend on its runtime behavior.
+
+    The mock still creates a file inside the agent's output_dir so
+    ``os.walk`` checks for non-empty agent directories pass.
+    """
+    with patch("besser.generators.agents.baf_generator.BAFGenerator") as mock:
+        def _fake_generate(self):
+            os.makedirs(self.output_dir, exist_ok=True)
+            with open(os.path.join(self.output_dir, "agent.py"), "w") as f:
+                f.write("# generated agent stub\n")
+
+        instance = MagicMock()
+        instance.generate.side_effect = lambda: _fake_generate(instance)
+        # Captures the ctor args per call so we can inspect in assertions
+        def _side_effect(agent, output_dir=None, config=None):
+            inst = MagicMock()
+            inst.output_dir = output_dir
+            inst.config = config
+            inst.agent = agent
+            inst.generate.side_effect = lambda: _fake_generate(inst)
+            return inst
+        mock.side_effect = _side_effect
+        yield mock
+
+
+def test_agent_slug_normalizes_names():
+    assert agent_slug("Alpha") == "alpha"
+    assert agent_slug("My Agent") == "my_agent"
+    assert agent_slug("Support-Bot 2") == "support_bot_2"
+    assert agent_slug(_fake_agent("Beta")) == "beta"
+    assert agent_slug("") == "agent"
+
+
+def test_multi_agent_creates_one_dir_per_agent(domain_model, gui_model, tmpdir, mock_baf_generator):
+    alpha = _fake_agent("Alpha")
+    beta = _fake_agent("Beta")
+    output_dir = tmpdir.mkdir("output")
+
+    generator = WebAppGenerator(
+        model=domain_model,
+        gui_model=gui_model,
+        output_dir=str(output_dir),
+        agent_models=[alpha, beta],
+    )
+    generator.generate()
+
+    assert os.path.isdir(os.path.join(str(output_dir), "agents", "alpha"))
+    assert os.path.isdir(os.path.join(str(output_dir), "agents", "beta"))
+    assert os.path.isfile(os.path.join(str(output_dir), "agents", "alpha", "Dockerfile"))
+    assert os.path.isfile(os.path.join(str(output_dir), "agents", "beta", "Dockerfile"))
+
+    # Legacy single-agent ``agent/`` directory must NOT be created anymore.
+    assert not os.path.isdir(os.path.join(str(output_dir), "agent"))
+
+    assert mock_baf_generator.call_count == 2
+
+
+def test_multi_agent_docker_compose_contains_all_services(domain_model, gui_model, tmpdir, mock_baf_generator):
+    alpha = _fake_agent("Alpha")
+    beta = _fake_agent("Beta")
+    output_dir = tmpdir.mkdir("output")
+
+    generator = WebAppGenerator(
+        model=domain_model,
+        gui_model=gui_model,
+        output_dir=str(output_dir),
+        agent_models=[alpha, beta],
+    )
+    generator.generate()
+
+    with open(os.path.join(str(output_dir), "docker-compose.yml"), encoding="utf-8") as f:
+        compose = f.read()
+
+    assert "alpha_agent:" in compose
+    assert "beta_agent:" in compose
+    # Port offsets: first agent at 8765/5000, second at 8766/5001
+    assert "8765:8765" in compose
+    assert "8766:8765" in compose
+    assert "5000:5000" in compose
+    assert "5001:5000" in compose
+    # Build contexts must match the agents/<slug>/ layout
+    assert "./agents/alpha" in compose
+    assert "./agents/beta" in compose
+    # JSON-shaped per-agent URL map so the React AgentComponent can route by agent name
+    assert '"Alpha":"ws://localhost:8765"' in compose
+    assert '"Beta":"ws://localhost:8766"' in compose
+
+
+def test_docker_compose_agent_urls_parse_as_yaml(domain_model, gui_model, tmpdir, mock_baf_generator):
+    """The rendered compose file must be valid YAML and the JSON map must parse."""
+    import yaml
+
+    alpha = _fake_agent("Alpha")
+    beta = _fake_agent("Beta")
+    output_dir = tmpdir.mkdir("output")
+
+    WebAppGenerator(
+        model=domain_model,
+        gui_model=gui_model,
+        output_dir=str(output_dir),
+        agent_models=[alpha, beta],
+    ).generate()
+
+    with open(os.path.join(str(output_dir), "docker-compose.yml"), encoding="utf-8") as f:
+        compose_doc = yaml.safe_load(f)
+
+    import json
+    frontend_args = compose_doc["services"]["frontend"]["build"]["args"]
+    url_map = json.loads(frontend_args["VITE_AGENT_URLS"])
+    assert url_map == {
+        "Alpha": "ws://localhost:8765",
+        "Beta": "ws://localhost:8766",
+    }
+
+
+def test_agent_config_passed_through_per_agent(domain_model, gui_model, tmpdir, mock_baf_generator):
+    alpha = _fake_agent("Alpha")
+    beta = _fake_agent("Beta")
+    configs = {
+        "Alpha": {"intentRecognitionTechnology": "classical"},
+        "Beta": {"intentRecognitionTechnology": "llm"},
+    }
+    output_dir = tmpdir.mkdir("output")
+
+    generator = WebAppGenerator(
+        model=domain_model,
+        gui_model=gui_model,
+        output_dir=str(output_dir),
+        agent_models=[alpha, beta],
+        agent_configs=configs,
+    )
+    generator.generate()
+
+    call_configs = {call.args[0].name: call.kwargs.get("config") for call in mock_baf_generator.call_args_list}
+    assert call_configs["Alpha"] == {"intentRecognitionTechnology": "classical"}
+    assert call_configs["Beta"] == {"intentRecognitionTechnology": "llm"}
+
+
+def test_scalar_agent_model_backcompat(domain_model, gui_model, tmpdir, mock_baf_generator):
+    """Deprecated ``agent_model=`` / ``agent_config=`` still work."""
+    alpha = _fake_agent("Alpha")
+    output_dir = tmpdir.mkdir("output")
+
+    generator = WebAppGenerator(
+        model=domain_model,
+        gui_model=gui_model,
+        output_dir=str(output_dir),
+        agent_model=alpha,
+        agent_config={"intentRecognitionTechnology": "llm"},
+    )
+    # Deprecated properties return the scalar form
+    assert generator.agent_model is alpha
+    assert generator.agent_config == {"intentRecognitionTechnology": "llm"}
+    assert generator.agent_models == [alpha]
+
+    generator.generate()
+
+    # Output should live under agents/alpha/ (not legacy agent/)
+    assert os.path.isdir(os.path.join(str(output_dir), "agents", "alpha"))
+    assert not os.path.isdir(os.path.join(str(output_dir), "agent"))
+
+
+def test_no_agents_skips_agents_directory(domain_model, gui_model, tmpdir, mock_baf_generator):
+    """When no agents are passed, no agents/ directory is created and no BAF call."""
+    output_dir = tmpdir.mkdir("output")
+
+    generator = WebAppGenerator(
+        model=domain_model,
+        gui_model=gui_model,
+        output_dir=str(output_dir),
+    )
+    generator.generate()
+
+    assert not os.path.isdir(os.path.join(str(output_dir), "agents"))
+    assert not os.path.isdir(os.path.join(str(output_dir), "agent"))
+    mock_baf_generator.assert_not_called()
+
+
+def test_underscored_agent_name_produces_underscored_slug(domain_model, gui_model, tmpdir, mock_baf_generator):
+    """Underscores in the BUML Agent name survive into the filesystem slug.
+
+    Render hostnames rewrite underscores to dashes, so the GitHub deploy path
+    keeps a separate ``host_slug``. This test just pins the filesystem layout
+    that the generator itself is responsible for.
+    """
+    support = _fake_agent("Support_Bot")
+    output_dir = tmpdir.mkdir("output")
+    WebAppGenerator(
+        model=domain_model,
+        gui_model=gui_model,
+        output_dir=str(output_dir),
+        agent_models=[support],
+    ).generate()
+
+    assert os.path.isdir(os.path.join(str(output_dir), "agents", "support_bot"))
+    with open(os.path.join(str(output_dir), "docker-compose.yml"), encoding="utf-8") as f:
+        compose = f.read()
+    assert "support_bot_agent:" in compose
+    assert "./agents/support_bot" in compose
+
+
+def test_docker_compose_without_agents_has_no_agent_services(domain_model, gui_model, tmpdir, mock_baf_generator):
+    output_dir = tmpdir.mkdir("output")
+    generator = WebAppGenerator(
+        model=domain_model,
+        gui_model=gui_model,
+        output_dir=str(output_dir),
+    )
+    generator.generate()
+
+    with open(os.path.join(str(output_dir), "docker-compose.yml"), encoding="utf-8") as f:
+        compose = f.read()
+
+    assert "_agent:" not in compose
+    assert "VITE_AGENT_URL" not in compose


### PR DESCRIPTION
## Version 7.1.2

Patch release: **multi-agent support in the Full Web App generator**. Projects with several `AgentDiagram`s now end up with one generated agent per diagram, and GUI `AgentComponent`s can be bound to different agents individually. Changes span the web modeling editor frontend, the web-app generator, its templates, and the GitHub/Render deploy integration — no metamodel or API-level contract changes.

## Highlights

- **All agents are now generated**: `WebAppGenerator` accepts an `agent_models` list (plus a per-agent `agent_configs` mapping) and emits one subdirectory under `agents/<slug>/` per agent. The scalar `agent_model=` / `agent_config=` parameters are kept as deprecated back-compat shims.
- **Every agent is selectable in the editor**: the GUI `AgentComponent` property panel now lists *every* `AgentDiagram` in the project, not just the one referenced by the active GUI diagram. Previously the dropdown returned a single option and silently collapsed multi-agent projects to one agent.
- **Per-agent WebSocket routing at runtime**: the generated React `AgentComponent` reads a new `VITE_AGENT_URLS` JSON map keyed by agent name and opens the WebSocket matching its own `agent-name` prop. The legacy single-URL `VITE_AGENT_URL` variable is still emitted as a fallback for back-compat.
- **docker-compose rewrite**: one service block per agent with port offsets (`8765+i`, `5000+i`), per-agent volume, and a JSON `VITE_AGENT_URLS` build arg injected into the frontend image.
- **Render deployment rewrite**: one `type: web` service block per agent in `render.yaml` with unique per-agent service names (`<app>-<slug>-agent-<suffix>`). `frontend/.env.production` now carries the same JSON URL map so the React app resolves each component to its own deployed `*.onrender.com` WebSocket. Underscored project/agent names are converted to dashes for all hostnames to match Render's automatic rewrite, so the generated URLs actually resolve.
- **Name-uniqueness invariant**: agent names must be unique within a project. Adding a template that would collide silently auto-suffixes (`"Library Agent"` → `"Library Agent 2"`); manual renames to a duplicate are hard-blocked with a clear toast. The generation endpoint also returns `HTTP 400` with the duplicate list as a safety net.

## Test plan

- [x] `python -m pytest tests/ --ignore=tests/llm` — 672 passed, 5 skipped, 3 xfailed
- [x] New tests under `tests/generators/web_app/test_web_app_generator_multi_agent.py` cover multi-agent generation, back-compat scalars, per-agent config pass-through, docker-compose YAML parse, and the underscored-name slug regression
- [x] Frontend vitest for `getAgentOptions` (no regressions in `ProjectStorageRepository` tests)
- [x] Smoke test a 2-agent project through "Deploy to GitHub" → Render → verify both WebSockets connect from the generated React app

## Docs

- `docs/source/releases/v7/v7.1.2.rst` — release notes (this PR body mirrors it)
- `docs/source/generators/full_web_app.rst` — new "Multi-agent projects" section + updated output tree

## Linked frontend PR

Frontend submodule pointer bump is included in this PR. The frontend changes are tracked in the companion PR on `BESSER-PEARL/BESSER-Web-Modeling-Editor` https://github.com/BESSER-PEARL/BESSER-Web-Modeling-Editor/pull/104.