### PR TITLE
feat: add natural-language descriptions for OCL constraints (#499)

### DIFF
--- a/besser/BUML/metamodel/structural/structural.py
+++ b/besser/BUML/metamodel/structural/structural.py
@@ -1666,6 +1666,9 @@ class Constraint(NamedElement):
         context (Class): The class to which the constraint is associated.
         expression (str): The expression or condition defined by the constraint.
         language (str): The language in which the constraint expression is written.
+        description (str): Optional natural-language explanation shown to end-users when the
+            constraint is violated. Intended for non-technical audiences (e.g. graphical
+            editor users) who may not understand the raw constraint expression.
         timestamp (datetime): Object creation datetime (default is current time).
         metadata (Metadata): Metadata information for the constraint (None as default).
         is_derived (bool): Inherited from NamedElement, indicates whether the element is derived (False as default).
@@ -1675,17 +1678,20 @@ class Constraint(NamedElement):
         context (Class): The class to which the constraint is associated.
         expression (str): The expression or condition defined by the constraint.
         language (str): The language in which the constraint expression is written.
+        description (str): Optional natural-language explanation surfaced on validation failure.
         timestamp (datetime): Inherited from NamedElement; object creation datetime (default is current time).
         metadata (Metadata): Metadata information for the constraint (None as default).
         is_derived (bool): Inherited from NamedElement, indicates whether the element is derived (False as default).
     """
 
-    def __init__(self, name: str, context: Class, expression: Any, language: str, timestamp: datetime = None,
+    def __init__(self, name: str, context: Class, expression: Any, language: str,
+                 description: str = None, timestamp: datetime = None,
                  metadata: Metadata = None, is_derived: bool = False, uncertainty: float = 0.0):
         super().__init__(name, timestamp, metadata, is_derived=is_derived, uncertainty=uncertainty)
         self.context: Class = context
         self.expression: str = expression
         self.language: str = language
+        self.description: str = description
 
     @property
     def context(self) -> Class:
@@ -1717,10 +1723,23 @@ class Constraint(NamedElement):
         """str: Set the language in which the constraint expression is written."""
         self.__language = language
 
+    @property
+    def description(self) -> str:
+        """str: Get the natural-language explanation shown when the constraint is violated."""
+        return self.__description
+
+    @description.setter
+    def description(self, description: str):
+        """str: Set the natural-language explanation shown when the constraint is violated."""
+        if description is not None and not isinstance(description, str):
+            raise TypeError("description must be a string or None")
+        self.__description = description
+
     def __repr__(self):
         return (
             f'Constraint({self.name}, {self.context.name}, {self.language}, {self.expression}, '
-            f'{self.timestamp}, {self.metadata}, is_derived={self.is_derived})'
+            f'description={self.description!r}, {self.timestamp}, {self.metadata}, '
+            f'is_derived={self.is_derived})'
         )
 class Model(NamedElement):
     """A model is the root element. There are different types of models

--- a/besser/utilities/buml_code_builder/domain_model_builder.py
+++ b/besser/utilities/buml_code_builder/domain_model_builder.py
@@ -433,7 +433,13 @@ def domain_model_to_code(
                 f.write(f"    name=\"{_escape_python_string(constraint.name)}\",\n")
                 f.write(f"    context={context_var_name},\n")
                 f.write(f"    expression=\"{_escape_python_string(constraint.expression)}\",\n")
-                f.write(f"    language=\"{_escape_python_string(constraint.language)}\"\n")
+                f.write(f"    language=\"{_escape_python_string(constraint.language)}\"")
+                description = getattr(constraint, 'description', None)
+                if description:
+                    f.write(",\n")
+                    f.write(f"    description=\"{_escape_python_string(description)}\"\n")
+                else:
+                    f.write("\n")
                 f.write(")\n")
             f.write("\n")
 

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/class_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/class_diagram_converter.py
@@ -403,6 +403,10 @@ def class_buml_to_json(domain_model):
                 ),
             }
 
+            # Surface natural-language constraint descriptions for the editor
+            if isinstance(type_obj, Constraint) and getattr(type_obj, 'description', None):
+                element_data["description"] = type_obj.description
+
             # Add metadata fields for classes if they exist
             if isinstance(type_obj, Class) and hasattr(type_obj, 'metadata') and type_obj.metadata:
                 if type_obj.metadata.description:

