### PR TITLE
release: v7.1.4 — accept XLSX uploads in the Project Hub spreadsheet flow

### DIFF
--- a/besser/utilities/web_modeling_editor/backend/requirements.txt
+++ b/besser/utilities/web_modeling_editor/backend/requirements.txt
@@ -6,3 +6,4 @@ PyYAML
 deep_translator
 bocl == 1.0.0
 cryptography
+openpyxl >= 3.1.0

--- a/besser/utilities/web_modeling_editor/backend/routers/conversion_router.py
+++ b/besser/utilities/web_modeling_editor/backend/routers/conversion_router.py
@@ -97,7 +97,7 @@ MAX_BUML_SIZE = 2 * 1024 * 1024       # 2 MB
 # ---------------------------------------------------------------------------
 # Allowed MIME / extension sets per upload type
 # ---------------------------------------------------------------------------
-ALLOWED_CSV_EXTENSIONS = {".csv"}
+ALLOWED_SPREADSHEET_EXTENSIONS = {".csv", ".xlsx"}
 ALLOWED_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg"}
 ALLOWED_BUML_EXTENSIONS = {".py"}
 ALLOWED_KG_EXTENSIONS = {".ttl", ".rdf", ".json"}
@@ -155,6 +155,14 @@ def _validate_file_content(content: bytes, filename: str) -> None:
                 detail="CSV file does not contain comma or semicolon separators.",
             )
 
+    elif ext == ".xlsx":
+        # XLSX files are ZIP archives — check the ZIP magic bytes.
+        if not content.startswith(b"PK\x03\x04"):
+            raise HTTPException(
+                status_code=400,
+                detail="XLSX file appears to be corrupted or is not a valid Excel workbook.",
+            )
+
     elif ext == ".py":
         # Must be valid Python syntax
         try:
@@ -199,6 +207,49 @@ async def _write_file(path: str, data: bytes | str, mode: str = "wb") -> None:
         with open(path, mode) as fh:
             fh.write(data)
     await asyncio.to_thread(_do_write)
+
+
+def _xlsx_bytes_to_csv_file(xlsx_bytes: bytes, csv_path: str) -> None:
+    """Convert the first worksheet of an XLSX workbook to a UTF-8 CSV file.
+
+    Lazy-imports openpyxl so the rest of the backend stays importable if the
+    optional dependency is missing.
+    """
+    import csv as _csv
+    import io
+
+    try:
+        from openpyxl import load_workbook
+    except ImportError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="XLSX support requires the 'openpyxl' package. Install it with `pip install openpyxl`.",
+        ) from exc
+
+    try:
+        workbook = load_workbook(io.BytesIO(xlsx_bytes), read_only=True, data_only=True)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Could not read XLSX file: {exc}",
+        ) from exc
+
+    try:
+        worksheet = workbook.active
+        if worksheet is None:
+            raise HTTPException(status_code=400, detail="XLSX file contains no worksheets.")
+
+        with open(csv_path, "w", encoding="utf-8", newline="") as fh:
+            writer = _csv.writer(fh)
+            rows_written = 0
+            for row in worksheet.iter_rows(values_only=True):
+                writer.writerow(["" if cell is None else cell for cell in row])
+                rows_written += 1
+    finally:
+        workbook.close()
+
+    if rows_written == 0:
+        raise HTTPException(status_code=400, detail="XLSX worksheet is empty.")
 
 
 async def _read_json_file(path: str) -> dict:
@@ -459,18 +510,32 @@ async def get_single_json_model(buml_file: UploadFile = File(...)):
 @handle_endpoint_errors("csv_to_domain_model_endpoint")
 async def csv_to_domain_model_endpoint(files: list[UploadFile] = File(...)):
     """
-    Accepts one or more CSV files and returns a B-UML domain model as JSON.
+    Accepts one or more CSV or XLSX files and returns a B-UML domain model as JSON.
+    XLSX files are converted to CSV (first worksheet) before reverse engineering.
     """
     file_paths = []
     with tempfile.TemporaryDirectory(prefix=CSV_TEMP_DIR_PREFIX) as temp_dir:
         # Save uploaded files to temp dir
         for file in files:
             file_content = await file.read()
