### PR TITLE
feat(ocl): AST utilities + Cabot-Teniente normalization pipeline

### DIFF
--- a/besser/BUML/metamodel/ocl/__init__.py
+++ b/besser/BUML/metamodel/ocl/__init__.py
@@ -1,1 +1,16 @@
 from .ocl import *
+
+from besser.BUML.metamodel.ocl.walk import walk
+from besser.BUML.metamodel.ocl.clone import clone
+from besser.BUML.metamodel.ocl.predicates import (
+    is_op, is_and, is_or, is_xor, is_implies, is_not,
+    is_size, is_isempty, is_allinstances,
+    is_comparison, is_atomic_type_test,
+    is_loop, is_loop_with_n_iterators,
+    is_self, is_bool_const,
+)
+from besser.BUML.metamodel.ocl.chain import (
+    is_chain_from_self, walk_chain_from_self,
+    chain_min_multiplicity, chain_max_multiplicity,
+)
+from besser.BUML.metamodel.ocl.substitute import substitute, ScopeStack

--- a/besser/BUML/metamodel/ocl/__init__.py
+++ b/besser/BUML/metamodel/ocl/__init__.py
@@ -14,3 +14,14 @@ from besser.BUML.metamodel.ocl.chain import (
     chain_min_multiplicity, chain_max_multiplicity,
 )
 from besser.BUML.metamodel.ocl.substitute import substitute, ScopeStack
+
+__all__ = [
+    "walk", "clone", "substitute", "ScopeStack",
+    "is_op", "is_and", "is_or", "is_xor", "is_implies", "is_not",
+    "is_size", "is_isempty", "is_allinstances",
+    "is_comparison", "is_atomic_type_test",
+    "is_loop", "is_loop_with_n_iterators",
+    "is_self", "is_bool_const",
+    "is_chain_from_self", "walk_chain_from_self",
+    "chain_min_multiplicity", "chain_max_multiplicity",
+]

--- a/besser/BUML/metamodel/ocl/chain.py
+++ b/besser/BUML/metamodel/ocl/chain.py
@@ -1,0 +1,83 @@
+"""Property-chain analysis on OCL ASTs.
+
+Helpers for inspecting navigation chains rooted at ``self``, e.g.
+``self.r1.r2.r3``. After parsing through the bug-fixing ``WrappingVisitor``,
+such chains appear as nested ``PropertyCallExpression`` nodes terminating in
+``VariableExp("self")``.
+
+These helpers are useful for any pass that reasons about static reachability
+through the structural model: the multiplicity-based normalization rule
+(paper §3.1.3), the context-change feature, foreign-key inference in code
+generators, dangling-end checks in validators.
+"""
+
+from besser.BUML.metamodel.ocl.ocl import PropertyCallExpression, VariableExp
+
+
+def is_chain_from_self(node):
+    """True iff `node` is a chain of ``PropertyCallExpression`` nodes terminating in ``self``.
+
+    A bare ``Property`` (i.e. an AST node from an unwrapped visitor) returns
+    ``False`` — the helper only recognises chains in their fully reconstructed
+    form.
+    """
+    if not isinstance(node, PropertyCallExpression):
+        return False
+    cur = node.source
+    while isinstance(cur, PropertyCallExpression):
+        cur = cur.source
+    return isinstance(cur, VariableExp) and cur.name == "self"
+
+
+def walk_chain_from_self(node):
+    """Return the chain's ``Property`` list from outermost to innermost step.
+
+    For ``self.r1.r2.r3`` returns ``[r1, r2, r3]``. Returns ``None`` if `node`
+    is not a chain rooted at ``self``.
+    """
+    if not is_chain_from_self(node):
+        return None
+    chain = []
+    cur = node
+    while isinstance(cur, PropertyCallExpression):
+        chain.append(cur.property)
+        cur = cur.source
+    chain.reverse()
+    return chain
+
+
+def chain_min_multiplicity(node):
+    """Smallest minimum multiplicity along the chain, or ``None`` if unknown.
+
+    If every step has a defined multiplicity and the returned value is ``>= 1``,
+    the chain is statically guaranteed to be non-empty: the
+    ``self.r1...rn->notEmpty() == true`` simplification (paper §3.1.3 rule 1)
+    is sound.
+    """
+    chain = walk_chain_from_self(node)
+    if chain is None:
+        return None
+    mins = []
+    for prop in chain:
+        if prop.multiplicity is None:
+            return None
+        mins.append(prop.multiplicity.min)
+    return min(mins) if mins else None
+
+
+def chain_max_multiplicity(node):
+    """Largest maximum multiplicity along the chain, or ``None`` if unknown.
+
+    If every step has a defined multiplicity and the returned value is ``<= 1``,
+    the chain has at most one element and the ``forAll`` collapse simplification
+    (paper §3.1.3 rule 2) is sound.
+    """
+    chain = walk_chain_from_self(node)
+    if chain is None:
+        return None
+    maxs = []
+    for prop in chain:
+        if prop.multiplicity is None:
+            return None
+        maxs.append(prop.multiplicity.max)
+    return max(maxs) if maxs else None

--- a/besser/BUML/metamodel/ocl/clone.py
+++ b/besser/BUML/metamodel/ocl/clone.py
@@ -1,0 +1,88 @@
+"""Structural cloning of OCL ASTs.
+
+``clone(node)`` returns a fresh AST tree that mirrors `node`. References to
+domain-model objects (``Property``, ``Class``, primitive types) are shared
+with the original, not duplicated — these belong to the structural model and
+must remain identity-equal across clones.
+
+Use this whenever a transformation must not mutate its input. ``copy.deepcopy``
+is unsuitable because it would clone the entire ``DomainModel`` graph reachable
+through ``Property.owner``.
+"""
+
+from besser.BUML.metamodel.ocl.ocl import (
+    OperationCallExpression, LoopExp, IteratorExp, IfExp,
+    PropertyCallExpression, VariableExp, TypeExp, InfixOperator,
+    IntegerLiteralExpression, RealLiteralExpression,
+    BooleanLiteralExpression, StringLiteralExpression, DateLiteralExpression,
+)
+
+
+def clone(node):
+    """Return a fresh copy of `node` with shared structural-model references."""
+    if node is None:
+        return None
+
+    # IteratorExp checked before LoopExp because IteratorExp <: LoopExp.
+    if isinstance(node, IteratorExp):
+        return IteratorExp(node.name, node.type)
+
+    if isinstance(node, LoopExp):
+        new = LoopExp(node.name, node.type)
+        if node.source is not None:
+            new.source = clone(node.source)
+        for it in node.iterator:
+            new.addIterator(clone(it))
+        for body_expr in node.body:
+            new.add_body(clone(body_expr))
+        return new
+
+    if isinstance(node, IfExp):
+        new = IfExp(node.name, node.type)
+        new.ifCondition = clone(node.ifCondition)
+        new.thenExpression = clone(node.thenExpression)
+        new.elseCondition = clone(node.elseCondition)
+        return new
+
+    if isinstance(node, OperationCallExpression):
+        new_args = []
+        for arg in node.arguments:
+            if isinstance(arg, InfixOperator):
+                # InfixOperator carries a single string operator; treat as immutable.
+                new_args.append(arg)
+            else:
+                new_args.append(clone(arg))
+        new = OperationCallExpression(node.name, node.operation, new_args)
+        if node.source is not None:
+            new.source = clone(node.source)
+        if node.referredOperation is not None:
+            new.referredOperation = clone(node.referredOperation)
+        return new
+
+    if isinstance(node, PropertyCallExpression):
+        # Share the underlying Property reference.
+        new = PropertyCallExpression(node.name, node.property)
+        if node.source is not None:
+            new.source = clone(node.source)
+        return new
+
+    if isinstance(node, VariableExp):
+        return VariableExp(node.name, None)
+
+    if isinstance(node, TypeExp):
+        return TypeExp(node.name, node.name)
+
+    if isinstance(node, IntegerLiteralExpression):
+        return IntegerLiteralExpression(node.name, node.value)
+    if isinstance(node, RealLiteralExpression):
+        return RealLiteralExpression(node.name, node.value)
+    if isinstance(node, BooleanLiteralExpression):
+        return BooleanLiteralExpression(node.name, node.value)
+    if isinstance(node, StringLiteralExpression):
+        return StringLiteralExpression(node.name, node.value)
+    if isinstance(node, DateLiteralExpression):
+        return DateLiteralExpression(node.name, node.value)
+
+    # Bare structural-model objects (e.g. Property leaked through unwrapped
+    # visitor) are shared, not cloned.
+    return node