--- a/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/class_diagram_processor.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/class_diagram_processor.py
@@ -614,9 +614,15 @@ def _process_constraints(
     for element_id, element in elements.items():
         if element.get("type") in ["ClassOCLConstraint"]:
             ocl = element.get("constraint")
+            description = element.get("description")
             if ocl:
                 try:
-                    new_constraints, warnings = process_ocl_constraints(ocl, domain_model, constraint_counter)
+                    new_constraints, warnings = process_ocl_constraints(
+                        ocl,
+                        domain_model,
+                        constraint_counter,
+                        default_description=description,
+                    )
                     all_constraints.update(new_constraints)
                     all_warnings.extend(warnings)
                     constraint_counter += 1

--- a/besser/utilities/web_modeling_editor/backend/services/converters/parsers/ocl_parser.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/parsers/ocl_parser.py
@@ -6,12 +6,46 @@ import re
 from besser.BUML.metamodel.structural import DomainModel, Constraint
 
 
-def process_ocl_constraints(ocl_text: str, domain_model: DomainModel, counter: int) -> tuple[list, list]:
+def _extract_inline_description(block: str) -> tuple[str, str]:
+    """Split an OCL constraint block into its expression and an inline description.
+
+    OCL supports ``--`` single-line comments. We treat any text following ``--``
+    on a line as a natural-language description of the constraint. The returned
+    expression has the comment stripped so it can be fed to the OCL parser
+    without relying on comment-handling behaviour.
+
+    Returns:
+        tuple[str, str]: ``(expression_without_comments, description_or_empty_string)``.
+    """
+    description_parts: list[str] = []
+    cleaned_lines: list[str] = []
+    for raw_line in block.split('\n'):
+        match = re.search(r'--\s*(.*?)\s*$', raw_line)
+        if match and match.group(1):
+            description_parts.append(match.group(1))
+            raw_line = raw_line[:match.start()].rstrip()
+        cleaned_lines.append(raw_line)
+    cleaned = '\n'.join(cleaned_lines)
+    description = ' '.join(description_parts).strip()
+    return cleaned, description
+
+
+def process_ocl_constraints(
+    ocl_text: str,
+    domain_model: DomainModel,
+    counter: int,
+    default_description: str = None,
+) -> tuple[list, list]:
     """Process OCL constraints and convert them to BUML Constraint objects.
 
     Supports multiple constraints separated by ``context`` keywords in the
     same OCL text block.  Each ``context ... inv ...`` section is parsed as
     a separate Constraint.
+
+    Natural-language explanations can be attached to a constraint by either
+    passing ``default_description`` (applied to every constraint extracted
+    from this block) or by embedding an OCL ``--`` comment inline (per
+    constraint). An inline comment always wins over ``default_description``.
     """
     if not ocl_text:
         return [], []
@@ -33,8 +67,12 @@ def process_ocl_constraints(ocl_text: str, domain_model: DomainModel, counter: i
         if not block:
             continue
 
+        # Extract inline `--` description before collapsing newlines so that
+        # comments (which terminate at end-of-line) are attributed correctly.
+        cleaned_block, inline_description = _extract_inline_description(block)
+
         # Collapse newlines within a single constraint block
-        line = block.replace('\n', ' ').strip()
+        line = cleaned_block.replace('\n', ' ').strip()
 
         if not line.lower().startswith('context'):
             continue
@@ -56,12 +94,15 @@ def process_ocl_constraints(ocl_text: str, domain_model: DomainModel, counter: i
         constraint_count += 1
         constraint_name = f"constraint_{context_class_name}_{counter}_{constraint_count}"
 
+        description = inline_description or (default_description or None)
+
         constraints.append(
             Constraint(
                 name=constraint_name,
                 context=context_class,
                 expression=line,
-                language="OCL"
+                language="OCL",
+                description=description,
             )
         )
 

--- a/besser/utilities/web_modeling_editor/backend/services/validators/ocl_checker.py
+++ b/besser/utilities/web_modeling_editor/backend/services/validators/ocl_checker.py
@@ -81,38 +81,56 @@ def check_ocl_constraint(domain_model, object_model = None):
         parser = OCLWrapper(domain_model, object_model)
 
         for constraint in domain_model.constraints:
+            description = getattr(constraint, "description", None)
+            # Suffix appended to every message so non-technical users see the
+            # plain-language reason alongside the raw OCL expression.
+            explanation_suffix = f" — {description}" if description else ""
             try:
                 if object_model is None:
                     # Syntax-check only — parse without evaluation since there
                     # are no object instances to evaluate against.
                     try:
                         _parse_only(constraint.expression)
-                        valid_constraints.append(f"✅ '{constraint.expression}'")
+                        valid_constraints.append(
+                            f"✅ '{constraint.expression}'{explanation_suffix}"
+                        )
                     except BOCLSyntaxError as syntax_err:
                         invalid_constraints.append(
-                            f"❌ '{constraint.expression}' - Error: Invalid OCL syntax: {syntax_err}"
+                            f"❌ '{constraint.expression}' - Error: Invalid OCL syntax: "
+                            f"{syntax_err}{explanation_suffix}"
                         )
                 else:
                     # Check if there are instances of the context class in the object model
                     context_class_name = extract_context_class_name(constraint.expression)
-                    context_instances = [obj for obj in object_model.objects 
+                    context_instances = [obj for obj in object_model.objects
                                         if hasattr(obj, 'classifier') and obj.classifier.name.lower() == context_class_name.lower()]
 
                     if not context_instances:
                         # No instances of the context class exist, skip evaluation
                         # valid_constraints.append(f"⚠️ '{constraint.expression}' - No instances of '{context_class_name}' found to evaluate constraint")
                         continue
-                    
+
                     # Use evaluate method for OCLWrapper (evaluation with object model)
                     result = parser.evaluate(constraint)
                     if result is True:
-                        valid_constraints.append(f"✅ '{constraint.expression}' - Evaluates to: True")
+                        valid_constraints.append(
+                            f"✅ '{constraint.expression}' - Evaluates to: True{explanation_suffix}"
+                        )
                     elif result is False:
-                        invalid_constraints.append(f"❌ '{constraint.expression}' - Constraint violation: Evaluates to False")
+                        # Prefer the natural-language description as the primary
+                        # violation reason when one is provided.
+                        violation_reason = description if description else "Evaluates to False"
+                        invalid_constraints.append(
+                            f"❌ '{constraint.expression}' - Constraint violation: {violation_reason}"
+                        )
                     else:
-                        valid_constraints.append(f"✅ '{constraint.expression}' - Evaluates to: {result}")
+                        valid_constraints.append(
+                            f"✅ '{constraint.expression}' - Evaluates to: {result}{explanation_suffix}"
+                        )
             except Exception as e:
-                invalid_constraints.append(f"❌ '{constraint.expression}' - Error: {str(e)} \n")
+                invalid_constraints.append(
+                    f"❌ '{constraint.expression}' - Error: {str(e)}{explanation_suffix} \n"
+                )
 
         return {
             "success": len(invalid_constraints) == 0,

--- a/tests/utilities/web_modeling_editor/backend/services/converters/parsers/test_constraint_descriptions.py
+++ b/tests/utilities/web_modeling_editor/backend/services/converters/parsers/test_constraint_descriptions.py
@@ -1,0 +1,248 @@
+"""
+Tests for natural-language descriptions on OCL Constraints.
+
+Covers Issue #499: when an OCL constraint is invalid during validation,
+end users should see a plain-language explanation alongside the raw OCL
+expression. This file exercises the four touch points that thread the
+``description`` field end-to-end:
+
+  1. ``Constraint`` metamodel field
+  2. ``process_ocl_constraints`` (JSON -> BUML) — both the dedicated
+     ``description`` parameter and the inline ``--`` OCL comment fallback
+  3. ``check_ocl_constraint`` validator output
+  4. ``buml_to_json`` class-diagram converter round-trip
+"""
+
+import pytest
+
+from besser.BUML.metamodel.structural import (
+    Class,
+    Constraint,
+    DomainModel,
+    IntegerType,
+    Property,
+)
+from besser.utilities.web_modeling_editor.backend.services.converters.parsers.ocl_parser import (
+    process_ocl_constraints,
+)
+from besser.utilities.web_modeling_editor.backend.services.validators.ocl_checker import (
+    check_ocl_constraint,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def professor_domain_model():
+    """A trivial single-class domain model used by the OCL parser tests."""
+    professor = Class(name="Professor")
+    professor.attributes = {Property(name="age", type=IntegerType)}
+    return DomainModel(name="University", types={professor})
+
+
+# ===========================================================================
+# 1. Constraint metamodel
+# ===========================================================================
+
+class TestConstraintDescriptionField:
+    """The ``description`` field on the Constraint metamodel class."""
+
+    def _make_class(self):
+        return Class(name="Professor")
+
+    def test_default_description_is_none(self):
+        c = Constraint(
+            name="c1",
+            context=self._make_class(),
+            expression="context Professor inv: self.age > 25",
+            language="OCL",
+        )
+        assert c.description is None
+
+    def test_description_can_be_set_via_constructor(self):
+        c = Constraint(
+            name="c1",
+            context=self._make_class(),
+            expression="context Professor inv: self.age > 25",
+            language="OCL",
+            description="Professors must be over 25",
+        )
+        assert c.description == "Professors must be over 25"
+
+    def test_description_setter_round_trip(self):
+        c = Constraint(
+            name="c1",
+            context=self._make_class(),
+            expression="context Professor inv: self.age > 25",
+            language="OCL",
+        )
+        c.description = "Updated reason"
+        assert c.description == "Updated reason"
+
+    def test_description_setter_rejects_non_string(self):
+        c = Constraint(
+            name="c1",
+            context=self._make_class(),
+            expression="context Professor inv: self.age > 25",
+            language="OCL",
+        )
+        with pytest.raises(TypeError):
+            c.description = 123
+
+    def test_repr_includes_description(self):
+        c = Constraint(
+            name="c1",
+            context=self._make_class(),
+            expression="context Professor inv: self.age > 25",
+            language="OCL",
+            description="Realistic age",
+        )
+        assert "Realistic age" in repr(c)
+
+
+# ===========================================================================
+# 2. JSON -> BUML parser (process_ocl_constraints)
+# ===========================================================================
+
+class TestProcessOclConstraintsDescription:
+    """``process_ocl_constraints`` should attach descriptions to Constraint objects."""
+
+    def test_default_description_applied_to_all_blocks(self, professor_domain_model):
+        ocl = "context Professor inv: self.age > 25"
+        constraints, warnings = process_ocl_constraints(
+            ocl,
+            professor_domain_model,
+            counter=0,
+            default_description="Be sure to choose a realistic age",
+        )
+        assert warnings == []
+        assert len(constraints) == 1
+        assert constraints[0].description == "Be sure to choose a realistic age"
+
+    def test_inline_comment_takes_precedence_over_default(self, professor_domain_model):
+        ocl = "context Professor inv: self.age > 25 -- Inline wins"
+        constraints, _ = process_ocl_constraints(
+            ocl,
+            professor_domain_model,
+            counter=0,
+            default_description="Default loses",
+        )
+        assert len(constraints) == 1
+        assert constraints[0].description == "Inline wins"
+        # The comment is stripped from the expression so the OCL parser
+        # never has to deal with it.
+        assert "--" not in constraints[0].expression
+        assert "Inline wins" not in constraints[0].expression
+
+    def test_no_description_yields_none(self, professor_domain_model):
+        ocl = "context Professor inv: self.age > 25"
+        constraints, _ = process_ocl_constraints(
+            ocl, professor_domain_model, counter=0
+        )
+        assert len(constraints) == 1
+        assert constraints[0].description is None
+
+    def test_inline_comment_per_constraint_in_multi_block(self):
+        """Per-constraint inline comments are attributed to the right Constraint."""
+        prof = Class(name="Professor")
+        prof.attributes = {Property(name="age", type=IntegerType)}
+        student = Class(name="Student")
+        student.attributes = {Property(name="gpa", type=IntegerType)}
+        dm = DomainModel(name="Uni", types={prof, student})
+
+        ocl = (
+            "context Professor inv: self.age > 25 -- Profs must be experienced\n"
+            "context Student inv: self.gpa >= 0 -- GPA cannot be negative\n"
+        )
+        constraints, warnings = process_ocl_constraints(ocl, dm, counter=0)
+        assert warnings == []
+        # Order is the order of appearance in the input
+        by_context = {c.context.name: c for c in constraints}
+        assert by_context["Professor"].description == "Profs must be experienced"
+        assert by_context["Student"].description == "GPA cannot be negative"
+
+
+# ===========================================================================
+# 3. Validator output (check_ocl_constraint)
+# ===========================================================================
+
+class TestCheckOclConstraintIncludesDescription:
+    """``check_ocl_constraint`` must surface descriptions in result strings."""
+
+    def test_syntax_only_pass_message_includes_description(self, professor_domain_model):
+        c = Constraint(
+            name="c1",
+            context=next(iter(professor_domain_model.types)),
+            expression="context Professor inv: self.age > 25",
+            language="OCL",
+            description="Realistic age",
+        )
+        professor_domain_model.constraints = {c}
+
+        result = check_ocl_constraint(professor_domain_model)
+        assert result["success"] is True
+        joined = " ".join(result["valid_constraints"])
+        assert "Realistic age" in joined
+
+    def test_syntax_error_message_includes_description(self, professor_domain_model):
+        bad = Constraint(
+            name="c_bad",
+            context=next(iter(professor_domain_model.types)),
+            expression="this is not valid OCL @@@",
+            language="OCL",
+            description="Friendly hint to the user",
+        )
+        professor_domain_model.constraints = {bad}
+
+        result = check_ocl_constraint(professor_domain_model)
+        assert result["success"] is False
+        joined = " ".join(result["invalid_constraints"])
+        assert "Friendly hint to the user" in joined
+
+    def test_no_description_means_no_suffix_change(self, professor_domain_model):
+        c = Constraint(
+            name="c1",
+            context=next(iter(professor_domain_model.types)),
+            expression="context Professor inv: self.age > 25",
+            language="OCL",
+        )
+        professor_domain_model.constraints = {c}
+
+        result = check_ocl_constraint(professor_domain_model)
+        assert result["success"] is True
+        # The legacy success format must not be polluted by a stray separator
+        # when no description is provided.
+        for entry in result["valid_constraints"]:
+            assert " — " not in entry  # em-dash separator is description-only
+
+
+# ===========================================================================
+# 4. BUML -> JSON round-trip
+# ===========================================================================
+
+class TestBumlToJsonRoundTripDescription:
+    """The class-diagram converter should emit the description field."""
+
+    def test_description_appears_in_json_output(self, professor_domain_model):
+        from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json.class_diagram_converter import (
+            class_buml_to_json,
+        )
+
+        c = Constraint(
+            name="c1",
+            context=next(iter(professor_domain_model.types)),
+            expression="context Professor inv: self.age > 25",
+            language="OCL",
+            description="Realistic age",
+        )
+        professor_domain_model.constraints = {c}
+
+        json_output = class_buml_to_json(professor_domain_model)
+        elements = json_output.get("elements", {})
+        constraint_elements = [
+            e for e in elements.values() if e.get("type") == "ClassOCLConstraint"
+        ]
+        assert constraint_elements, "expected at least one ClassOCLConstraint element"
+        assert constraint_elements[0].get("description") == "Realistic age"


### PR DESCRIPTION
Adds an optional `description` field to the `Constraint` metamodel so end-users see a plain-language explanation when an OCL constraint is violated during model validation, instead of the raw expression.

Threaded end-to-end:
- Metamodel: new `description` field on Constraint
- JSON->BUML: accepts a `description` JSON field on ClassOCLConstraint elements, plus inline OCL `--` comments per constraint (inline wins)
- BUML->JSON: emits `description` so editor round-trips preserve it
- Validator: surfaces the description as the violation reason in /validate-diagram output (legacy format unchanged when no description)
- Code builder: generated Constraint() Python code includes the field

Tests: 13 new tests covering all four touch points.

Note: this commit was generated by Claude Code on behalf of the user.