### PR TITLE
fix(agent-personalization): trigger personalization on content-only changes

### DIFF
--- a/besser/generators/agents/baf_generator.py
+++ b/besser/generators/agents/baf_generator.py
@@ -35,6 +35,7 @@ _PERSONALIZATION_CONFIG_KEYS = frozenset({
     # original dict by ``flatten_agent_config_structure``).
     "presentation",
     "modality",
+    "content",
     # Flattened presentation fields.
     "agentLanguage",
     "agentStyle",
@@ -47,6 +48,10 @@ _PERSONALIZATION_CONFIG_KEYS = frozenset({
     # Flattened modality fields.
     "inputModalities",
     "outputModalities",
+    # Flattened content fields (user-profile-driven reply rewriting).
+    "adaptContentToUserProfile",
+    "userProfileName",
+    "userProfileModel",
 })
 
 


### PR DESCRIPTION
## Summary
- Fix a bug where enabling agent personalization with **only content changes** (toggling *Adapt content to user profile* + selecting a user profile, without touching the *Presentation* section) didn''t trigger the personalization pass — the OpenAI call that rewrites agent replies against the user profile was silently skipped.
- Root cause: `_config_has_personalization_content` in `besser/generators/agents/baf_generator.py` allowlisted `presentation` and `modality` keys but omitted the `content` section. With a sparse config containing only `adaptContentToUserProfile` / `userProfileName` / `userProfileModel`, the gate returned `False` and `configure_agent` never ran.
- Fix: add `content`, `adaptContentToUserProfile`, `userProfileName`, and `userProfileModel` to the allowlist so the personalization pass fires for content-only configurations.

## Test plan
- [x] Manual: configure an agent with the *Content* section only (adapt-to-profile + a user profile), Save & Apply — personalization call now fires and replies are rewritten against the profile.
- [ ] Existing presentation-only / modality-only flows continue to trigger personalization (no regression).
- [ ] Configs with only system/runtime keys (platform, LLM, intent recognition) still skip the personalization pass.

Generated with [Claude Code](https://claude.com/claude-code)