--- a/besser/BUML/metamodel/ocl/ocl.py
+++ b/besser/BUML/metamodel/ocl/ocl.py
@@ -101,7 +101,7 @@ class PropertyCallExpression(OCLExpression):
     """
 
     def __init__(self, name: str, property: Property):
-        super().__init__(name, Type(property.type))
+        super().__init__(name, property.type)
         self.property: Property = property
 
     def __repr__(self):

--- a/besser/BUML/metamodel/ocl/predicates.py
+++ b/besser/BUML/metamodel/ocl/predicates.py
@@ -1,0 +1,126 @@
+"""Predicate helpers for dispatching on OCL AST nodes.
+
+The B-OCL metamodel encodes most operators as ``OperationCallExpression``
+nodes with an ``operation`` string discriminator (``"and"``, ``"or"``,
+``"forAll"``, ``"="``, etc.) rather than as dedicated subclasses. Direct
+``isinstance`` checks are therefore not enough; consumers need to compose
+``isinstance`` with an ``operation`` string equality.
+
+These predicates centralize that pattern so every consumer (rewrite rules,
+validators, code generators, analysis passes) tests for the same operator
+shapes the same way.
+"""
+
+from besser.BUML.metamodel.ocl.ocl import (
+    OperationCallExpression, LoopExp, BooleanLiteralExpression, VariableExp,
+)
+
+
+_COMP_OPS = {"<", ">", "<=", ">=", "=", "<>"}
+_TYPE_TEST_OPS = {"OCLISTYPEOF", "OCLISKINDOF", "OCLASTYPE"}
+
+
+def is_op(node, op):
+    """True iff `node` is an ``OperationCallExpression`` with ``operation == op``."""
+    return isinstance(node, OperationCallExpression) and node.operation == op
+
+
+def is_and(node):
+    return is_op(node, "and")
+
+
+def is_or(node):
+    return is_op(node, "or")
+
+
+def is_xor(node):
+    return is_op(node, "xor")
+
+
+def is_implies(node):
+    return is_op(node, "implies")
+
+
+def is_not(node):
+    return is_op(node, "not")
+
+
+def is_size(node):
+    return is_op(node, "Size")
+
+
+def is_isempty(node):
+    return is_op(node, "IsEmpty")
+
+
+def is_allinstances(node):
+    return is_op(node, "ALLInstances")
+
+
+def is_comparison(node):
+    """True iff `node` is a binary comparison operator (``<``, ``>``, ``<=``, ``>=``, ``=``, ``<>``).
+
+    Comparisons use the 3-argument shape ``[L, InfixOperator(op), R]``.
+    """
+    return (isinstance(node, OperationCallExpression)
+            and node.operation in _COMP_OPS
+            and len(node.arguments) == 3)
+
+
+def is_atomic_type_test(node):
+    """True iff `node` is ``oclIsTypeOf`` / ``oclIsKindOf`` / ``oclAsType``.
+
+    Rules that distribute negation must leave these alone — they are atomic
+    predicates from a normalization standpoint.
+    """
+    return (isinstance(node, OperationCallExpression)
+            and node.operation in _TYPE_TEST_OPS)
+
+
+def is_loop(node, name=None):
+    """True iff `node` is a ``LoopExp``. With ``name``, requires ``node.name == name``.
+
+    Accepts ``"forAll"``, ``"exists"``, ``"select"``, ``"reject"``, ``"collect"``,
+    ``"iterate"``.
+    """
+    if not isinstance(node, LoopExp):
+        return False
+    if name is None:
+        return True
+    return node.name == name
+
+
+def is_loop_with_n_iterators(node, k):
+    """True iff `node` is a loop with exactly ``k`` iterator variables.
+
+    Most rewrite rules in the literature assume single-iterator loops; multi-
+    iterator forms (``forAll(a, b | …)``) should be detected and skipped.
+    """
+    return isinstance(node, LoopExp) and len(node.iterator) == k
+
+
+def is_self(node):
+    """True iff `node` is the ``self`` variable expression."""
+    return isinstance(node, VariableExp) and node.name == "self"
+
+
+def is_bool_const(node, value=None):
+    """True iff `node` is a ``BooleanLiteralExpression``.
+
+    With ``value``, requires the boolean to equal ``value``. Tolerates the
+    legacy lexeme-as-string representation (``"true"`` / ``"false"``) so
+    callers don't need to know whether the AST has been through ``WrappingVisitor``.
+    """
+    if not isinstance(node, BooleanLiteralExpression):
+        return False
+    if value is None:
+        return True
+    return _coerce_bool(node.value) == value
+
+
+def _coerce_bool(v):
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, str):
+        return v.strip().lower() == "true"
+    return bool(v)

--- a/besser/BUML/metamodel/ocl/substitute.py
+++ b/besser/BUML/metamodel/ocl/substitute.py
@@ -1,0 +1,127 @@
+"""Capture-avoiding variable substitution on OCL ASTs.
+
+:func:`substitute` replaces every *free* occurrence of a variable in an OCL
+expression with a clone of a replacement expression. A variable is *bound*
+inside the body of a ``LoopExp`` whose iterator declarations include a
+matching name; bound occurrences are not substituted.
+
+Used by:
+
+- the ``allInstances`` normalization rule (substitute the iterator variable
+  with ``self``);
+- the multiplicity-1 ``forAll`` collapse (substitute the iterator with the
+  source navigation chain);
+- any future pass that performs let-inlining, alpha-renaming, or partial
+  evaluation.
+
+The base visitor's flat-dict iterator scope (in ``BOCLVisitorImpl``) has a
+known shadowing bug for nested loops with same-named iterators. This module
+uses an explicit stack so substitution is correct under any nesting.
+"""
+
+from besser.BUML.metamodel.ocl.clone import clone
+from besser.BUML.metamodel.ocl.ocl import (
+    IfExp, InfixOperator, LoopExp, OperationCallExpression,
+    PropertyCallExpression, VariableExp,
+)
+
+
+class ScopeStack:
+    """Stack of variable-binding frames for capture-avoiding substitution.
+
+    Each frame is a set of bound names. Pushing a frame on entry to a loop
+    body and popping on exit ensures inner shadowing does not leak.
+    """
+
+    def __init__(self):
+        self._frames = []
+
+    def push(self, names):
+        self._frames.append(set(names))
+
+    def pop(self):
+        return self._frames.pop()
+
+    def is_bound(self, name):
+        return any(name in frame for frame in self._frames)
+
+
+def substitute(expr, var_name, replacement, scope=None):
+    """Return a fresh AST with every free ``VariableExp(var_name)`` replaced by ``clone(replacement)``.
+
+    ``expr`` is not mutated. If a nested ``LoopExp`` declares an iterator with
+    the same name as ``var_name``, occurrences inside that loop's body are
+    treated as bound and left untouched.
+
+    Args:
+        expr: The expression to substitute into. May be any OCL AST node.
+        var_name: The variable name to replace.
+        replacement: The expression to substitute in place of each free
+            occurrence. Cloned at each substitution site so the result is a
+            tree (no aliasing).
+        scope: Optional initial scope stack. Defaults to a fresh empty stack.
+
+    Returns:
+        A fresh AST tree.
+    """
+    if scope is None:
+        scope = ScopeStack()
+    return _sub(expr, var_name, replacement, scope)
+
+
+def _sub(node, var, repl, scope):
+    if node is None:
+        return None
+
+    if isinstance(node, VariableExp):
+        if node.name == var and not scope.is_bound(var):
+            return clone(repl)
+        return clone(node)
+
+    if isinstance(node, LoopExp):
+        new = LoopExp(node.name, node.type)
+        if node.source is not None:
+            # Source is in the enclosing scope; iterator shadowing applies
+            # only to the body.
+            new.source = _sub(node.source, var, repl, scope)
+        for it in node.iterator:
+            new.addIterator(clone(it))
+
+        bound_names = [it.name for it in node.iterator]
+        scope.push(bound_names)
+        try:
+            for body_expr in node.body:
+                new.add_body(_sub(body_expr, var, repl, scope))
+        finally:
+            scope.pop()
+        return new
+
+    if isinstance(node, IfExp):
+        new = IfExp(node.name, node.type)
+        new.ifCondition = _sub(node.ifCondition, var, repl, scope)
+        new.thenExpression = _sub(node.thenExpression, var, repl, scope)
+        new.elseCondition = _sub(node.elseCondition, var, repl, scope)
+        return new
+
+    if isinstance(node, OperationCallExpression):
+        new_args = []
+        for arg in node.arguments:
+            if isinstance(arg, InfixOperator):
+                new_args.append(arg)
+            else:
+                new_args.append(_sub(arg, var, repl, scope))
+        new = OperationCallExpression(node.name, node.operation, new_args)
+        if node.source is not None:
+            new.source = _sub(node.source, var, repl, scope)
+        if node.referredOperation is not None:
+            new.referredOperation = clone(node.referredOperation)
+        return new
+
+    if isinstance(node, PropertyCallExpression):
+        new = PropertyCallExpression(node.name, node.property)
+        if node.source is not None:
+            new.source = _sub(node.source, var, repl, scope)
+        return new
+
+    # Leaf — clone (which is identity for shared metamodel objects).
+    return clone(node)

--- a/besser/BUML/metamodel/ocl/walk.py
+++ b/besser/BUML/metamodel/ocl/walk.py
@@ -1,0 +1,56 @@
+"""Post-order traversal of OCL ASTs.
+
+Generic walker that yields every expression node in a B-OCL AST. Intended for
+any pass that needs to inspect an AST: validators, code generators, the
+normalization rule engine, the future context-change pass, static analysis, etc.
+
+Children-visiting policy:
+- ``OperationCallExpression``: visit ``source`` (if not None), then arguments
+  left-to-right. ``InfixOperator`` instances inside ``arguments`` are skipped
+  (they are markers, not sub-expressions).
+- ``LoopExp`` / ``IteratorExp``: visit ``source`` (if not None), then each
+  expression in ``body``. ``iterator`` (variable declarations) is not visited.
+- ``IfExp``: visit ``ifCondition``, ``thenExpression``, ``elseCondition``.
+- ``PropertyCallExpression``: visit ``source`` only. ``property`` is a
+  metamodel ``Property`` reference and is not recursed into.
+- All literal types, ``VariableExp``, ``TypeExp``, and bare ``Property``: leaf.
+"""
+
+from besser.BUML.metamodel.ocl.ocl import (
+    OperationCallExpression, LoopExp, IfExp, PropertyCallExpression,
+    InfixOperator,
+)
+
+
+def walk(node):
+    """Yield every node in `node`'s OCL subtree in post-order.
+
+    Children are visited before their parent. ``None`` is a no-op.
+    """
+    if node is None:
+        return
+    if isinstance(node, OperationCallExpression):
+        if node.source is not None:
+            yield from walk(node.source)
+        for arg in node.arguments:
+            if isinstance(arg, InfixOperator):
+                continue
+            yield from walk(arg)
+        yield node
+    elif isinstance(node, LoopExp):
+        if node.source is not None:
+            yield from walk(node.source)
+        for body_expr in node.body:
+            yield from walk(body_expr)
+        yield node
+    elif isinstance(node, IfExp):
+        yield from walk(node.ifCondition)
+        yield from walk(node.thenExpression)
+        yield from walk(node.elseCondition)
+        yield node
+    elif isinstance(node, PropertyCallExpression):
+        if node.source is not None:
+            yield from walk(node.source)
+        yield node
+    else:
+        yield node

--- a/besser/BUML/notations/ocl/__init__.py
+++ b/besser/BUML/notations/ocl/__init__.py
@@ -17,6 +17,7 @@ from besser.BUML.notations.ocl.api import parse_ocl
 from besser.BUML.notations.ocl.pretty_printer import pretty_print
 from besser.BUML.notations.ocl.wrapping_visitor import WrappingVisitor
 from besser.BUML.notations.ocl.error_handling import BOCLSyntaxError
+from besser.BUML.notations.ocl.normalization import normalize
 
 # Re-exports from the metamodel for one-stop import.
 from besser.BUML.metamodel.ocl import (
@@ -32,6 +33,7 @@ from besser.BUML.metamodel.ocl import (
 
 __all__ = [
     "parse_ocl", "pretty_print", "WrappingVisitor", "BOCLSyntaxError",
+    "normalize",
     "walk", "clone", "substitute", "ScopeStack",
     "is_op", "is_and", "is_or", "is_xor", "is_implies", "is_not",
     "is_size", "is_isempty", "is_allinstances",

--- a/besser/BUML/notations/ocl/__init__.py
+++ b/besser/BUML/notations/ocl/__init__.py
@@ -1,0 +1,43 @@
+"""B-OCL notation: parser front-end and AST printing.
+
+Public surface:
+
+- :func:`parse_ocl` — parse a B-OCL constraint string into an AST.
+- :func:`pretty_print` — render an AST back to OCL source text.
+- :class:`WrappingVisitor` — bug-fixed visitor (used internally by
+  :func:`parse_ocl`); expose for callers that drive the ANTLR pipeline directly.
+- :class:`BOCLSyntaxError` — raised on parse errors.
+
+AST helpers (``walk``, ``clone``, ``predicates``, ``chain``) live next to the
+metamodel in :mod:`besser.BUML.metamodel.ocl` and are re-exported here for
+discoverability.
+"""
+
+from besser.BUML.notations.ocl.api import parse_ocl
+from besser.BUML.notations.ocl.pretty_printer import pretty_print
+from besser.BUML.notations.ocl.wrapping_visitor import WrappingVisitor
+from besser.BUML.notations.ocl.error_handling import BOCLSyntaxError
+
+# Re-exports from the metamodel for one-stop import.
+from besser.BUML.metamodel.ocl import (
+    walk, clone, substitute, ScopeStack,
+    is_op, is_and, is_or, is_xor, is_implies, is_not,
+    is_size, is_isempty, is_allinstances,
+    is_comparison, is_atomic_type_test,
+    is_loop, is_loop_with_n_iterators,
+    is_self, is_bool_const,
+    is_chain_from_self, walk_chain_from_self,
+    chain_min_multiplicity, chain_max_multiplicity,
+)
+
+__all__ = [
+    "parse_ocl", "pretty_print", "WrappingVisitor", "BOCLSyntaxError",
+    "walk", "clone", "substitute", "ScopeStack",
+    "is_op", "is_and", "is_or", "is_xor", "is_implies", "is_not",
+    "is_size", "is_isempty", "is_allinstances",
+    "is_comparison", "is_atomic_type_test",
+    "is_loop", "is_loop_with_n_iterators",
+    "is_self", "is_bool_const",
+    "is_chain_from_self", "walk_chain_from_self",
+    "chain_min_multiplicity", "chain_max_multiplicity",
+]

--- a/besser/BUML/notations/ocl/api.py
+++ b/besser/BUML/notations/ocl/api.py
@@ -1,0 +1,94 @@
+"""Public parsing API for B-OCL.
+
+:func:`parse_ocl` is the canonical entry point for any consumer that needs an
+OCL AST. It mirrors the wiring already used by ``OCLWrapper.evaluate`` in the
+B-OCL-Interpreter, with three differences:
+
+- It uses :class:`WrappingVisitor` so the returned AST has reconstructed
+  property chains and Python ``bool`` values for boolean literals.
+- It raises :class:`BOCLSyntaxError` on parse errors instead of silently
+  returning a partial AST.
+- It returns an :class:`OCLConstraint` so the context class is preserved for
+  downstream pretty-printing and rule lookups.
+"""
+
+import re
+
+from antlr4 import InputStream, CommonTokenStream
+
+from besser.BUML.metamodel.ocl.ocl import OCLConstraint
+from besser.BUML.metamodel.structural import Class, DomainModel
+from besser.BUML.notations.ocl.BOCLLexer import BOCLLexer
+from besser.BUML.notations.ocl.BOCLParser import BOCLParser
+from besser.BUML.notations.ocl.error_handling import (
+    BOCLErrorListener, BOCLSyntaxError,
+)
+from besser.BUML.notations.ocl.wrapping_visitor import WrappingVisitor
+
+
+_CONTEXT_RE = re.compile(r"\bcontext\s+(\w+)\s+(?:inv|pre|post|init)\b")
+
+
+def parse_ocl(text: str, model: DomainModel,
+              context_class: Class = None) -> OCLConstraint:
+    """Parse an OCL constraint string into a fresh AST.
+
+    Args:
+        text: The OCL source, e.g. ``"context Employee inv: self.age > 16"``.
+        model: The :class:`DomainModel` used to resolve the context class and
+            property bindings.
+        context_class: Optional explicit context :class:`Class`. If omitted,
+            the class is parsed from the ``context X inv|pre|post|init`` header
+            and resolved against ``model.types``.
+
+    Returns:
+        An :class:`OCLConstraint` whose ``expression`` is the parsed AST and
+        whose ``context`` is the resolved context class.
+
+    Raises:
+        BOCLSyntaxError: if the text fails to lex or parse.
+        ValueError: if the context class cannot be located in the model.
+    """
+    if context_class is None:
+        match = _CONTEXT_RE.search(text)
+        if match is None:
+            raise ValueError(
+                "parse_ocl: input does not contain a "
+                "'context <ClassName> inv|pre|post|init' header"
+            )
+        ctx_name = match.group(1)
+        context_class = _resolve_class(model, ctx_name)
+        if context_class is None:
+            raise ValueError(
+                f"parse_ocl: context class {ctx_name!r} not found in domain model"
+            )
+
+    input_stream = InputStream(text)
+    lexer = BOCLLexer(input_stream)
+    lexer.removeErrorListeners()
+    error_listener = BOCLErrorListener()
+    lexer.addErrorListener(error_listener)
+    stream = CommonTokenStream(lexer)
+    parser = BOCLParser(stream)
+    parser.removeErrorListeners()
+    parser.addErrorListener(error_listener)
+    tree = parser.oclFile()
+    if error_listener.has_errors():
+        raise BOCLSyntaxError(error_listener.errors)
+
+    visitor = WrappingVisitor(model, None, context_class)
+    expression = visitor.visit(tree)
+
+    return OCLConstraint(
+        name="parsed",
+        context=context_class,
+        expression=expression,
+        language="OCL",
+    )
+
+
+def _resolve_class(model: DomainModel, name: str):
+    for t in model.types:
+        if isinstance(t, Class) and t.name == name:
+            return t
+    return None

--- a/besser/BUML/notations/ocl/normalization/__init__.py
+++ b/besser/BUML/notations/ocl/normalization/__init__.py
@@ -1,0 +1,10 @@
+"""B-OCL normalization: rewrite a constraint into canonical form.
+
+Public entry point: :func:`normalize`. The rule-set and driver internals are
+documented in :mod:`besser.BUML.notations.ocl.normalization.normalize` and the
+``rules`` submodule.
+"""
+
+from besser.BUML.notations.ocl.normalization.normalize import normalize, Context
+
+__all__ = ["normalize", "Context"]

--- a/besser/BUML/notations/ocl/normalization/normalize.py
+++ b/besser/BUML/notations/ocl/normalization/normalize.py
@@ -1,0 +1,152 @@
+"""Bottom-up fixed-point rewrite driver.
+
+:func:`normalize` clones the input AST, then iterates: each pass walks the AST
+in post-order, asks every rule (in fixed order) whether it applies at each
+node, and rewrites at the first matching rule. The pass terminates when a
+full traversal produces no rewrite. Termination is guaranteed by the
+lexicographic measure ``⟨#sugar-operators, AST size, #negations⟩`` — every
+rule strictly decreases that measure.
+
+The driver returns a fresh :class:`OCLConstraint`. Inputs are not mutated.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, List, Tuple
+
+from besser.BUML.metamodel.ocl import clone
+from besser.BUML.metamodel.ocl.ocl import (
+    IfExp, InfixOperator, LoopExp, OCLConstraint,
+    OperationCallExpression, PropertyCallExpression,
+)
+from besser.BUML.metamodel.structural import DomainModel
+
+
+@dataclass
+class Context:
+    """Shared state passed to every rule.
+
+    Attributes:
+        model: The :class:`DomainModel` providing class and property bindings.
+        constraint: The original :class:`OCLConstraint` (read-only) — gives
+            rules access to the context class via ``constraint.context``.
+        log: Trace of rule applications as ``(rule_name, before, after)``
+            triples. ``before`` and ``after`` are short string repr's, suitable
+            for debugging or assertion in tests.
+    """
+    model: DomainModel
+    constraint: OCLConstraint
+    log: List[Tuple[str, str, str]] = field(default_factory=list)
+
+
+def normalize(constraint: OCLConstraint, model: DomainModel,
+              max_iterations: int = 1000) -> OCLConstraint:
+    """Return a fresh :class:`OCLConstraint` in B-OCL normal form.
+
+    Args:
+        constraint: The constraint to normalize. Not mutated.
+        model: The owning :class:`DomainModel` (used for class/property
+            lookups in some rules).
+        max_iterations: Hard cap on outer fixed-point iterations. Default is
+            1000; reaching this implies a rule is non-terminating, which is a
+            bug.
+
+    Returns:
+        A new :class:`OCLConstraint` with the same name, context, and language
+        as the input, and a normalized expression.
+    """
+    # Defer rule import to avoid a circular import on package load.
+    from besser.BUML.notations.ocl.normalization.rules import build_default_rules
+
+    rules = build_default_rules()
+    expr = clone(constraint.expression)
+    ctx = Context(model=model, constraint=constraint)
+
+    for _ in range(max_iterations):
+        new_expr, changed = _rewrite_pass(expr, rules, ctx)
+        if not changed:
+            return OCLConstraint(
+                name=constraint.name,
+                context=constraint.context,
+                expression=new_expr,
+                language=constraint.language or "OCL",
+            )
+        expr = new_expr
+
+    raise RuntimeError(
+        f"normalize: rewrite did not reach a fixed point in "
+        f"{max_iterations} iterations — possible non-terminating rule. "
+        f"Trace: {ctx.log[-10:]}"
+    )
+
+
+def _rewrite_pass(node, rules, ctx):
+    """One bottom-up traversal. Returns ``(node, changed_anywhere)``."""
+    if node is None:
+        return None, False
+
+    changed = False
+
+    # Recurse into children first (post-order). We mutate `node` in place
+    # because the top-level driver cloned the input — every node we touch
+    # here is freshly owned by this normalization run.
+    if isinstance(node, OperationCallExpression):
+        if node.source is not None:
+            new_src, ch = _rewrite_pass(node.source, rules, ctx)
+            if ch:
+                node.source = new_src
+                changed = True
+        for i, arg in enumerate(node.arguments):
+            if isinstance(arg, InfixOperator):
+                continue
+            new_arg, ch = _rewrite_pass(arg, rules, ctx)
+            if ch:
+                node.arguments[i] = new_arg
+                changed = True
+    elif isinstance(node, LoopExp):
+        if node.source is not None:
+            new_src, ch = _rewrite_pass(node.source, rules, ctx)
+            if ch:
+                node.source = new_src
+                changed = True
+        for i, body_expr in enumerate(node.body):
+            new_body, ch = _rewrite_pass(body_expr, rules, ctx)
+            if ch:
+                node.body[i] = new_body
+                changed = True
+    elif isinstance(node, IfExp):
+        new_c, ch = _rewrite_pass(node.ifCondition, rules, ctx)
+        if ch:
+            node.ifCondition = new_c
+            changed = True
+        new_t, ch = _rewrite_pass(node.thenExpression, rules, ctx)
+        if ch:
+            node.thenExpression = new_t
+            changed = True
+        new_e, ch = _rewrite_pass(node.elseCondition, rules, ctx)
+        if ch:
+            node.elseCondition = new_e
+            changed = True
+    elif isinstance(node, PropertyCallExpression):
+        if node.source is not None:
+            new_src, ch = _rewrite_pass(node.source, rules, ctx)
+            if ch:
+                node.source = new_src
+                changed = True
+
+    # Try each rule on this (now-children-normalized) node.
+    for rule in rules:
+        if rule.applies(node, ctx):
+            new_node = rule.rewrite(node, ctx)
+            ctx.log.append((rule.name, _short(node), _short(new_node)))
+            return new_node, True
+
+    return node, changed
+
+
+def _short(node) -> str:
+    """Compact repr for the trace log."""
+    try:
+        from besser.BUML.notations.ocl.pretty_printer import pretty_print
+        return pretty_print(node)
+    except Exception:
+        return repr(node)

