### PR TITLE
release: v7.4.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ make html  # Windows: make.bat html
 ### Local Stack Deployment
 ```bash
 # Run full stack with Docker Compose
-docker-compose up --build
+docker compose up --build
 ```
 
 ## Architecture Overview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,8 +122,8 @@ that opens room for the best design.
 
 - **Python 3.10, 3.11, or 3.12** (CI tests against all three).
 - **Git**, including submodule support.
-- **Node.js 18+** *(only if you plan to run the web modeling editor frontend
-  locally)*.
+- **Node.js 20+** *(only if you plan to run the web modeling editor frontend
+  locally — matches the frontend repo's CI)*.
 
 ### Fork, clone, and initialize
 
@@ -187,7 +187,7 @@ If both run cleanly, you are ready to go.
 ### (Optional) Run the full local stack
 
 ```bash
-docker-compose up --build
+docker compose up --build
 ```
 
 This brings up the backend API and the web modeling editor for end-to-end
@@ -556,7 +556,7 @@ later. Linking a follow-up issue is even better.
 ## 🔗 Cross-Repo Changes (Frontend Submodule)
 
 The web modeling editor frontend lives in
-[BESSER-WEB-MODELING-EDITOR](https://github.com/BESSER-PEARL/BESSER-WEB-MODELING-EDITOR)
+[BESSER-Web-Modeling-Editor](https://github.com/BESSER-PEARL/BESSER-Web-Modeling-Editor)
 and is included here as a submodule under
 `besser/utilities/web_modeling_editor/frontend`.
 

--- a/DEVELOPMENT_SETUP.md
+++ b/DEVELOPMENT_SETUP.md
@@ -36,7 +36,7 @@ Complete guide to set up the BESSER development environment from scratch.
 
 ### 4. Docker Desktop (optional)
 
-Only needed if you want to run the full stack with `docker-compose up`.
+Only needed if you want to run the full stack with `docker compose up`.
 
 - Download from [docker.com](https://www.docker.com/products/docker-desktop/)
 
@@ -86,7 +86,7 @@ Open your browser and go to **http://localhost:8080**.
 Instead of running backend and frontend separately:
 
 ```bash
-docker-compose up --build
+docker compose up --build
 ```
 
 This starts both services. Open `http://localhost:8080`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The BESSER low-code platform is built on top of [B-UML](https://besser.readthedo
 With B-UML you can specify your software application and then use any of the [code-generators available](https://besser.readthedocs.io/en/latest/generators.html) to translate your model into executable code suitable for various applications, such as Django web apps or database structures compatible with SQLAlchemy.
 
 This repository contains the backend foundation for the ecosystem: the
-metamodel, code generators, notations, utilities, and services that drive the web modeling editor and the Python SDK. The editor's frontend is maintained in the companion [BESSER-WEB-MODELING-EDITOR](https://github.com/BESSER-PEARL/BESSER-WEB-MODELING-EDITOR) repository and is included here only as a submodule (at `besser/utilities/web_modeling_editor/frontend`) for local deployments.
+metamodel, code generators, notations, utilities, and services that drive the web modeling editor and the Python SDK. The editor's frontend is maintained in the companion [BESSER-Web-Modeling-Editor](https://github.com/BESSER-PEARL/BESSER-Web-Modeling-Editor) repository and is included here only as a submodule (at `besser/utilities/web_modeling_editor/frontend`) for local deployments.
 
 **Check out the [BESSER Web Modeling Editor online](https://editor.besser-pearl.org/)**
 ![BESSER Web Modeling Editor Demo](./docs/source/img/besser_new.gif)

--- a/docs/source/contributing/create_dsl.rst
+++ b/docs/source/contributing/create_dsl.rst
@@ -39,7 +39,7 @@ that repository, then the submodule pointer updated in BESSER.
 
   - **Enable an existing diagram type** (already implemented in the editor package): wire it into the webapp project
     model, sidebar, and import/export flows. See
-    ``packages/webapp2/src/main/features/project/ADDING_NEW_DIAGRAM_TYPE.md`` in the WME repo.
+    ``packages/webapp/src/main/features/project/ADDING_NEW_DIAGRAM_TYPE.md`` in the WME repo.
   - **Add a brand-new diagram/DSL**: extend the editor package first (diagram type, element types, renderers, palette
     previews, translations, property editors), then wire it into the webapp.
 * Frontend (WME repo): update the editor package and webapp to expose the new diagram type and UI affordances. Follow

--- a/docs/source/contributing/diagram_dsl_workflow.rst
+++ b/docs/source/contributing/diagram_dsl_workflow.rst
@@ -9,7 +9,7 @@ that must work across both repositories:
 
 Use this when you need **new elements, new rendering, and new backend processing**.
 If you only need to expose an existing UML diagram type in the webapp, follow the WME
-checklist in ``packages/webapp2/src/main/features/project/ADDING_NEW_DIAGRAM_TYPE.md``.
+checklist in ``packages/webapp/src/main/features/project/ADDING_NEW_DIAGRAM_TYPE.md``.
 
 Decision Tree
 -------------
@@ -82,7 +82,7 @@ Step 3: Wire the Diagram into the Webapp (WME repo)
 Once the editor package can render the diagram, expose it in the webapp.
 Follow the checklist in:
 
-``packages/webapp2/src/main/features/project/ADDING_NEW_DIAGRAM_TYPE.md``
+``packages/webapp/src/main/features/project/ADDING_NEW_DIAGRAM_TYPE.md``
 
 That checklist covers:
 

--- a/docs/source/releases/v7.rst
+++ b/docs/source/releases/v7.rst
@@ -4,6 +4,7 @@ Version 7
 .. toctree::
    :maxdepth: 1
 
+   v7/v7.4.1
    v7/v7.4.0
    v7/v7.3.0
    v7/v7.2.0

--- a/docs/source/releases/v7/v7.4.1.rst
+++ b/docs/source/releases/v7/v7.4.1.rst
@@ -1,0 +1,57 @@
+Version 7.4.1
+=============
+
+Patch release: **internal cleanup — drop the legacy ``packages/webapp`` and
+rename ``packages/webapp2`` to ``packages/webapp``** in the Web Modeling
+Editor frontend. No user-visible behavior changes, no API changes, no
+metamodel changes — this is a tidy-up that removes dead code and restores
+the canonical package name.
+
+Highlights
+----------
+
+- **Frontend monorepo simplification.** The legacy Webpack + Bootstrap
+  ``packages/webapp`` package — kept on disk "for reference only" since
+  the v7 redesign — is now removed. The active React + Vite + Radix UI app
+  that previously lived under ``packages/webapp2`` is renamed to
+  ``packages/webapp`` so the canonical workspace name reflects what users
+  actually run. Build artefacts now land in ``build/webapp/`` instead of
+  ``build/webapp2/``; the standalone ``packages/server`` reads from the
+  new path directly (the legacy fallback was deleted).
+- **Documentation sweep.** Every reference to ``webapp2`` across both
+  repositories is now ``webapp`` — frontend ``README.md``, ``CLAUDE.md``,
+  ``CONTRIBUTING.md``; the backend ``docs/source/contributing/`` RSTs;
+  and 15 frontend Sphinx RSTs (``overview/``, ``contributing/``,
+  ``editor/``, ``reference/``, ``webapp/``). Stale "this package is
+  deprecated and will be removed" warnings are gone too.
+- **Documentation polish (separate from the rename).** Tightened the
+  backend's ``README.md``, ``CONTRIBUTING.md``, ``DEVELOPMENT_SETUP.md``,
+  and ``CLAUDE.md`` in three small ways: the repository URL is now the
+  canonical Title-Case ``BESSER-Web-Modeling-Editor`` (GitHub still
+  redirects the old all-caps form, but the new form is what we ship);
+  the Node version requirement in the backend ``CONTRIBUTING.md`` is now
+  ``Node.js 20+`` to match the frontend repo's CI matrix; and
+  ``docker-compose`` (Compose v1 syntax) is replaced with the v2 form
+  ``docker compose`` in setup instructions.
+
+Compatibility
+-------------
+
+* No public API change. The published ``@besser/wme`` npm package
+  (the editor) is untouched; only the internal monorepo workspace name
+  changed.
+* No metamodel, generator, or backend API change.
+* Anyone who scripted ``npm run *:webapp2`` against this monorepo will
+  need to switch to ``npm run *:webapp``. ``npm run dev``, ``npm run
+  build``, ``npm run test``, and ``npm run lint`` continue to work
+  unchanged — they were already aliases that covered both names.
+
+Testing
+-------
+
+* Frontend: ``npm run build`` produces ``build/webapp/`` and
+  ``build/server/`` cleanly under the renamed workspace.
+* Frontend: 55 perspective unit tests (``project.test.ts``,
+  ``HiddenPerspectivesBanner.test.tsx``, ``ProjectSettingsPanel.test.tsx``,
+  ``WorkspaceSidebar.test.tsx``) green.
+* Backend: no Python code changed; the existing test suite still applies.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = besser
-version = 7.4.0
+version = 7.4.1
 author = Luxembourg Institute of Science and Technology
 description = BESSER
 long_description = file: README.md


### PR DESCRIPTION
## Summary

Internal cleanup only. No API, metamodel, generator, or user-visible behavior change.

- Drop the legacy `packages/webapp` (Webpack + Bootstrap, kept only "for reference") in the WME frontend submodule.
- Rename `packages/webapp2` -> `packages/webapp` so the canonical workspace name reflects what users actually run; `build/webapp2/` -> `build/webapp/`.
- Sweep every reference to `webapp2` across both repositories (READMEs, CLAUDE.md, CONTRIBUTING.md, 17 RSTs, server constants, .gitignore, source comments).
- Tighten READMEs / CONTRIBUTING / DEVELOPMENT_SETUP / CLAUDE: canonical Title-Case `BESSER-Web-Modeling-Editor` repo URL, Node 20+ to match frontend CI, `docker compose` v2 syntax.

Submodule advanced from `df492a83` -> `799540b8`.

## Test plan

- [x] Frontend: `npm run build` produces `build/webapp/` and `build/server/` cleanly under the renamed workspace
- [x] Frontend: 55 perspective unit tests still green
- [ ] Backend: full pytest suite green (no Python changes; expected to pass)
- [x] Manual smoke after deploy: editor.besser-pearl.org loads, sidebar/perspectives still work