-            _validate_upload(file, max_size=MAX_CSV_SIZE, allowed_extensions=ALLOWED_CSV_EXTENSIONS, content=file_content)
+            _validate_upload(
+                file,
+                max_size=MAX_CSV_SIZE,
+                allowed_extensions=ALLOWED_SPREADSHEET_EXTENSIONS,
+                content=file_content,
+            )
             _validate_file_content(file_content, file.filename or "")
             safe_filename = os.path.basename(file.filename)
-            file_path = os.path.join(temp_dir, safe_filename)
-            await _write_file(file_path, file_content)
+            _, ext = os.path.splitext(safe_filename)
+            ext = ext.lower()
+
+            if ext == ".xlsx":
+                csv_name = os.path.splitext(safe_filename)[0] + ".csv"
+                file_path = os.path.join(temp_dir, csv_name)
+                _xlsx_bytes_to_csv_file(file_content, file_path)
+            else:
+                file_path = os.path.join(temp_dir, safe_filename)
+                await _write_file(file_path, file_content)
             file_paths.append(file_path)
 
         # Generate DomainModel from CSVs

--- a/docs/source/releases/v7.rst
+++ b/docs/source/releases/v7.rst
@@ -4,6 +4,7 @@ Version 7
 .. toctree::
    :maxdepth: 1
 
+   v7/v7.1.4
    v7/v7.1.3
    v7/v7.1.2
    v7/v7.1.1

--- a/docs/source/releases/v7/v7.1.4.rst
+++ b/docs/source/releases/v7/v7.1.4.rst
@@ -1,0 +1,12 @@
+Version 7.1.4
+=============
+
+Patch release: **the "From Spreadsheet" project creation flow now accepts XLSX workbooks as advertised**. Backend-only fix — no metamodel, generator, or public API contract changes. The frontend submodule pointer is unchanged.
+
+Highlights
+----------
+
+- **XLSX uploads in ``/besser_api/csv-to-domain-model`` no longer fail with "Unsupported file type '.xlsx'"** (`#501 <https://github.com/BESSER-PEARL/BESSER/issues/501>`_): the Project Hub "From Spreadsheet" dialog already exposed ``accept=".csv,.xlsx,.xls,..."`` on its file input and the copy promised "Auto-generate a class diagram from CSV/XLSX files", but the backend's ``_validate_upload`` whitelisted only ``{".csv"}`` and rejected everything else with a 415. ``conversion_router.py`` now carries an ``ALLOWED_SPREADSHEET_EXTENSIONS = {".csv", ".xlsx"}`` set, validates ``.xlsx`` content by checking the ZIP magic bytes (``PK\x03\x04``), and converts each uploaded workbook's first worksheet to a UTF-8 CSV via ``openpyxl`` inside the request's temp directory before handing the resulting path list to the existing ``csv_to_domain_model`` reverse engineer. ``csv_reverse.py`` itself is unchanged — the xlsx-to-csv normalization happens entirely in the endpoint.
+- **New optional backend dependency: ``openpyxl >= 3.1.0``** added to ``besser/utilities/web_modeling_editor/backend/requirements.txt`` (not the top-level ``requirements.txt`` — this only matters for the editor backend). The import is lazy inside the helper, so the rest of the backend stays importable when the package is missing; if a user uploads XLSX without openpyxl installed they get a clear 500 with installation instructions instead of a traceback.
+- **Legacy ``.xls`` (BIFF) is deliberately not supported**: reading ``.xls`` would require the deprecated ``xlrd`` package (upstream dropped ``.xlsx`` support in 2.0 and warns against use for new work). Users who upload ``.xls`` get the same clear 415 as before, listing ``.csv, .xlsx`` as the allowed extensions.
+- **Regression coverage** in ``tests/utilities/web_modeling_editor/backend/test_spreadsheet_import.py``: CSV upload still succeeds, XLSX upload succeeds and produces a ``ClassDiagram``, unsupported extensions return 415 with both allowed extensions named in the error, and malformed XLSX (bad magic bytes) returns 400 before reaching openpyxl.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = besser
-version = 7.1.3
+version = 7.1.4
 author = Luxembourg Institute of Science and Technology
 description = BESSER
 long_description = file: README.md