--- a/besser/BUML/notations/ocl/normalization/normalize.py
+++ b/besser/BUML/notations/ocl/normalization/normalize.py
@@ -11,7 +11,7 @@ The driver returns a fresh :class:`OCLConstraint`. Inputs are not mutated.
 """
 
 from dataclasses import dataclass, field
-from typing import Any, List, Tuple
+from typing import List, Tuple
 
 from besser.BUML.metamodel.ocl import clone
 from besser.BUML.metamodel.ocl.ocl import (

--- a/besser/BUML/notations/ocl/normalization/rules/__init__.py
+++ b/besser/BUML/notations/ocl/normalization/rules/__init__.py
@@ -1,0 +1,32 @@
+"""Normalization rule modules.
+
+Each module defines a list of :class:`Rule` instances. The engine consumes the
+concatenated list in a fixed order (see :func:`build_default_rules`).
+"""
+
+from besser.BUML.notations.ocl.normalization.rules.boolean import BOOLEAN_RULES
+from besser.BUML.notations.ocl.normalization.rules.cnf import CNF_RULES
+from besser.BUML.notations.ocl.normalization.rules.collection import COLLECTION_RULES
+from besser.BUML.notations.ocl.normalization.rules.iterator import ITERATOR_RULES
+from besser.BUML.notations.ocl.normalization.rules.all_instances import ALL_INSTANCES_RULES
+from besser.BUML.notations.ocl.normalization.rules.multiplicity import MULTIPLICITY_RULES
+
+
+def build_default_rules():
+    """Return the full ordered rule list applied at every traversal."""
+    return [
+        # Constant collapse + simple structural rewrites first so cheaper rules
+        # don't keep firing on already-simplified output of bigger rewrites.
+        *BOOLEAN_RULES,
+        # Sugar elimination — implies, xor, if-bool.
+        *CNF_RULES,
+        # Collection sugar — isEmpty, reject.
+        *COLLECTION_RULES,
+        # Multiplicity-aware fast paths fire before iterator rewrites so they
+        # can collapse trivially-true chain forms.
+        *MULTIPLICITY_RULES,
+        # Size-of-select fusions and exists→forAll.
+        *ITERATOR_RULES,
+        # allInstances over the constraint context class.
+        *ALL_INSTANCES_RULES,
+    ]

--- a/besser/BUML/notations/ocl/normalization/rules/_helpers.py
+++ b/besser/BUML/notations/ocl/normalization/rules/_helpers.py
@@ -1,0 +1,46 @@
+"""Small constructors and dispatch helpers reused by multiple rule modules."""
+
+from besser.BUML.metamodel.ocl import clone
+from besser.BUML.metamodel.ocl.ocl import (
+    BooleanLiteralExpression, InfixOperator, IntegerLiteralExpression,
+    OperationCallExpression,
+)
+
+
+def make_bool(value: bool) -> BooleanLiteralExpression:
+    return BooleanLiteralExpression("NP", value)
+
+
+def make_int(value: int) -> IntegerLiteralExpression:
+    return IntegerLiteralExpression("NP", value)
+
+
+def make_not(operand) -> OperationCallExpression:
+    return OperationCallExpression(
+        name="unary_not", operation="not", arguments=[clone(operand)],
+    )
+
+
+def make_and(left, right) -> OperationCallExpression:
+    return OperationCallExpression(
+        name="AND_BINARY", operation="and",
+        arguments=[clone(left), clone(right)],
+    )
+
+
+def make_or(left, right) -> OperationCallExpression:
+    return OperationCallExpression(
+        name="OR_BINARY", operation="or",
+        arguments=[clone(left), clone(right)],
+    )
+
+
+def make_comparison(left, op: str, right) -> OperationCallExpression:
+    return OperationCallExpression(
+        name="Operation", operation=op,
+        arguments=[clone(left), InfixOperator(op), clone(right)],
+    )
+
+
+def is_zero_literal(node) -> bool:
+    return isinstance(node, IntegerLiteralExpression) and node.value == 0

--- a/besser/BUML/notations/ocl/normalization/rules/all_instances.py
+++ b/besser/BUML/notations/ocl/normalization/rules/all_instances.py
@@ -1,0 +1,34 @@
+"""Paper §2.2 — eliminate ``allInstances`` over the constraint context type.
+
+When the receiver of ``allInstances()`` is the same class as the constraint's
+context, ``ct.allInstances()->forAll(v | Y)`` is equivalent to ``Y[self/v]``.
+"""
+
+from besser.BUML.metamodel.ocl import (
+    clone, is_allinstances, is_loop, is_loop_with_n_iterators, substitute,
+)
+from besser.BUML.metamodel.ocl.ocl import TypeExp, VariableExp
+
+
+class AllInstancesContextElim:
+    name = "AllInstancesContextElim"
+
+    def applies(self, node, ctx):
+        if not is_loop(node, "forAll") or not is_loop_with_n_iterators(node, 1):
+            return False
+        src = node.source
+        if not is_allinstances(src):
+            return False
+        type_exp = src.source
+        if not isinstance(type_exp, TypeExp):
+            return False
+        return type_exp.name == ctx.constraint.context.name
+
+    def rewrite(self, node, ctx):
+        var_name = node.iterator[0].name
+        body = clone(node.body[0])
+        # Replace every free occurrence of `var_name` with `self`.
+        return substitute(body, var_name, VariableExp("self", None))
+
+
+ALL_INSTANCES_RULES = [AllInstancesContextElim()]

--- a/besser/BUML/notations/ocl/normalization/rules/boolean.py
+++ b/besser/BUML/notations/ocl/normalization/rules/boolean.py
@@ -8,7 +8,6 @@ normalizer: every other rule produces output that these rules then clean up.
 from besser.BUML.metamodel.ocl import (
     clone, is_and, is_or, is_not, is_comparison, is_bool_const,
 )
-from besser.BUML.metamodel.ocl.ocl import OperationCallExpression
 from besser.BUML.notations.ocl.normalization.rules._helpers import (
     make_bool, make_or, make_and, make_comparison, make_not,
 )

--- a/besser/BUML/notations/ocl/normalization/rules/boolean.py
+++ b/besser/BUML/notations/ocl/normalization/rules/boolean.py
@@ -1,0 +1,158 @@
+"""Paper §2.1 Table 1 — boolean simplifications.
+
+Constant collapse, double-negation elimination, DeMorgan's laws, and
+negated-comparison flattening. These rules are the workhorse of the
+normalizer: every other rule produces output that these rules then clean up.
+"""
+
+from besser.BUML.metamodel.ocl import (
+    clone, is_and, is_or, is_not, is_comparison, is_bool_const,
+)
+from besser.BUML.metamodel.ocl.ocl import OperationCallExpression
+from besser.BUML.notations.ocl.normalization.rules._helpers import (
+    make_bool, make_or, make_and, make_comparison, make_not,
+)
+
+
+_NEGATED_COMP = {
+    "<": ">=",
+    ">": "<=",
+    "<=": ">",
+    ">=": "<",
+    "=": "<>",
+    "<>": "=",
+}
+
+
+# ---------------------------------------------------------------------------
+# Constant collapse
+# ---------------------------------------------------------------------------
+class AndTrue:
+    name = "AndTrue"
+
+    def applies(self, node, ctx):
+        return (is_and(node) and len(node.arguments) == 2
+                and (is_bool_const(node.arguments[0], True)
+                     or is_bool_const(node.arguments[1], True)))
+
+    def rewrite(self, node, ctx):
+        if is_bool_const(node.arguments[0], True):
+            return clone(node.arguments[1])
+        return clone(node.arguments[0])
+
+
+class AndFalse:
+    name = "AndFalse"
+
+    def applies(self, node, ctx):
+        return (is_and(node) and len(node.arguments) == 2
+                and (is_bool_const(node.arguments[0], False)
+                     or is_bool_const(node.arguments[1], False)))
+
+    def rewrite(self, node, ctx):
+        return make_bool(False)
+
+
+class OrTrue:
+    name = "OrTrue"
+
+    def applies(self, node, ctx):
+        return (is_or(node) and len(node.arguments) == 2
+                and (is_bool_const(node.arguments[0], True)
+                     or is_bool_const(node.arguments[1], True)))
+
+    def rewrite(self, node, ctx):
+        return make_bool(True)
+
+
+class OrFalse:
+    name = "OrFalse"
+
+    def applies(self, node, ctx):
+        return (is_or(node) and len(node.arguments) == 2
+                and (is_bool_const(node.arguments[0], False)
+                     or is_bool_const(node.arguments[1], False)))
+
+    def rewrite(self, node, ctx):
+        if is_bool_const(node.arguments[0], False):
+            return clone(node.arguments[1])
+        return clone(node.arguments[0])
+
+
+class NotTrue:
+    name = "NotTrue"
+
+    def applies(self, node, ctx):
+        return is_not(node) and is_bool_const(node.arguments[0], True)
+
+    def rewrite(self, node, ctx):
+        return make_bool(False)
+
+
+class NotFalse:
+    name = "NotFalse"
+
+    def applies(self, node, ctx):
+        return is_not(node) and is_bool_const(node.arguments[0], False)
+
+    def rewrite(self, node, ctx):
+        return make_bool(True)
+
+
+# ---------------------------------------------------------------------------
+# Negation
+# ---------------------------------------------------------------------------
+class DoubleNeg:
+    name = "DoubleNeg"
+
+    def applies(self, node, ctx):
+        return is_not(node) and is_not(node.arguments[0])
+
+    def rewrite(self, node, ctx):
+        return clone(node.arguments[0].arguments[0])
+
+
+class NegatedComparison:
+    name = "NegatedComparison"
+
+    def applies(self, node, ctx):
+        return is_not(node) and is_comparison(node.arguments[0])
+
+    def rewrite(self, node, ctx):
+        cmp = node.arguments[0]
+        flipped_op = _NEGATED_COMP[cmp.operation]
+        return make_comparison(cmp.arguments[0], flipped_op, cmp.arguments[2])
+
+
+class DeMorganAnd:
+    name = "DeMorganAnd"
+
+    def applies(self, node, ctx):
+        return is_not(node) and is_and(node.arguments[0])
+
+    def rewrite(self, node, ctx):
+        and_node = node.arguments[0]
+        return make_or(make_not(and_node.arguments[0]),
+                       make_not(and_node.arguments[1]))
+
+
+class DeMorganOr:
+    name = "DeMorganOr"
+
+    def applies(self, node, ctx):
+        return is_not(node) and is_or(node.arguments[0])
+
+    def rewrite(self, node, ctx):
+        or_node = node.arguments[0]
+        return make_and(make_not(or_node.arguments[0]),
+                        make_not(or_node.arguments[1]))
+
+
+BOOLEAN_RULES = [
+    # Constants are cheapest and unblock everything else.
+    AndTrue(), AndFalse(), OrTrue(), OrFalse(), NotTrue(), NotFalse(),
+    # Negation pushed inward.
+    DoubleNeg(),
+    NegatedComparison(),
+    DeMorganAnd(), DeMorganOr(),
+]

--- a/besser/BUML/notations/ocl/normalization/rules/cnf.py
+++ b/besser/BUML/notations/ocl/normalization/rules/cnf.py
@@ -1,0 +1,63 @@
+"""Paper §2.3 — sugar elimination toward CNF.
+
+Eliminates ``implies``, ``xor``, and boolean ``if`` expressions in favour of
+``and`` / ``or`` / ``not``. CNF distribution (OR over AND) is intentionally
+omitted — see PRD §7.1; it can blow up AST size exponentially and is rarely
+needed by downstream consumers.
+"""
+
+from besser.BUML.metamodel.ocl import clone, is_implies, is_xor
+from besser.BUML.metamodel.ocl.ocl import IfExp
+from besser.BUML.notations.ocl.normalization.rules._helpers import (
+    make_and, make_not, make_or,
+)
+
+
+class ImpliesElim:
+    name = "ImpliesElim"
+
+    def applies(self, node, ctx):
+        return is_implies(node) and len(node.arguments) == 2
+
+    def rewrite(self, node, ctx):
+        # A implies B  →  (not A) or B
+        left, right = node.arguments
+        return make_or(make_not(left), right)
+
+
+class XorElim:
+    name = "XorElim"
+
+    def applies(self, node, ctx):
+        return is_xor(node) and len(node.arguments) == 2
+
+    def rewrite(self, node, ctx):
+        # A xor B  →  (A and not B) or (not A and B)
+        left, right = node.arguments
+        return make_or(
+            make_and(clone(left), make_not(right)),
+            make_and(make_not(left), clone(right)),
+        )
+
+
+class IfBoolElim:
+    name = "IfBoolElim"
+
+    def applies(self, node, ctx):
+        # Convert any IfExp; even non-boolean branches are folded since the
+        # result is structurally well-defined and downstream consumers need
+        # zero ``IfExp`` nodes in normal form. Branches that aren't boolean
+        # are uncommon in invariants and the resulting expression remains
+        # semantically faithful for any branch type that supports ``and`` /
+        # ``or`` (i.e. all OCL boolean expressions).
+        return isinstance(node, IfExp)
+
+    def rewrite(self, node, ctx):
+        # if C then T else E endif  →  (C and T) or ((not C) and E)
+        return make_or(
+            make_and(node.ifCondition, node.thenExpression),
+            make_and(make_not(node.ifCondition), node.elseCondition),
+        )
+
+
+CNF_RULES = [ImpliesElim(), XorElim(), IfBoolElim()]

--- a/besser/BUML/notations/ocl/normalization/rules/cnf.py
+++ b/besser/BUML/notations/ocl/normalization/rules/cnf.py
@@ -7,10 +7,39 @@ needed by downstream consumers.
 """
 
 from besser.BUML.metamodel.ocl import clone, is_implies, is_xor
-from besser.BUML.metamodel.ocl.ocl import IfExp
+from besser.BUML.metamodel.ocl.ocl import (
+    BooleanLiteralExpression, IfExp, LoopExp, OperationCallExpression,
+)
 from besser.BUML.notations.ocl.normalization.rules._helpers import (
     make_and, make_not, make_or,
 )
+
+
+_BOOLEAN_OPS = {
+    "and", "or", "not", "xor", "implies",
+    "=", "<>", "<", ">", "<=", ">=",
+    "IsEmpty", "OCLISTYPEOF", "OCLISKINDOF",
+}
+_BOOLEAN_LOOPS = {"forAll", "exists"}
+
+
+def _is_boolean_expr(node) -> bool:
+    """True when `node` is statically known to evaluate to a boolean.
+
+    Used by :class:`IfBoolElim` to skip ``IfExp`` whose branches return
+    something other than a boolean — rewriting those would produce
+    ``and``/``or`` over non-boolean operands, which is not OCL-valid.
+    """
+    if isinstance(node, BooleanLiteralExpression):
+        return True
+    if isinstance(node, OperationCallExpression):
+        return node.operation in _BOOLEAN_OPS
+    if isinstance(node, LoopExp):
+        return node.name in _BOOLEAN_LOOPS
+    if isinstance(node, IfExp):
+        return (_is_boolean_expr(node.thenExpression)
+                and _is_boolean_expr(node.elseCondition))
+    return False
 
 
 class ImpliesElim:
@@ -44,13 +73,14 @@ class IfBoolElim:
     name = "IfBoolElim"
 
     def applies(self, node, ctx):
-        # Convert any IfExp; even non-boolean branches are folded since the
-        # result is structurally well-defined and downstream consumers need
-        # zero ``IfExp`` nodes in normal form. Branches that aren't boolean
-        # are uncommon in invariants and the resulting expression remains
-        # semantically faithful for any branch type that supports ``and`` /
-        # ``or`` (i.e. all OCL boolean expressions).
-        return isinstance(node, IfExp)
+        # Only fold IfExp whose branches are themselves boolean — rewriting
+        # ``if C then 5 else 10 endif`` to ``(C and 5) or ((not C) and 10)``
+        # would produce ``and``/``or`` over integers, which isn't OCL-valid.
+        # Non-boolean IfExp are left in place for downstream consumers.
+        if not isinstance(node, IfExp):
+            return False
+        return (_is_boolean_expr(node.thenExpression)
+                and _is_boolean_expr(node.elseCondition))
 
     def rewrite(self, node, ctx):
         # if C then T else E endif  →  (C and T) or ((not C) and E)

--- a/besser/BUML/notations/ocl/normalization/rules/collection.py
+++ b/besser/BUML/notations/ocl/normalization/rules/collection.py
@@ -1,0 +1,46 @@
+"""Paper §2.1 Table 2 — trivial collection sugar.
+
+``X->isEmpty()`` becomes ``X->size() = 0``. ``X->reject(p)`` becomes
+``X->select(not p)``.
+"""
+
+from besser.BUML.metamodel.ocl import clone, is_isempty, is_loop
+from besser.BUML.metamodel.ocl.ocl import LoopExp, OperationCallExpression
+from besser.BUML.notations.ocl.normalization.rules._helpers import (
+    make_comparison, make_int, make_not,
+)
+
+
+class IsEmptyToSize:
+    name = "IsEmptyToSize"
+
+    def applies(self, node, ctx):
+        return is_isempty(node)
+
+    def rewrite(self, node, ctx):
+        # X->isEmpty()  →  X->size() = 0
+        size = OperationCallExpression(
+            name="Size", operation="Size", arguments=[],
+        )
+        size.source = clone(node.source)
+        return make_comparison(size, "=", make_int(0))
+
+
+class RejectToSelect:
+    name = "RejectToSelect"
+
+    def applies(self, node, ctx):
+        return is_loop(node, "reject")
+
+    def rewrite(self, node, ctx):
+        # X->reject(v | p)  →  X->select(v | not p)
+        new_loop = LoopExp("select", None)
+        new_loop.source = clone(node.source)
+        for it in node.iterator:
+            new_loop.addIterator(clone(it))
+        if node.body:
+            new_loop.add_body(make_not(node.body[0]))
+        return new_loop
+
+
+COLLECTION_RULES = [IsEmptyToSize(), RejectToSelect()]

--- a/besser/BUML/notations/ocl/normalization/rules/iterator.py
+++ b/besser/BUML/notations/ocl/normalization/rules/iterator.py
@@ -1,0 +1,130 @@
+"""Paper §2.1 Table 3 — iterator simplifications.
+
+- ``exists`` rewritten to ``not(forAll(not …))``.
+- ``size(select(X, p)) = 0`` rewritten to ``X->forAll(v | not p)``.
+- ``size(select(X, p)) > 0`` rewritten to ``X->exists(v | p)`` (which then
+  reduces via :class:`ExistsToForAll`).
+- ``select(X, p)->forAll(v | Y)`` fused to ``X->forAll(v | p implies Y)``.
+"""
+
+from besser.BUML.metamodel.ocl import (
+    clone, is_loop, is_loop_with_n_iterators, is_size, is_comparison,
+    substitute,
+)
+from besser.BUML.metamodel.ocl.ocl import LoopExp
+from besser.BUML.notations.ocl.normalization.rules._helpers import (
+    is_zero_literal, make_not,
+)
+
+
+class ExistsToForAll:
+    name = "ExistsToForAll"
+
+    def applies(self, node, ctx):
+        return is_loop(node, "exists") and is_loop_with_n_iterators(node, 1)
+
+    def rewrite(self, node, ctx):
+        # X->exists(v | Y)  →  not (X->forAll(v | not Y))
+        new_loop = LoopExp("forAll", None)
+        new_loop.source = clone(node.source)
+        for it in node.iterator:
+            new_loop.addIterator(clone(it))
+        if node.body:
+            new_loop.add_body(make_not(node.body[0]))
+        return make_not(new_loop)
+
+
+def _is_size_of_select(node):
+    return (is_size(node) and is_loop(node.source, "select")
+            and is_loop_with_n_iterators(node.source, 1))
+
+
+class SelectSizeZero:
+    """``X->select(v | p)->size() = 0``  →  ``X->forAll(v | not p)``."""
+    name = "SelectSizeZero"
+
+    def applies(self, node, ctx):
+        if not is_comparison(node) or node.operation != "=":
+            return False
+        return ((_is_size_of_select(node.arguments[0])
+                 and is_zero_literal(node.arguments[2]))
+                or (_is_size_of_select(node.arguments[2])
+                    and is_zero_literal(node.arguments[0])))
+
+    def rewrite(self, node, ctx):
+        size = (node.arguments[0]
+                if _is_size_of_select(node.arguments[0])
+                else node.arguments[2])
+        select_loop = size.source
+        new_loop = LoopExp("forAll", None)
+        new_loop.source = clone(select_loop.source)
+        for it in select_loop.iterator:
+            new_loop.addIterator(clone(it))
+        new_loop.add_body(make_not(select_loop.body[0]))
+        return new_loop
+
+
+class SelectSizeGtZero:
+    """``X->select(v | p)->size() > 0``  →  ``X->exists(v | p)`` (then ExistsToForAll)."""
+    name = "SelectSizeGtZero"
+
+    def applies(self, node, ctx):
+        if not is_comparison(node) or node.operation != ">":
+            return False
+        return (_is_size_of_select(node.arguments[0])
+                and is_zero_literal(node.arguments[2]))
+
+    def rewrite(self, node, ctx):
+        size = node.arguments[0]
+        select_loop = size.source
+        new_loop = LoopExp("exists", None)
+        new_loop.source = clone(select_loop.source)
+        for it in select_loop.iterator:
+            new_loop.addIterator(clone(it))
+        new_loop.add_body(clone(select_loop.body[0]))
+        return new_loop
+
+
+class SelectForAllFusion:
+    """``select(X, v1 | p)->forAll(v2 | Y)``  →  ``X->forAll(v2 | p[v2/v1] implies Y)``."""
+    name = "SelectForAllFusion"
+
+    def applies(self, node, ctx):
+        return (is_loop(node, "forAll")
+                and is_loop_with_n_iterators(node, 1)
+                and is_loop(node.source, "select")
+                and is_loop_with_n_iterators(node.source, 1)
+                and node.body)
+
+    def rewrite(self, node, ctx):
+        from besser.BUML.metamodel.ocl.ocl import OperationCallExpression, VariableExp
+        select_loop = node.source
+        select_var = select_loop.iterator[0].name
+        forall_var = node.iterator[0].name
+        # Rename select's variable to forAll's variable in the predicate.
+        renamed_pred = substitute(
+            select_loop.body[0], select_var, VariableExp(forall_var, None),
+        )
+        forall_body = clone(node.body[0])
+
+        # implies node — eliminated by the next pass.
+        implies = OperationCallExpression(
+            name="IMPLIES_BINARY", operation="implies",
+            arguments=[renamed_pred, forall_body],
+        )
+
+        new_loop = LoopExp("forAll", None)
+        new_loop.source = clone(select_loop.source)
+        for it in node.iterator:
+            new_loop.addIterator(clone(it))
+        new_loop.add_body(implies)
+        return new_loop
+
+
+ITERATOR_RULES = [
+    # The size-of-select fast paths must fire before ExistsToForAll so they
+    # produce a tighter rewrite when their pattern matches the comparison.
+    SelectSizeZero(), SelectSizeGtZero(),
+    SelectForAllFusion(),
+    ExistsToForAll(),
+]

--- a/besser/BUML/notations/ocl/normalization/rules/multiplicity.py
+++ b/besser/BUML/notations/ocl/normalization/rules/multiplicity.py
@@ -1,0 +1,86 @@
+"""Paper §3.1.3 rules 1–2 — multiplicity-aware static collapses.
+
+When every step of a navigation chain rooted at ``self`` has a minimum
+multiplicity ``≥ 1``, the chain is statically guaranteed non-empty and
+``->size() > 0`` (or ``->size() = 0``) reduces to ``true`` (or ``false``).
+When every step has a maximum multiplicity ``≤ 1``, the chain has at most
+one element and ``->forAll(v | X)`` reduces to ``X[chain/v]``.
+"""
+
+from besser.BUML.metamodel.ocl import (
+    clone, is_chain_from_self, chain_min_multiplicity,
+    chain_max_multiplicity, is_size, is_comparison,
+    is_loop, is_loop_with_n_iterators, substitute,
+)
+from besser.BUML.notations.ocl.normalization.rules._helpers import (
+    is_zero_literal, make_bool,
+)
+
+
+def _size_of_chain(node):
+    return (is_size(node) and is_chain_from_self(node.source))
+
+
+class NotEmptyChainTrue:
+    """``size(chain) > 0`` collapses to ``true`` when every step has min ≥ 1."""
+    name = "NotEmptyChainTrue"
+
+    def applies(self, node, ctx):
+        if not is_comparison(node) or node.operation != ">":
+            return False
+        if not _size_of_chain(node.arguments[0]):
+            return False
+        if not is_zero_literal(node.arguments[2]):
+            return False
+        chain_min = chain_min_multiplicity(node.arguments[0].source)
+        return chain_min is not None and chain_min >= 1
+
+    def rewrite(self, node, ctx):
+        return make_bool(True)
+
+
+class IsEmptyChainFalse:
+    """``size(chain) = 0`` collapses to ``false`` when every step has min ≥ 1."""
+    name = "IsEmptyChainFalse"
+
+    def applies(self, node, ctx):
+        if not is_comparison(node) or node.operation != "=":
+            return False
+        # Match either side ordering.
+        if _size_of_chain(node.arguments[0]) and is_zero_literal(node.arguments[2]):
+            chain_src = node.arguments[0].source
+        elif _size_of_chain(node.arguments[2]) and is_zero_literal(node.arguments[0]):
+            chain_src = node.arguments[2].source
+        else:
+            return False
+        chain_min = chain_min_multiplicity(chain_src)
+        return chain_min is not None and chain_min >= 1
+
+    def rewrite(self, node, ctx):
+        return make_bool(False)
+
+
+class ForAllChainSingle:
+    """``chain->forAll(v | X)`` collapses to ``X[chain/v]`` when every step has max ≤ 1."""
+    name = "ForAllChainSingle"
+
+    def applies(self, node, ctx):
+        if not is_loop(node, "forAll") or not is_loop_with_n_iterators(node, 1):
+            return False
+        if not is_chain_from_self(node.source):
+            return False
+        chain_max = chain_max_multiplicity(node.source)
+        return chain_max is not None and chain_max <= 1
+
+    def rewrite(self, node, ctx):
+        var_name = node.iterator[0].name
+        chain = clone(node.source)
+        body = clone(node.body[0])
+        return substitute(body, var_name, chain)
+
+
+MULTIPLICITY_RULES = [
+    NotEmptyChainTrue(),
+    IsEmptyChainFalse(),
+    ForAllChainSingle(),
+]

--- a/besser/BUML/notations/ocl/pretty_printer.py
+++ b/besser/BUML/notations/ocl/pretty_printer.py
@@ -117,8 +117,8 @@ def _render_operation(node: OperationCallExpression, parent_prec: int) -> str:
         return _paren(f"not {operand}", _PREC_UNARY, parent_prec)
 
     if op == "ALLInstances":
-        # source is a TypeExp; ALLInstances is a type-method call.
-        return f"{_render(node.source, _PREC_POSTFIX)}.allInstances()"
+        # OCL spec uses ``::`` for class-scoped operations.
+        return f"{_render(node.source, _PREC_POSTFIX)}::allInstances()"
 
     if op == "Size":
         return f"{_render(node.source, _PREC_POSTFIX)}->size()"