--- a/tests/utilities/web_modeling_editor/backend/test_spreadsheet_import.py
+++ b/tests/utilities/web_modeling_editor/backend/test_spreadsheet_import.py
@@ -1,0 +1,84 @@
+"""Tests for the /csv-to-domain-model endpoint accepting CSV and XLSX uploads.
+
+Regression coverage for https://github.com/BESSER-PEARL/BESSER/issues/501.
+"""
+
+import asyncio
+import io
+
+import httpx
+import pytest
+from httpx._transports.asgi import ASGITransport
+from openpyxl import Workbook
+
+from besser.utilities.web_modeling_editor.backend.backend import app
+
+BASE_URL = "http://testserver"
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _post_files(url: str, files):
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=BASE_URL) as ac:
+        return await ac.post(url, files=files)
+
+
+def _make_csv_bytes() -> bytes:
+    return b"id,name\n1,Alice\n2,Bob\n"
+
+
+def _make_xlsx_bytes() -> bytes:
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["id", "name"])
+    ws.append([1, "Alice"])
+    ws.append([2, "Bob"])
+    buffer = io.BytesIO()
+    wb.save(buffer)
+    return buffer.getvalue()
+
+
+def test_csv_upload_still_works():
+    files = [("files", ("User.csv", _make_csv_bytes(), "text/csv"))]
+    resp = _run(_post_files("/besser_api/csv-to-domain-model", files))
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["diagramType"] == "ClassDiagram"
+
+
+def test_xlsx_upload_is_accepted():
+    files = [
+        (
+            "files",
+            (
+                "User.xlsx",
+                _make_xlsx_bytes(),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ),
+        )
+    ]
+    resp = _run(_post_files("/besser_api/csv-to-domain-model", files))
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["diagramType"] == "ClassDiagram"
+
+
+def test_unsupported_extension_is_rejected():
+    files = [("files", ("User.pdf", b"not a spreadsheet", "application/pdf"))]
+    resp = _run(_post_files("/besser_api/csv-to-domain-model", files))
+    assert resp.status_code == 415
+    assert ".csv" in resp.text and ".xlsx" in resp.text
+
+
+def test_xlsx_with_bad_magic_bytes_is_rejected():
+    files = [("files", ("User.xlsx", b"not a zip archive", "application/octet-stream"))]
+    resp = _run(_post_files("/besser_api/csv-to-domain-model", files))
+    assert resp.status_code == 400
+    assert "XLSX" in resp.text or "Excel" in resp.text
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Resolves #501: the Project Hub "From Spreadsheet" flow advertised CSV/XLSX in the UI but the backend rejected `.xlsx` with a 415. `conversion_router.py` now whitelists `.xlsx`, validates ZIP magic bytes, and converts the first worksheet to CSV via `openpyxl` before handing off to the existing `csv_to_domain_model` reverse engineer.
- Adds `openpyxl >= 3.1.0` to the **editor backend** requirements (`besser/utilities/web_modeling_editor/backend/requirements.txt`) — not the top-level `requirements.txt`, since the fix is backend-only.
- Backend-only release: no frontend submodule bump, no metamodel / generator / public API changes. Legacy `.xls` (BIFF) remains unsupported on purpose.

## Test plan
- [x] New regression tests pass: `python -m pytest tests/utilities/web_modeling_editor/backend/test_spreadsheet_import.py -v` (4/4)
- [x] Full backend test suite green: `python -m pytest tests/utilities/web_modeling_editor/backend -q` (199/199)
- [ ] Manual smoke test from the editor: File → New → From Spreadsheet → upload an `.xlsx` → class diagram generated
- [ ] Full docs build: `cd docs && make html` — new v7.1.4 release page renders