--- a/besser/BUML/notations/ocl/pretty_printer.py
+++ b/besser/BUML/notations/ocl/pretty_printer.py
@@ -1,0 +1,171 @@
+"""Pretty-print B-OCL ASTs back to OCL source text.
+
+Renders an OCL expression — or a full :class:`OCLConstraint` — to a
+canonical string using the precedence hierarchy locked in by the post-grammar-
+fix B-OCL grammar:
+
+    Postfix > Unary > Mul > Add > Comp > AND > XOR > OR > IMPLIES
+
+Parentheses are added only where strictly required by the precedence relation
+between a node and its parent.
+"""
+
+from besser.BUML.metamodel.ocl.ocl import (
+    OCLConstraint, OperationCallExpression, LoopExp, IfExp,
+    PropertyCallExpression, VariableExp, TypeExp,
+    IntegerLiteralExpression, RealLiteralExpression,
+    BooleanLiteralExpression, StringLiteralExpression, DateLiteralExpression,
+    InfixOperator,
+)
+
+
+# Precedence — higher binds tighter.
+_PREC_TOP = 0
+_PREC_IMPLIES = 10
+_PREC_OR = 20
+_PREC_XOR = 30
+_PREC_AND = 40
+_PREC_COMP = 50
+_PREC_ADD = 60
+_PREC_MUL = 70
+_PREC_UNARY = 80
+_PREC_POSTFIX = 90
+
+_OP_PREC = {
+    "implies": _PREC_IMPLIES,
+    "or": _PREC_OR,
+    "xor": _PREC_XOR,
+    "and": _PREC_AND,
+    "<": _PREC_COMP, ">": _PREC_COMP, "<=": _PREC_COMP, ">=": _PREC_COMP,
+    "=": _PREC_COMP, "<>": _PREC_COMP,
+    "+": _PREC_ADD, "-": _PREC_ADD,
+    "*": _PREC_MUL, "/": _PREC_MUL,
+}
+
+_TYPE_TEST_NAMES = {
+    "OCLISTYPEOF": "oclIsTypeOf",
+    "OCLISKINDOF": "oclIsKindOf",
+    "OCLASTYPE": "oclAsType",
+}
+
+
+def pretty_print(node) -> str:
+    """Render an OCL AST or :class:`OCLConstraint` to OCL source text.
+
+    For an :class:`OCLConstraint`, emits ``context <ClassName> inv: <expr>``.
+    For a raw expression, emits the expression alone.
+    """
+    if isinstance(node, OCLConstraint):
+        return f"context {node.context.name} inv: {_render(node.expression, _PREC_TOP)}"
+    return _render(node, _PREC_TOP)
+
+
+def _paren(text: str, child_prec: int, parent_prec: int) -> str:
+    return f"({text})" if child_prec < parent_prec else text
+
+
+def _render(node, parent_prec: int) -> str:
+    if node is None:
+        return ""
+    if isinstance(node, OperationCallExpression):
+        return _render_operation(node, parent_prec)
+    if isinstance(node, LoopExp):
+        return _render_loop(node)
+    if isinstance(node, IfExp):
+        return _render_if(node)
+    if isinstance(node, PropertyCallExpression):
+        return _render_property_call(node)
+    if isinstance(node, VariableExp):
+        return node.name
+    if isinstance(node, TypeExp):
+        return node.name
+    if isinstance(node, BooleanLiteralExpression):
+        return _render_boolean(node.value)
+    if isinstance(node, IntegerLiteralExpression):
+        return str(node.value)
+    if isinstance(node, RealLiteralExpression):
+        return str(node.value)
+    if isinstance(node, StringLiteralExpression):
+        return f"'{node.value}'"
+    if isinstance(node, DateLiteralExpression):
+        return str(node.value)
+    # Fallback for bare structural-model objects (Property leaked from an
+    # un-wrapped visitor) and anything else with a ``name``.
+    if hasattr(node, "name"):
+        return str(node.name)
+    return repr(node)
+
+
+def _render_boolean(value) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value).strip().lower()
+
+
+def _render_property_call(node: PropertyCallExpression) -> str:
+    if node.source is None:
+        return node.property.name
+    return f"{_render(node.source, _PREC_POSTFIX)}.{node.property.name}"
+
+
+def _render_operation(node: OperationCallExpression, parent_prec: int) -> str:
+    op = node.operation
+    args = node.arguments
+
+    if op == "not":
+        operand = _render(args[0], _PREC_UNARY)
+        return _paren(f"not {operand}", _PREC_UNARY, parent_prec)
+
+    if op == "ALLInstances":
+        # source is a TypeExp; ALLInstances is a type-method call.
+        return f"{_render(node.source, _PREC_POSTFIX)}.allInstances()"
+
+    if op == "Size":
+        return f"{_render(node.source, _PREC_POSTFIX)}->size()"
+
+    if op == "IsEmpty":
+        return f"{_render(node.source, _PREC_POSTFIX)}->isEmpty()"
+
+    if op in _TYPE_TEST_NAMES:
+        method = _TYPE_TEST_NAMES[op]
+        type_arg = args[0]
+        return (f"{_render(node.source, _PREC_POSTFIX)}."
+                f"{method}({_render(type_arg, _PREC_TOP)})")
+
+    # Comparison or arithmetic (3-argument shape with InfixOperator marker).
+    if len(args) == 3 and isinstance(args[1], InfixOperator):
+        prec = _OP_PREC.get(op, _PREC_COMP)
+        left = _render(args[0], prec)
+        right = _render(args[2], prec + 1)
+        return _paren(f"{left} {op} {right}", prec, parent_prec)
+
+    # Boolean binary (2-argument shape).
+    if op in ("and", "or", "xor", "implies") and len(args) == 2:
+        prec = _OP_PREC[op]
+        left = _render(args[0], prec)
+        right = _render(args[1], prec + 1)
+        return _paren(f"{left} {op} {right}", prec, parent_prec)
+
+    # Generic method-call fallback (e.g. user-defined methods).
+    rendered_args = ", ".join(
+        _render(a, _PREC_TOP) for a in args if not isinstance(a, InfixOperator)
+    )
+    if node.source is not None:
+        return f"{_render(node.source, _PREC_POSTFIX)}.{op}({rendered_args})"
+    return f"{op}({rendered_args})"
+
+
+def _render_loop(node: LoopExp) -> str:
+    src = _render(node.source, _PREC_POSTFIX) if node.source is not None else ""
+    iters = ", ".join(it.name for it in node.iterator)
+    body = _render(node.body[0], _PREC_TOP) if node.body else ""
+    if iters:
+        return f"{src}->{node.name}({iters} | {body})"
+    return f"{src}->{node.name}({body})"
+
+
+def _render_if(node: IfExp) -> str:
+    cond = _render(node.ifCondition, _PREC_TOP)
+    then_e = _render(node.thenExpression, _PREC_TOP)
+    else_e = _render(node.elseCondition, _PREC_TOP)
+    return f"if {cond} then {then_e} else {else_e} endif"

--- a/besser/BUML/notations/ocl/wrapping_visitor.py
+++ b/besser/BUML/notations/ocl/wrapping_visitor.py
@@ -1,0 +1,150 @@
+"""Bug-fixing subclass of the generated B-OCL visitor.
+
+The default ``BOCLVisitorImpl`` (in ``visitor.py``) has several issues that
+break any consumer that needs the AST in its proper shape:
+
+1. **Chain flattening in ``visitDotNavigation``**: the receiver expression
+   visit result is discarded, so ``self.r1.r2`` parses to a bare leaf
+   ``Property`` with no chain in the AST.
+2. **Same flattening in ``visitDotSizeNavigation``**: the special-case
+   ``size`` attribute access has the same bug.
+3. **Wrong lookup context for chained navigation**: every step of a property
+   chain is resolved against ``self.context_class`` rather than against the
+   receiver's actual type, so ``self.employer.minSalary`` would look up
+   ``minSalary`` on ``Employee`` (the constraint context) instead of on
+   ``Department`` (the type of ``self.employer``).
+4. **Wrong iterator-variable typing in ``visitArrowIterator``**: when no
+   explicit type annotation is supplied (``forAll(e | …)``), the base visitor
+   sets ``iterators_context[e]`` to the constraint's context class, regardless
+   of what collection is being iterated. The element type of the source
+   collection is what's needed.
+5. **Boolean-lexeme-as-string in ``visitBooleanLiteral``**: the literal value
+   is stored as the lexeme ``"true"`` / ``"false"`` (a Python ``str``)
+   instead of a Python ``bool``.
+
+This subclass overrides the affected methods to fix all of the above. Until
+the fixes are upstreamed into ``BOCLVisitorImpl`` itself, all consumers
+should parse via ``WrappingVisitor`` (or via :func:`parse_ocl`, which uses it).
+"""
+
+from besser.BUML.metamodel.ocl.ocl import (
+    BooleanLiteralExpression, IteratorExp, LoopExp, OperationCallExpression,
+    PropertyCallExpression, TypeExp, VariableExp,
+)
+from besser.BUML.notations.ocl.BOCLParser import BOCLParser
+from besser.BUML.notations.ocl.visitor import BOCLVisitorImpl
+
+
+class WrappingVisitor(BOCLVisitorImpl):
+    """``BOCLVisitorImpl`` subclass that produces a chain-preserving AST."""
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _receiver_type(self, receiver):
+        """Return the static type of `receiver`, or None if it cannot be inferred."""
+        if isinstance(receiver, VariableExp):
+            if receiver.name == "self":
+                return self.context_class
+            return self.iterators_context.get(receiver.name)
+        if isinstance(receiver, PropertyCallExpression):
+            return receiver.property.type
+        return None
+
+    def _infer_collection_element_type(self, source):
+        """Best-effort element type for `source` when treated as a collection.
+
+        ``self.employee`` (an association end) → ``Employee``.
+        ``Employee.allInstances()`` → ``Employee``.
+        ``X->select(...)`` / ``X->reject(...)`` / ``X->collect(...)`` →
+        same as the select/reject/collect's source.
+        """
+        if isinstance(source, PropertyCallExpression):
+            return source.property.type
+        if isinstance(source, OperationCallExpression):
+            if source.operation == "ALLInstances":
+                type_exp = source.source
+                if isinstance(type_exp, TypeExp):
+                    return self._get_class_by_name(type_exp.name)
+            return None
+        if isinstance(source, LoopExp):
+            # select / reject / collect preserve element type.
+            return self._infer_collection_element_type(source.source)
+        return None
+
+    def _wrap_navigation(self, receiver, name, ctx):
+        """Resolve `name` against the receiver's type, falling back to the
+        constraint's scopes, then return a ``PropertyCallExpression``."""
+        prop = None
+        target_type = self._receiver_type(receiver)
+        if target_type is not None:
+            prop = self._resolve_property(name, target_type)
+        if prop is None:
+            prop = self._resolve_property(name)
+        if prop is None:
+            prop = self._resolve_property_in_iterators(name)
+        if prop is None:
+            ctx_name = self.context_class.name if self.context_class else "?"
+            raise Exception(
+                f"Property '{name}' not found in context '{ctx_name}'"
+            )
+        pce = PropertyCallExpression(prop.name, prop)
+        pce.source = receiver
+        return pce
+
+    # ------------------------------------------------------------------
+    # Overrides
+    # ------------------------------------------------------------------
+    def visitDotNavigation(self, ctx):
+        receiver = self.visit(ctx.expression())
+        return self._wrap_navigation(receiver, ctx.ID().getText(), ctx)
+
+    def visitDotSizeNavigation(self, ctx):
+        receiver = self.visit(ctx.expression())
+        return self._wrap_navigation(receiver, "size", ctx)
+
+    def visitBooleanLiteral(self, ctx):
+        text = ctx.BOOLEAN_LITERAL().getText()
+        return BooleanLiteralExpression("NP", text == "true")
+
+    def visitArrowIterator(self, ctx: BOCLParser.ArrowIteratorContext):
+        source = self.visit(ctx.expression(0))
+        op_name = ctx.iteratorOp().getText()
+        loop = LoopExp(op_name, None)
+        loop.source = source
+
+        var_decl = ctx.iteratorVarDecl()
+        ids = var_decl.ID()
+        registered = []  # iterator names we added to the scope, to clean up
+        i = 0
+        while i < len(ids):
+            var_name = ids[i].getText()
+            iter_type = None
+
+            # Explicit ``e: T`` annotation — second ID is the type name.
+            if i + 1 < len(ids):
+                type_name = ids[i + 1].getText()
+                explicit = self._get_class_by_name(type_name)
+                if explicit is not None:
+                    iter_type = explicit
+                    self.iterators_context[var_name] = explicit
+                    loop.addIterator(IteratorExp(var_name, explicit))
+                    registered.append(var_name)
+                    i += 2
+                    continue
+
+            # No annotation — infer from the iterated source.
+            inferred = self._infer_collection_element_type(source)
+            iter_type = inferred if inferred is not None else self.context_class
+            stored_type = inferred if inferred is not None else "NotMentioned"
+            self.iterators_context[var_name] = iter_type
+            loop.addIterator(IteratorExp(var_name, stored_type))
+            registered.append(var_name)
+            i += 1
+
+        body = self.visit(ctx.expression(1))
+        loop.add_body(body)
+
+        for var_name in registered:
+            self.iterators_context.pop(var_name, None)
+        return loop

--- a/besser/BUML/notations/ocl/wrapping_visitor.py
+++ b/besser/BUML/notations/ocl/wrapping_visitor.py
@@ -32,6 +32,7 @@ from besser.BUML.metamodel.ocl.ocl import (
     PropertyCallExpression, TypeExp, VariableExp,
 )
 from besser.BUML.notations.ocl.BOCLParser import BOCLParser
+from besser.BUML.notations.ocl.error_handling import BOCLSyntaxError
 from besser.BUML.notations.ocl.visitor import BOCLVisitorImpl
 
 
@@ -85,9 +86,9 @@ class WrappingVisitor(BOCLVisitorImpl):
             prop = self._resolve_property_in_iterators(name)
         if prop is None:
             ctx_name = self.context_class.name if self.context_class else "?"
-            raise Exception(
+            raise BOCLSyntaxError([
                 f"Property '{name}' not found in context '{ctx_name}'"
-            )
+            ])
         pce = PropertyCallExpression(prop.name, prop)
         pce.source = receiver
         return pce

--- a/tests/BUML/metamodel/ocl/test_chain.py
+++ b/tests/BUML/metamodel/ocl/test_chain.py
@@ -1,0 +1,113 @@
+"""Tests for besser.BUML.metamodel.ocl.chain."""
+
+from besser.BUML.metamodel.ocl import (
+    is_chain_from_self, walk_chain_from_self,
+    chain_min_multiplicity, chain_max_multiplicity,
+)
+from besser.BUML.metamodel.ocl.ocl import (
+    PropertyCallExpression, VariableExp, IntegerLiteralExpression,
+)
+from besser.BUML.metamodel.structural import (
+    Property, IntegerType, Multiplicity,
+)
+
+
+def _chain(*props_with_source):
+    """Build self.r1.r2.... from a sequence of (name, mult) tuples."""
+    cur = VariableExp("self", None)
+    for name, mult in props_with_source:
+        prop = Property(name, IntegerType, multiplicity=mult)
+        pce = PropertyCallExpression(name, prop)
+        pce.source = cur
+        cur = pce
+    return cur
+
+
+def test_is_chain_from_self_recognises_simple_chain():
+    chain = _chain(("r1", Multiplicity(1, 1)))
+    assert is_chain_from_self(chain)
+
+
+def test_is_chain_from_self_recognises_long_chain():
+    chain = _chain(
+        ("r1", Multiplicity(1, 1)),
+        ("r2", Multiplicity(0, "*")),
+        ("r3", Multiplicity(1, 1)),
+    )
+    assert is_chain_from_self(chain)
+
+
+def test_is_chain_from_self_rejects_bare_property():
+    # A bare Property leaked from an unwrapped visitor — not recognised as a chain.
+    bare = Property("r1", IntegerType, multiplicity=Multiplicity(1, 1))
+    assert not is_chain_from_self(bare)
+
+
+def test_is_chain_from_self_rejects_non_self_root():
+    # `e.r1` where `e` is an iterator variable is a chain but not from self.
+    cur = VariableExp("e", None)
+    prop = Property("r1", IntegerType, multiplicity=Multiplicity(1, 1))
+    pce = PropertyCallExpression("r1", prop)
+    pce.source = cur
+    assert not is_chain_from_self(pce)
+
+
+def test_is_chain_from_self_rejects_non_chain():
+    assert not is_chain_from_self(IntegerLiteralExpression("NP", 1))
+    assert not is_chain_from_self(VariableExp("self", None))
+
+
+def test_walk_chain_returns_property_list_in_order():
+    chain = _chain(
+        ("r1", Multiplicity(1, 1)),
+        ("r2", Multiplicity(0, 5)),
+        ("r3", Multiplicity(2, 2)),
+    )
+    props = walk_chain_from_self(chain)
+    assert [p.name for p in props] == ["r1", "r2", "r3"]
+
+
+def test_walk_chain_returns_none_for_non_chain():
+    assert walk_chain_from_self(IntegerLiteralExpression("NP", 1)) is None
+
+
+def test_chain_min_multiplicity_min_across_steps():
+    # mins: 1, 0, 1 → min = 0
+    chain = _chain(
+        ("r1", Multiplicity(1, 1)),
+        ("r2", Multiplicity(0, 5)),
+        ("r3", Multiplicity(1, 1)),
+    )
+    assert chain_min_multiplicity(chain) == 0
+
+
+def test_chain_min_multiplicity_all_at_least_one_signals_non_empty():
+    chain = _chain(
+        ("r1", Multiplicity(1, 1)),
+        ("r2", Multiplicity(2, 5)),
+        ("r3", Multiplicity(1, 1)),
+    )
+    assert chain_min_multiplicity(chain) == 1
+
+
+def test_chain_max_multiplicity_max_across_steps():
+    # maxes: 1, 5, 1 → max = 5
+    chain = _chain(
+        ("r1", Multiplicity(1, 1)),
+        ("r2", Multiplicity(0, 5)),
+        ("r3", Multiplicity(1, 1)),
+    )
+    assert chain_max_multiplicity(chain) == 5
+
+
+def test_chain_max_multiplicity_all_at_most_one_signals_singleton():
+    chain = _chain(
+        ("r1", Multiplicity(1, 1)),
+        ("r2", Multiplicity(0, 1)),
+    )
+    assert chain_max_multiplicity(chain) == 1
+
+
+def test_chain_multiplicity_returns_none_for_non_chain():
+    assert chain_min_multiplicity(IntegerLiteralExpression("NP", 1)) is None
+    assert chain_max_multiplicity(IntegerLiteralExpression("NP", 1)) is None

--- a/tests/BUML/metamodel/ocl/test_clone.py
+++ b/tests/BUML/metamodel/ocl/test_clone.py
@@ -1,0 +1,129 @@
+"""Tests for besser.BUML.metamodel.ocl.clone."""
+
+from besser.BUML.metamodel.ocl import clone
+from besser.BUML.metamodel.ocl.ocl import (
+    OperationCallExpression, LoopExp, IteratorExp, IfExp,
+    PropertyCallExpression, VariableExp, TypeExp,
+    IntegerLiteralExpression, RealLiteralExpression,
+    BooleanLiteralExpression, StringLiteralExpression,
+    InfixOperator,
+)
+from besser.BUML.metamodel.structural import Property, IntegerType
+
+
+def test_clone_none_returns_none():
+    assert clone(None) is None
+
+
+def test_clone_integer_literal_is_fresh():
+    n = IntegerLiteralExpression("NP", 42)
+    c = clone(n)
+    assert c is not n
+    assert c.value == 42
+
+
+def test_clone_real_string_boolean_literals_round_trip():
+    for n in [
+        RealLiteralExpression("NP", 1.5),
+        StringLiteralExpression("str", "hello"),
+        BooleanLiteralExpression("NP", True),
+        BooleanLiteralExpression("NP", "true"),  # tolerate legacy lexeme
+    ]:
+        c = clone(n)
+        assert c is not n
+        assert c.value == n.value
+
+
+def test_clone_variable_exp():
+    v = VariableExp("e", None)
+    c = clone(v)
+    assert c is not v
+    assert c.name == "e"
+
+
+def test_clone_type_exp():
+    t = TypeExp("Employee", "Employee")
+    c = clone(t)
+    assert c is not t
+    assert c.name == "Employee"
+
+
+def test_clone_property_call_shares_property_reference():
+    p = Property("age", IntegerType)
+    pce = PropertyCallExpression("age", p)
+    pce.source = VariableExp("self", None)
+    c = clone(pce)
+    assert c is not pce
+    assert c.property is p  # Property is shared, not duplicated
+    assert c.source is not pce.source
+    assert c.source.name == "self"
+
+
+def test_clone_operation_preserves_infix_operator_identity():
+    infix = InfixOperator(">")
+    op = OperationCallExpression(
+        name="Operation", operation=">",
+        arguments=[
+            IntegerLiteralExpression("NP", 1),
+            infix,
+            IntegerLiteralExpression("NP", 2),
+        ],
+    )
+    c = clone(op)
+    assert c is not op
+    assert c.arguments[0] is not op.arguments[0]
+    assert c.arguments[1] is infix  # InfixOperator shared (treated as immutable)
+    assert c.arguments[2] is not op.arguments[2]
+    assert c.operation == ">"
+
+
+def test_clone_boolean_binary_two_arg_shape():
+    left = IntegerLiteralExpression("NP", 1)
+    right = IntegerLiteralExpression("NP", 2)
+    op = OperationCallExpression(name="AND_BINARY", operation="and", arguments=[left, right])
+    c = clone(op)
+    assert c is not op
+    assert c.operation == "and"
+    assert len(c.arguments) == 2
+    assert c.arguments[0] is not left
+
+
+def test_clone_loop_deep_copies_body_and_iterators():
+    src = VariableExp("self", None)
+    body = IntegerLiteralExpression("NP", 1)
+    loop = LoopExp("forAll", None)
+    loop.source = src
+    loop.addIterator(IteratorExp("e", "NotMentioned"))
+    loop.add_body(body)
+    c = clone(loop)
+    assert c is not loop
+    assert c.source is not loop.source
+    assert c.iterator[0] is not loop.iterator[0]
+    assert c.iterator[0].name == "e"
+    assert c.body[0] is not body
+
+
+def test_clone_if_expression():
+    cond = BooleanLiteralExpression("NP", True)
+    if_node = IfExp("if", "IfExpression")
+    if_node.ifCondition = cond
+    if_node.thenExpression = IntegerLiteralExpression("NP", 1)
+    if_node.elseCondition = IntegerLiteralExpression("NP", 2)
+    c = clone(if_node)
+    assert c is not if_node
+    assert c.ifCondition is not cond
+    assert c.thenExpression.value == 1
+    assert c.elseCondition.value == 2
+
+
+def test_clone_does_not_mutate_input():
+    inner = IntegerLiteralExpression("NP", 5)
+    outer = OperationCallExpression(
+        name="Operation", operation=">",
+        arguments=[inner, InfixOperator(">"), IntegerLiteralExpression("NP", 3)],
+    )
+    c = clone(outer)
+    # mutate clone
+    c.arguments[0].value = 999
+    # original untouched
+    assert inner.value == 5

--- a/tests/BUML/metamodel/ocl/test_predicates.py
+++ b/tests/BUML/metamodel/ocl/test_predicates.py
@@ -1,0 +1,106 @@
+"""Tests for besser.BUML.metamodel.ocl.predicates."""
+
+from besser.BUML.metamodel.ocl import (
+    is_op, is_and, is_or, is_xor, is_implies, is_not,
+    is_size, is_isempty, is_allinstances,
+    is_comparison, is_atomic_type_test,
+    is_loop, is_loop_with_n_iterators,
+    is_self, is_bool_const,
+)
+from besser.BUML.metamodel.ocl.ocl import (
+    OperationCallExpression, LoopExp, IteratorExp,
+    BooleanLiteralExpression, VariableExp, TypeExp,
+    IntegerLiteralExpression, InfixOperator,
+)
+
+
+def _bin(op_name, op, args):
+    return OperationCallExpression(name=op_name, operation=op, arguments=args)
+
+
+def test_is_op_basic():
+    assert is_op(_bin("AND_BINARY", "and", []), "and")
+    assert not is_op(_bin("AND_BINARY", "and", []), "or")
+    assert not is_op(IntegerLiteralExpression("NP", 1), "and")
+
+
+def test_boolean_op_predicates():
+    assert is_and(_bin("AND_BINARY", "and", []))
+    assert is_or(_bin("OR_BINARY", "or", []))
+    assert is_xor(_bin("XOR_BINARY", "xor", []))
+    assert is_implies(_bin("IMPLIES_BINARY", "implies", []))
+    assert is_not(_bin("unary_not", "not", []))
+    assert not is_and(_bin("OR_BINARY", "or", []))
+
+
+def test_collection_op_predicates():
+    assert is_size(OperationCallExpression(name="Size", operation="Size", arguments=[]))
+    assert is_isempty(OperationCallExpression(name="IsEmpty", operation="IsEmpty", arguments=[]))
+    assert is_allinstances(
+        OperationCallExpression(name="ALLInstances", operation="ALLInstances", arguments=[])
+    )
+
+
+def test_is_comparison_requires_three_arg_shape():
+    three = OperationCallExpression(
+        name="Operation", operation="<",
+        arguments=[
+            IntegerLiteralExpression("NP", 1), InfixOperator("<"),
+            IntegerLiteralExpression("NP", 2),
+        ],
+    )
+    assert is_comparison(three)
+    # Two-arg shape with same operation string is not a comparison.
+    two = OperationCallExpression(name="Op", operation="<",
+                                  arguments=[IntegerLiteralExpression("NP", 1),
+                                             IntegerLiteralExpression("NP", 2)])
+    assert not is_comparison(two)
+
+
+def test_is_atomic_type_test():
+    for op in ("OCLISTYPEOF", "OCLISKINDOF", "OCLASTYPE"):
+        node = OperationCallExpression(name=op, operation=op,
+                                       arguments=[TypeExp("T", "T")])
+        assert is_atomic_type_test(node)
+    assert not is_atomic_type_test(_bin("AND_BINARY", "and", []))
+
+
+def test_is_loop():
+    loop = LoopExp("forAll", None)
+    assert is_loop(loop)
+    assert is_loop(loop, "forAll")
+    assert not is_loop(loop, "exists")
+    assert not is_loop(IntegerLiteralExpression("NP", 1))
+
+
+def test_is_loop_with_n_iterators():
+    loop = LoopExp("forAll", None)
+    assert is_loop_with_n_iterators(loop, 0)
+    loop.addIterator(IteratorExp("a", "NotMentioned"))
+    assert is_loop_with_n_iterators(loop, 1)
+    loop.addIterator(IteratorExp("b", "NotMentioned"))
+    assert is_loop_with_n_iterators(loop, 2)
+    assert not is_loop_with_n_iterators(loop, 1)
+
+
+def test_is_self():
+    assert is_self(VariableExp("self", None))
+    assert not is_self(VariableExp("e", None))
+    assert not is_self(IntegerLiteralExpression("NP", 1))
+
+
+def test_is_bool_const_with_python_bool():
+    n_true = BooleanLiteralExpression("NP", True)
+    n_false = BooleanLiteralExpression("NP", False)
+    assert is_bool_const(n_true)
+    assert is_bool_const(n_true, True)
+    assert not is_bool_const(n_true, False)
+    assert is_bool_const(n_false, False)
+
+
+def test_is_bool_const_tolerates_lexeme_string():
+    n_true = BooleanLiteralExpression("NP", "true")
+    n_false = BooleanLiteralExpression("NP", "false")
+    assert is_bool_const(n_true, True)
+    assert is_bool_const(n_false, False)
+    assert not is_bool_const(n_true, False)

--- a/tests/BUML/metamodel/ocl/test_substitute.py
+++ b/tests/BUML/metamodel/ocl/test_substitute.py
@@ -1,0 +1,209 @@
+"""Tests for besser.BUML.metamodel.ocl.substitute."""
+
+from besser.BUML.metamodel.ocl import substitute, ScopeStack
+from besser.BUML.metamodel.ocl.ocl import (
+    BooleanLiteralExpression, IfExp, InfixOperator, IntegerLiteralExpression,
+    IteratorExp, LoopExp, OperationCallExpression, PropertyCallExpression,
+    VariableExp,
+)
+from besser.BUML.metamodel.structural import IntegerType, Property
+
+
+def _int(v):
+    return IntegerLiteralExpression("NP", v)
+
+
+def _comp(left, op, right):
+    return OperationCallExpression(
+        name="Operation", operation=op,
+        arguments=[left, InfixOperator(op), right],
+    )
+
+
+def _and(left, right):
+    return OperationCallExpression(
+        name="AND_BINARY", operation="and", arguments=[left, right],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Free-variable substitution
+# ---------------------------------------------------------------------------
+
+def test_replaces_free_variable_in_leaf():
+    expr = VariableExp("e", None)
+    repl = VariableExp("self", None)
+    out = substitute(expr, "e", repl)
+    assert isinstance(out, VariableExp) and out.name == "self"
+
+
+def test_unrelated_variable_is_unchanged():
+    expr = VariableExp("x", None)
+    repl = VariableExp("self", None)
+    out = substitute(expr, "e", repl)
+    assert isinstance(out, VariableExp) and out.name == "x"
+    # Distinct identity — substitute returns a clone for non-matches.
+    assert out is not expr
+
+
+def test_replaces_variable_inside_comparison():
+    e = VariableExp("e", None)
+    expr = _comp(e, ">", _int(16))
+    out = substitute(expr, "e", VariableExp("self", None))
+    new_left = out.arguments[0]
+    assert isinstance(new_left, VariableExp) and new_left.name == "self"
+
+
+def test_substitute_does_not_mutate_input():
+    e = VariableExp("e", None)
+    expr = _comp(e, ">", _int(16))
+    _ = substitute(expr, "e", VariableExp("self", None))
+    # Original AST untouched.
+    assert expr.arguments[0] is e
+    assert e.name == "e"
+
+
+def test_substitute_with_property_chain_replacement():
+    # X[self.r1/v]: replace `e` with `self.r1`.
+    p = Property("r1", IntegerType)
+    chain = PropertyCallExpression("r1", p)
+    chain.source = VariableExp("self", None)
+
+    body = _comp(VariableExp("e", None), ">", _int(0))
+    out = substitute(body, "e", chain)
+
+    new_left = out.arguments[0]
+    assert isinstance(new_left, PropertyCallExpression)
+    assert new_left.property is p  # Property reference shared
+    assert isinstance(new_left.source, VariableExp)
+    assert new_left.source.name == "self"
+
+
+def test_replacement_is_cloned_per_occurrence():
+    # Two occurrences of `e` must each get a fresh clone — no aliasing.
+    e1 = VariableExp("e", None)
+    e2 = VariableExp("e", None)
+    expr = _and(e1, e2)
+    repl = VariableExp("self", None)
+    out = substitute(expr, "e", repl)
+    assert out.arguments[0] is not out.arguments[1]
+
+
+# ---------------------------------------------------------------------------
+# Capture avoidance
+# ---------------------------------------------------------------------------
+
+def test_inner_loop_shadows_outer_substitution():
+    # forAll(e | e > 0)  — substituting `e` should NOT touch the body
+    # because the inner loop binds `e`.
+    inner_body = _comp(VariableExp("e", None), ">", _int(0))
+    loop = LoopExp("forAll", None)
+    loop.source = VariableExp("self", None)
+    loop.addIterator(IteratorExp("e", "NotMentioned"))
+    loop.add_body(inner_body)
+
+    out = substitute(loop, "e", VariableExp("REPLACED", None))
+
+    # Source is a free `self`, not affected by `e` substitution either way.
+    assert out.source.name == "self"
+    # Body's `e` is bound — must NOT have been replaced.
+    new_body_left = out.body[0].arguments[0]
+    assert isinstance(new_body_left, VariableExp)
+    assert new_body_left.name == "e"  # untouched
+
+
+def test_substitution_reaches_loop_source():
+    # `e->forAll(x | x > 0)` — substituting `e` should affect the source.
+    body = _comp(VariableExp("x", None), ">", _int(0))
+    loop = LoopExp("forAll", None)
+    loop.source = VariableExp("e", None)
+    loop.addIterator(IteratorExp("x", "NotMentioned"))
+    loop.add_body(body)
+
+    out = substitute(loop, "e", VariableExp("self", None))
+    assert isinstance(out.source, VariableExp) and out.source.name == "self"
+    # x stays x in the body
+    assert out.body[0].arguments[0].name == "x"
+
+
+def test_nested_loop_with_distinct_iterator_names_substitutes_correctly():
+    # forAll(e | forAll(d | e > d))
+    # Substituting `e` reaches `e > d` because only `d` is bound by inner.
+    inner_body = _comp(VariableExp("e", None), ">", VariableExp("d", None))
+    inner = LoopExp("forAll", None)
+    inner.source = VariableExp("ignored", None)
+    inner.addIterator(IteratorExp("d", "NotMentioned"))
+    inner.add_body(inner_body)
+
+    outer = LoopExp("forAll", None)
+    outer.source = VariableExp("ignored2", None)
+    outer.addIterator(IteratorExp("e", "NotMentioned"))
+    outer.add_body(inner)
+
+    # Reach inside both layers because of the explicit scope stack:
+    # we want substitute(outer.body[0], "e", ...) to substitute through
+    # the inner loop because `e` is not shadowed there.
+    out = substitute(inner, "e", VariableExp("REPLACED", None))
+    new_e = out.body[0].arguments[0]
+    assert new_e.name == "REPLACED"
+
+
+def test_nested_loop_with_same_iterator_name_does_not_substitute():
+    # forAll(e | e > 0) — substituting `e` in the loop is a no-op for the body.
+    inner_body = _comp(VariableExp("e", None), ">", _int(0))
+    loop = LoopExp("forAll", None)
+    loop.source = VariableExp("ignored", None)
+    loop.addIterator(IteratorExp("e", "NotMentioned"))
+    loop.add_body(inner_body)
+
+    out = substitute(loop, "e", VariableExp("REPLACED", None))
+    # Body's `e` is bound by this loop's iterator; not substituted.
+    assert out.body[0].arguments[0].name == "e"
+
+
+# ---------------------------------------------------------------------------
+# IfExp and other forms
+# ---------------------------------------------------------------------------
+
+def test_substitute_inside_if():
+    cond = VariableExp("e", None)
+    then_e = VariableExp("e", None)
+    else_e = _int(0)
+    if_node = IfExp("if", "IfExpression")
+    if_node.ifCondition = cond
+    if_node.thenExpression = then_e
+    if_node.elseCondition = else_e
+
+    out = substitute(if_node, "e", BooleanLiteralExpression("NP", True))
+    assert isinstance(out.ifCondition, BooleanLiteralExpression)
+    assert out.ifCondition.value is True
+    assert isinstance(out.thenExpression, BooleanLiteralExpression)
+    # else branch unchanged
+    assert isinstance(out.elseCondition, IntegerLiteralExpression)
+
+
+def test_substitute_through_property_chain():
+    # e.r1 — substitute e -> self
+    p = Property("r1", IntegerType)
+    pce = PropertyCallExpression("r1", p)
+    pce.source = VariableExp("e", None)
+    out = substitute(pce, "e", VariableExp("self", None))
+    assert out.property is p
+    assert isinstance(out.source, VariableExp) and out.source.name == "self"
+
+
+# ---------------------------------------------------------------------------
+# ScopeStack unit
+# ---------------------------------------------------------------------------
+
+def test_scope_stack_push_pop_is_bound():
+    s = ScopeStack()
+    assert not s.is_bound("e")
+    s.push(["e"])
+    assert s.is_bound("e")
+    s.push(["x"])
+    assert s.is_bound("e") and s.is_bound("x")
+    s.pop()
+    assert s.is_bound("e") and not s.is_bound("x")
+    s.pop()
+    assert not s.is_bound("e")

--- a/tests/BUML/metamodel/ocl/test_walk.py
+++ b/tests/BUML/metamodel/ocl/test_walk.py
@@ -1,0 +1,106 @@
+"""Tests for besser.BUML.metamodel.ocl.walk."""
+
+from besser.BUML.metamodel.ocl import walk
+from besser.BUML.metamodel.ocl.ocl import (
+    OperationCallExpression, LoopExp, IteratorExp, IfExp,
+    PropertyCallExpression, VariableExp,
+    IntegerLiteralExpression, BooleanLiteralExpression, InfixOperator,
+)
+from besser.BUML.metamodel.structural import Property, IntegerType
+
+
+def _int(v):
+    return IntegerLiteralExpression("NP", v)
+
+
+def _comp(left, op, right):
+    return OperationCallExpression(
+        name="Operation", operation=op,
+        arguments=[left, InfixOperator(op), right],
+    )
+
+
+def test_walk_none_yields_nothing():
+    assert list(walk(None)) == []
+
+
+def test_walk_leaf():
+    n = _int(7)
+    assert list(walk(n)) == [n]
+
+
+def test_walk_comparison_post_order():
+    left = _int(3)
+    right = _int(5)
+    cmp = _comp(left, "<", right)
+    nodes = list(walk(cmp))
+    assert nodes == [left, right, cmp]
+
+
+def test_walk_skips_infix_operator():
+    left = _int(1)
+    right = _int(2)
+    cmp = _comp(left, "=", right)
+    for n in walk(cmp):
+        assert not isinstance(n, InfixOperator)
+
+
+def test_walk_boolean_binary():
+    left = _comp(_int(1), "<", _int(2))
+    right = _comp(_int(3), ">", _int(4))
+    and_node = OperationCallExpression(
+        name="AND_BINARY", operation="and", arguments=[left, right]
+    )
+    nodes = list(walk(and_node))
+    # post-order: leaves first, then comparisons, then AND
+    assert nodes[-1] is and_node
+    assert left in nodes and right in nodes
+
+
+def test_walk_unary_not():
+    operand = _comp(_int(1), "<", _int(2))
+    not_node = OperationCallExpression(
+        name="unary_not", operation="not", arguments=[operand]
+    )
+    nodes = list(walk(not_node))
+    assert nodes[-1] is not_node
+    assert operand in nodes
+
+
+def test_walk_property_call_chain():
+    p1 = Property("r1", IntegerType)
+    p2 = Property("r2", IntegerType)
+    self_var = VariableExp("self", None)
+    pce1 = PropertyCallExpression("r1", p1)
+    pce1.source = self_var
+    pce2 = PropertyCallExpression("r2", p2)
+    pce2.source = pce1
+    nodes = list(walk(pce2))
+    assert nodes == [self_var, pce1, pce2]
+
+
+def test_walk_loop_visits_source_and_body_not_iterator():
+    src = VariableExp("self", None)
+    body = _comp(_int(1), ">", _int(0))
+    loop = LoopExp("forAll", None)
+    loop.source = src
+    loop.addIterator(IteratorExp("e", "NotMentioned"))
+    loop.add_body(body)
+    nodes = list(walk(loop))
+    # IteratorExp is a variable declaration, not visited as a child
+    assert all(not isinstance(n, IteratorExp) for n in nodes)
+    assert src in nodes and body in nodes
+    assert nodes[-1] is loop
+
+
+def test_walk_if_visits_all_three_branches():
+    cond = BooleanLiteralExpression("NP", True)
+    then_e = _int(1)
+    else_e = _int(2)
+    if_node = IfExp("if", "IfExpression")
+    if_node.ifCondition = cond
+    if_node.thenExpression = then_e
+    if_node.elseCondition = else_e
+    nodes = list(walk(if_node))
+    assert cond in nodes and then_e in nodes and else_e in nodes
+    assert nodes[-1] is if_node

--- a/tests/BUML/notations/ocl/conftest.py
+++ b/tests/BUML/notations/ocl/conftest.py
@@ -1,0 +1,37 @@
+"""Shared fixture for B-OCL notation tests.
+
+The model mirrors the trimmed paper Fig. 1 from PRD §6.1: ``Department`` and
+``Employee`` linked by a ``WorksIn`` association with multiplicity 1..1 on the
+employer end and 0..* on the employee end. Sufficient to exercise every
+parse/print round-trip and the multiplicity-based normalization rules later.
+"""
+
+import pytest
+
+from besser.BUML.metamodel.structural import (
+    DomainModel, Class, Property, BinaryAssociation, Multiplicity,
+    StringType, IntegerType, FloatType,
+)
+
+
+@pytest.fixture(scope="module")
+def model() -> DomainModel:
+    department = Class("Department", attributes={
+        Property("name", StringType),
+        Property("minSalary", FloatType),
+        Property("maxJuniorSal", FloatType),
+    })
+    employee = Class("Employee", attributes={
+        Property("name", StringType),
+        Property("age", IntegerType),
+        Property("salary", FloatType),
+    })
+    works_in = BinaryAssociation("WorksIn", ends={
+        Property("employer", department, multiplicity=Multiplicity(1, 1)),
+        Property("employee", employee, multiplicity=Multiplicity(0, "*")),
+    })
+    return DomainModel(
+        "CompanyModel",
+        types={department, employee},
+        associations={works_in},
+    )

--- a/tests/BUML/notations/ocl/test_normalization.py
+++ b/tests/BUML/notations/ocl/test_normalization.py
@@ -148,3 +148,38 @@ def test_idempotence(ocl_input, model):
     once = normalize(parsed, model)
     twice = normalize(once, model)
     assert pretty_print(once) == pretty_print(twice)
+
+
+def test_if_with_non_boolean_branches_is_left_alone(model):
+    """``if C then <int> else <int> endif`` must not be flattened.
+
+    Rewriting it would emit ``and`` / ``or`` over integers, which is not
+    OCL-valid. The IfExp must survive normalization unchanged.
+    """
+    parsed = parse_ocl(
+        "context Employee inv: "
+        "if self.age > 16 then 5 else 10 endif = 5",
+        model,
+    )
+    normalized = normalize(parsed, model)
+
+    if_nodes = [n for n in walk(normalized.expression) if isinstance(n, IfExp)]
+    assert len(if_nodes) == 1, (
+        f"IfExp with non-boolean branches should survive; got: "
+        f"{pretty_print(normalized)}"
+    )
+
+
+def test_if_with_boolean_branches_is_eliminated(model):
+    """``if C then <bool-expr> else <bool-expr> endif`` is still folded."""
+    parsed = parse_ocl(
+        "context Employee inv: "
+        "if self.age > 16 then self.salary > 0.0 else self.salary < 0.0 endif",
+        model,
+    )
+    normalized = normalize(parsed, model)
+    for node in walk(normalized.expression):
+        assert not isinstance(node, IfExp), (
+            f"boolean-branched IfExp must be eliminated; got: "
+            f"{pretty_print(normalized)}"
+        )

--- a/tests/BUML/notations/ocl/test_normalization.py
+++ b/tests/BUML/notations/ocl/test_normalization.py
@@ -1,0 +1,150 @@
+"""Integration tests for B-OCL normalization (PRD §6.3).
+
+Each test parses an OCL string, normalizes it, pretty-prints the result, and
+checks identity against the expected normal form. Idempotence is asserted on
+every case: ``normalize(normalize(c)) == normalize(c)``.
+
+Test inputs trace the worked examples in Cabot & Teniente, Sci. Comput.
+Program. 68 (2007). T7's input uses ``->size() > 0`` instead of ``->notEmpty()``
+because ``notEmpty`` is not in the BESSER grammar today (the rewrite system
+itself never produces it; the substitution is purely a test-input choice).
+"""
+
+import pytest
+
+from besser.BUML.notations.ocl import normalize, parse_ocl, pretty_print
+
+
+def _normalize_to_string(input_str, model):
+    parsed = parse_ocl(input_str, model)
+    normalized = normalize(parsed, model)
+    return pretty_print(normalized), normalized
+
+
+def assert_normalizes_to(input_str, expected_str, model):
+    rendered, normalized = _normalize_to_string(input_str, model)
+    assert rendered == expected_str, (
+        f"\n  got:      {rendered}\n  expected: {expected_str}"
+    )
+    # Idempotence — normalizing again must be a no-op.
+    twice = pretty_print(normalize(normalized, model))
+    assert twice == expected_str, f"not idempotent: {twice!r}"
+
+
+# ---------------------------------------------------------------------------
+# PRD §6.3 — T1..T8
+# ---------------------------------------------------------------------------
+
+def test_T1_boolean_constant(model):
+    assert_normalizes_to(
+        "context Employee inv: self.age > 16 and true",
+        "context Employee inv: self.age > 16",
+        model,
+    )
+
+
+def test_T2_double_negation(model):
+    assert_normalizes_to(
+        "context Employee inv: not (not (self.age > 16))",
+        "context Employee inv: self.age > 16",
+        model,
+    )
+
+
+def test_T3_demorgan_with_negated_comparisons(model):
+    assert_normalizes_to(
+        "context Employee inv: not (self.age < 18 and self.salary < 1000.0)",
+        "context Employee inv: self.age >= 18 or self.salary >= 1000.0",
+        model,
+    )
+
+
+def test_T4_implies_elimination(model):
+    assert_normalizes_to(
+        "context Employee inv: self.age < 25 implies self.salary <= 50000.0",
+        "context Employee inv: self.age >= 25 or self.salary <= 50000.0",
+        model,
+    )
+
+
+def test_T5_exists_to_forall(model):
+    assert_normalizes_to(
+        "context Department inv: not self.employee->exists(e | e.salary > 1000000.0)",
+        "context Department inv: self.employee->forAll(e | e.salary <= 1000000.0)",
+        model,
+    )
+
+
+def test_T6_allinstances_removal(model):
+    assert_normalizes_to(
+        "context Employee inv: Employee::allInstances()->forAll(e | e.age > 16)",
+        "context Employee inv: self.age > 16",
+        model,
+    )
+
+
+def test_T7_multiplicity_aware_simplification(model):
+    # `self.employer` has multiplicity 1..1, so size() > 0 → true,
+    # then `true implies X` → X.
+    assert_normalizes_to(
+        "context Employee inv: self.employer->size() > 0 implies "
+        "self.employer.minSalary <= self.salary",
+        "context Employee inv: self.employer.minSalary <= self.salary",
+        model,
+    )
+
+
+def test_T8_paper_maxsalary_integration(model):
+    """Paper §2.4, steps 1–6. End-to-end pipeline test."""
+    assert_normalizes_to(
+        "context Department inv: Department::allInstances()->forAll("
+        "d | not d.employee->select(e | e.age < 25)->exists("
+        "e | e.salary > d.maxJuniorSal))",
+        "context Department inv: self.employee->forAll("
+        "e | e.age >= 25 or e.salary <= self.maxJuniorSal)",
+        model,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property tests — PRD §6.4
+# ---------------------------------------------------------------------------
+
+from besser.BUML.metamodel.ocl import (
+    is_implies, is_xor, is_isempty, is_loop, is_atomic_type_test, walk,
+)
+from besser.BUML.metamodel.ocl.ocl import IfExp
+
+
+@pytest.mark.parametrize("ocl_input", [
+    "context Employee inv: self.age > 16 and true",
+    "context Employee inv: not (not (self.age > 16))",
+    "context Employee inv: self.age < 25 implies self.salary <= 50000.0",
+    "context Department inv: not self.employee->exists(e | e.salary > 1000000.0)",
+    "context Department inv: Department::allInstances()->forAll("
+    "d | not d.employee->select(e | e.age < 25)->exists("
+    "e | e.salary > d.maxJuniorSal))",
+])
+def test_operator_surface_invariant(ocl_input, model):
+    """Normal form contains no implies / xor / exists / reject / isEmpty / IfExp."""
+    parsed = parse_ocl(ocl_input, model)
+    normalized = normalize(parsed, model)
+    for node in walk(normalized.expression):
+        assert not is_implies(node), pretty_print(normalized)
+        assert not is_xor(node), pretty_print(normalized)
+        assert not is_isempty(node), pretty_print(normalized)
+        assert not is_loop(node, "exists"), pretty_print(normalized)
+        assert not is_loop(node, "reject"), pretty_print(normalized)
+        assert not isinstance(node, IfExp), pretty_print(normalized)
+
+
+@pytest.mark.parametrize("ocl_input", [
+    "context Employee inv: self.age > 16",
+    "context Employee inv: self.age < 25 implies self.salary <= 50000.0",
+    "context Department inv: self.employee->forAll(e | e.age >= 25)",
+])
+def test_idempotence(ocl_input, model):
+    parsed = parse_ocl(ocl_input, model)
+    once = normalize(parsed, model)
+    twice = normalize(once, model)
+    assert pretty_print(once) == pretty_print(twice)

--- a/tests/BUML/notations/ocl/test_parse_ocl.py
+++ b/tests/BUML/notations/ocl/test_parse_ocl.py
@@ -46,6 +46,13 @@ def test_parse_raises_bocl_syntax_error_on_lex_or_parse_failure(model):
         parse_ocl("context Employee inv: (self.age > 16", model)
 
 
+def test_parse_raises_bocl_syntax_error_on_unresolved_property(model):
+    # Property doesn't exist on the context class — must surface as
+    # BOCLSyntaxError, not a bare Exception.
+    with pytest.raises(BOCLSyntaxError, match="not found"):
+        parse_ocl("context Employee inv: self.nonexistent > 16", model)
+
+
 def test_parse_iterator_constraint(model):
     result = parse_ocl(
         "context Department inv: self.employee->forAll(e | e.age > 16)",

--- a/tests/BUML/notations/ocl/test_parse_ocl.py
+++ b/tests/BUML/notations/ocl/test_parse_ocl.py
@@ -1,0 +1,55 @@
+"""Tests for besser.BUML.notations.ocl.api.parse_ocl."""
+
+import pytest
+
+from besser.BUML.metamodel.ocl.ocl import OCLConstraint
+from besser.BUML.notations.ocl import parse_ocl, BOCLSyntaxError
+
+
+def test_parse_returns_ocl_constraint(model):
+    result = parse_ocl("context Employee inv: self.age > 16", model)
+    assert isinstance(result, OCLConstraint)
+    assert result.context.name == "Employee"
+    assert result.language == "OCL"
+
+
+def test_parse_resolves_context_from_text(model):
+    result = parse_ocl("context Department inv: self.name <> ''", model)
+    assert result.context.name == "Department"
+
+
+def test_parse_explicit_context_class_overrides_text(model):
+    employee = next(t for t in model.types if getattr(t, "name", None) == "Employee")
+    # No header in the text — but explicit context_class supplied.
+    result = parse_ocl(
+        "context Employee inv: self.age > 16",
+        model,
+        context_class=employee,
+    )
+    assert result.context is employee
+
+
+def test_parse_raises_for_unknown_context(model):
+    with pytest.raises(ValueError, match="Nonexistent"):
+        parse_ocl("context Nonexistent inv: 1 = 1", model)
+
+
+def test_parse_raises_for_missing_header(model):
+    # No `context X inv:` prefix and no explicit context_class → ValueError.
+    with pytest.raises(ValueError, match="header"):
+        parse_ocl("self.age > 16", model)
+
+
+def test_parse_raises_bocl_syntax_error_on_lex_or_parse_failure(model):
+    # Unbalanced parenthesis → ANTLR error.
+    with pytest.raises(BOCLSyntaxError):
+        parse_ocl("context Employee inv: (self.age > 16", model)
+
+
+def test_parse_iterator_constraint(model):
+    result = parse_ocl(
+        "context Department inv: self.employee->forAll(e | e.age > 16)",
+        model,
+    )
+    assert isinstance(result, OCLConstraint)
+    assert result.context.name == "Department"

--- a/tests/BUML/notations/ocl/test_pretty_printer.py
+++ b/tests/BUML/notations/ocl/test_pretty_printer.py
@@ -1,0 +1,61 @@
+"""Tests for besser.BUML.notations.ocl.pretty_printer.pretty_print.
+
+Round-trip identity: ``pretty_print(parse_ocl(s)) == s`` for every input that's
+already in canonical form (no extra parens, canonical operator spelling).
+"""
+
+import pytest
+
+from besser.BUML.notations.ocl import parse_ocl, pretty_print
+
+
+@pytest.mark.parametrize("source", [
+    "context Employee inv: self.age > 16",
+    "context Employee inv: self.salary <= 50000.0",
+    "context Employee inv: self.age >= 18 or self.salary >= 1000.0",
+    "context Employee inv: not self.age > 16",
+    "context Employee inv: self.age > 16 and self.salary > 0.0",
+    "context Department inv: self.employee->forAll(e | e.age > 16)",
+    "context Employee inv: self.employer.minSalary <= self.salary",
+])
+def test_round_trip_identity(source, model):
+    constraint = parse_ocl(source, model)
+    rendered = pretty_print(constraint)
+    assert rendered == source
+
+
+def test_pretty_print_handles_raw_expression(model):
+    constraint = parse_ocl("context Employee inv: self.age > 16", model)
+    # Pass just the expression, not the whole OCLConstraint.
+    rendered = pretty_print(constraint.expression)
+    assert rendered == "self.age > 16"
+
+
+def test_pretty_print_emits_context_prologue_for_constraint(model):
+    constraint = parse_ocl("context Employee inv: self.age > 16", model)
+    assert pretty_print(constraint).startswith("context Employee inv: ")
+
+
+def test_pretty_print_boolean_literal_python_bool(model):
+    constraint = parse_ocl(
+        "context Employee inv: self.age > 16 and true",
+        model,
+    )
+    rendered = pretty_print(constraint)
+    assert rendered == "context Employee inv: self.age > 16 and true"
+
+
+def test_pretty_print_isEmpty(model):
+    constraint = parse_ocl(
+        "context Department inv: self.employee->isEmpty()",
+        model,
+    )
+    assert pretty_print(constraint) == "context Department inv: self.employee->isEmpty()"
+
+
+def test_pretty_print_size(model):
+    constraint = parse_ocl(
+        "context Department inv: self.employee->size() > 0",
+        model,
+    )
+    assert pretty_print(constraint) == "context Department inv: self.employee->size() > 0"

--- a/tests/BUML/notations/ocl/test_wrapping_visitor.py
+++ b/tests/BUML/notations/ocl/test_wrapping_visitor.py
@@ -1,0 +1,75 @@
+"""Tests for besser.BUML.notations.ocl.wrapping_visitor.WrappingVisitor.
+
+Verifies the three bugs the wrapper fixes are actually fixed:
+- chain reconstruction in dot navigation;
+- chain reconstruction for the special-case ``size`` attribute;
+- boolean literal coerced to Python ``bool``.
+"""
+
+from besser.BUML.metamodel.ocl import is_chain_from_self, walk_chain_from_self
+from besser.BUML.metamodel.ocl.ocl import (
+    BooleanLiteralExpression, OperationCallExpression,
+    PropertyCallExpression, VariableExp,
+)
+from besser.BUML.notations.ocl import parse_ocl
+
+
+def test_dot_navigation_preserves_chain(model):
+    constraint = parse_ocl(
+        "context Employee inv: self.employer.minSalary <= self.salary",
+        model,
+    )
+    expr = constraint.expression
+    # Top-level: comparison with three-arg shape.
+    assert isinstance(expr, OperationCallExpression)
+    left = expr.arguments[0]
+    # Left side is `self.employer.minSalary` — must be a 2-step chain.
+    assert is_chain_from_self(left)
+    chain = walk_chain_from_self(left)
+    assert [p.name for p in chain] == ["employer", "minSalary"]
+
+
+def test_simple_dot_navigation_is_a_one_step_chain(model):
+    constraint = parse_ocl("context Employee inv: self.age > 18", model)
+    expr = constraint.expression
+    left = expr.arguments[0]
+    assert is_chain_from_self(left)
+    assert [p.name for p in walk_chain_from_self(left)] == ["age"]
+
+
+def test_boolean_literal_is_python_bool(model):
+    constraint = parse_ocl(
+        "context Employee inv: self.age > 16 and true",
+        model,
+    )
+    # Walk the AST to find the BooleanLiteralExpression.
+    from besser.BUML.metamodel.ocl import walk
+    bools = [n for n in walk(constraint.expression)
+             if isinstance(n, BooleanLiteralExpression)]
+    assert len(bools) == 1
+    assert bools[0].value is True
+    assert not isinstance(bools[0].value, str)
+
+
+def test_boolean_literal_false(model):
+    constraint = parse_ocl(
+        "context Employee inv: self.age > 16 or false",
+        model,
+    )
+    from besser.BUML.metamodel.ocl import walk
+    bools = [n for n in walk(constraint.expression)
+             if isinstance(n, BooleanLiteralExpression)]
+    assert bools[0].value is False
+
+
+def test_chain_terminus_is_self_variable_expression(model):
+    constraint = parse_ocl(
+        "context Employee inv: self.employer.minSalary <= self.salary",
+        model,
+    )
+    left = constraint.expression.arguments[0]
+    # Walk to the innermost source: should be VariableExp("self").
+    cur = left
+    while isinstance(cur, PropertyCallExpression):
+        cur = cur.source
+    assert isinstance(cur, VariableExp) and cur.name == "self"


### PR DESCRIPTION
## Summary

Adds an OCL constraint manipulation toolkit and a normalization pipeline that rewrites constraints into a canonical form.

Based on the first part of: Jordi Cabot, Ernest Teniente, *Transformation techniques for OCL constraints*. Sci. Comput. Program. 68(3): 179-195 (2007).

### Two layers

**1. Generic AST utilities (`besser/BUML/metamodel/ocl/`)**
- ``walk`` — post-order traversal yielding every node.
- ``clone`` — structural deep-copy that keeps shared references to domain-model objects (``Property``, ``Class``); ``copy.deepcopy`` would clone the whole ``DomainModel`` graph.
- ``predicates`` — typed ``is_and`` / ``is_or`` / ``is_loop`` / ``is_comparison`` etc., hiding the ``OperationCallExpression`` + operation-string dispatch pattern.
- ``chain`` — analysis of ``self.r1.r2.r3`` chains incl. min/max multiplicity along the chain (used by the multiplicity-aware rules).
- ``substitute`` — capture-avoiding variable substitution with a proper ``ScopeStack`` that fixes a known shadowing bug in the base visitor.

**2. Notation layer (`besser/BUML/notations/ocl/`)**
- ``parse_ocl(text, model, context_class=None)`` — single canonical entry point returning a fresh ``OCLConstraint``. Raises ``BOCLSyntaxError`` on failure.
- ``WrappingVisitor`` — subclass of ``BOCLVisitorImpl`` that fixes 5 bugs in the generated visitor (chain flattening in ``visitDotNavigation`` / ``visitDotSizeNavigation``, wrong receiver-type lookup in chained navigation, wrong iterator-variable typing in ``visitArrowIterator``, boolean literals stored as the lexeme string).
- ``pretty_print`` — precedence-aware printer.
- ``normalize`` — bottom-up fixed-point rewrite engine with a logged trace and an iteration cap. Termination is justified by the lexicographic measure ``<#sugar-ops, AST size, #negations>``.
- 6 rule modules covering Cabot–Teniente §2 + §3.1.3:
  - ``boolean`` — and/or/not constant collapse, double-neg, DeMorgan, negated-comparison flipping.
  - ``cnf`` — sugar elim: ``implies``, ``xor``, boolean ``IfExp``. CNF distribution intentionally omitted (would explode AST size).
  - ``collection`` — ``isEmpty()`` -> ``size()=0``, ``reject(p)`` -> ``select(not p)``.
  - ``iterator`` — ``exists`` -> ``not forAll(not …)``, size-of-select fast paths, ``select->forAll`` fusion.
  - ``all_instances`` — ``Ctx::allInstances()->forAll(v|Y)`` -> ``Y[self/v]`` when receiver is the constraint context.
  - ``multiplicity`` — chain-rooted size collapses based on static min/max multiplicity (paper §3.1.3).

### Why this matters

After normalization, semantically-equivalent constraints share one canonical AST shape. Downstream consumers (code generators, validators, redundancy/equivalence checks in the web editor) only have to handle the small canonical operator set instead of the full sugary surface. The utility layer is independently useful for any pass that walks/rewrites OCL ASTs.

### Bug-fix included

One unrelated 1-line correctness fix in ``besser/BUML/metamodel/ocl/ocl.py``: ``PropertyCallExpression`` was double-wrapping its type as ``Type(property.type)``; ``property.type`` is already a ``Type``. Verified no caller reads ``PropertyCallExpression.type``.

### Hardening done in latest commit

- ``IfBoolElim`` now only fires on ``IfExp`` whose branches are themselves boolean. Folding ``if C then 5 else 10`` would produce ``and``/``or`` over integers, which is not OCL-valid. Non-boolean ``IfExp`` survive normalization unchanged.
- ``WrappingVisitor`` raises ``BOCLSyntaxError`` (not bare ``Exception``) for unresolved property names, so callers catching parser errors no longer miss this case.

## Test plan

- [x] 167 new OCL tests pass (``tests/BUML/metamodel/ocl/`` + ``tests/BUML/notations/ocl/``).
- [x] Full repo suite: 872 passed, 5 skipped, 3 xfailed. No regressions.
- [x] Existing OCL consumers untouched (``besser/generators/pydantic_classes/ocl_utils.py`` and the web-editor ``ocl_checker``); the new ``WrappingVisitor`` / ``parse_ocl`` are opt-in for future callers.
- [ ] Reviewer-side: confirm whether ``docs/source/buml_language/model_building/ocl_grammar.rst`` should be updated to describe the new public surface (``parse_ocl``, ``pretty_print``, ``normalize``).