### PR TITLE
fix(supabase): sanitize identifiers, validate user_root, add tests

### DIFF
--- a/besser/generators/supabase/supabase_generator.py
+++ b/besser/generators/supabase/supabase_generator.py
@@ -2,6 +2,7 @@ import os
 import re
 from collections import deque
 from datetime import datetime
+
 from jinja2 import Environment, FileSystemLoader
 
 from besser.BUML.metamodel.structural import (
@@ -28,7 +29,11 @@ class SupabaseGenerator(GeneratorInterface):
         denormalized ``user_id UUID`` column referencing ``public.<user_root>``,
         and RLS policies keyed on ``auth.uid() = user_id``. Association FKs
         pointing AT the user-root are suppressed to avoid duplicate columns.
-      - All identifiers are double-quoted in DDL to bypass reserved words.
+      - All identifiers are double-quoted in DDL and escaped (``"`` doubled to
+        ``""``) before reaching the template, so a malicious model name cannot
+        break out of the quoted identifier and inject DDL.
+      - Enum literal values are escaped (``'`` doubled to ``''``) for the
+        single-quoted ``CREATE TYPE ... AS ENUM`` string.
     """
 
     POSTGRES_TYPES = {
@@ -44,10 +49,50 @@ class SupabaseGenerator(GeneratorInterface):
     }
 
     def __init__(self, model: DomainModel, output_dir: str = None, user_root: str = "User"):
+        """
+        Args:
+            model: Source BUML domain model.
+            output_dir: Where to write the generated ``.sql`` file. Defaults
+                to ``./output``.
+            user_root: Name of the class that mirrors ``auth.users``. Pass
+                ``None`` to skip auth integration entirely.
+        """
         super().__init__(model, output_dir)
         self.user_root_name = user_root
 
+    # ---------------- Sanitization helpers ----------------
+    #
+    # Every name flowing into the SQL template passes through one of these
+    # helpers in the generator (not the template), so the template can render
+    # values verbatim without re-escaping. ``_safe_ident`` is the boundary for
+    # any value that appears inside a double-quoted identifier ("..."), and
+    # ``_safe_string`` is the boundary for any value that appears inside a
+    # single-quoted string literal ('...'). NUL / CR / LF are rejected outright
+    # -- they cannot appear in valid identifiers or single-line literals, and
+    # would almost certainly be an injection or a corrupted model.
+
+    @staticmethod
+    def _reject_control_chars(value: str, kind: str) -> str:
+        if any(c in value for c in ("\0", "\n", "\r")):
+            raise ValueError(
+                f"Invalid character (NUL/CR/LF) in {kind}: {value!r}"
+            )
+        return value
+
+    @classmethod
+    def _safe_ident(cls, name: str) -> str:
+        """Escape ``name`` for inclusion inside a double-quoted Postgres identifier."""
+        return cls._reject_control_chars(name, "identifier").replace('"', '""')
+
+    @classmethod
+    def _safe_string(cls, value: str) -> str:
+        """Escape ``value`` for inclusion inside a single-quoted Postgres string literal."""
+        return cls._reject_control_chars(value, "string literal").replace("'", "''")
+
+    # ---------------- Model introspection ----------------
+
     def _find_user_root(self):
+        """Return the Class named ``self.user_root_name``, or None."""
         if self.user_root_name is None:
             return None
         for cls in self.model.get_classes():
@@ -73,8 +118,9 @@ class SupabaseGenerator(GeneratorInterface):
         return reachable
 
     def _pg_type(self, attr):
+        """Map a BUML attribute to its Postgres type (already safe-quoted for enums)."""
         if isinstance(attr.type, Enumeration):
-            return f'"{attr.type.name.lower()}"'
+            return f'"{self._safe_ident(attr.type.name.lower())}"'
         return self.POSTGRES_TYPES.get(attr.type.name, "TEXT")
 
     def _classes_for_emit(self, user_root):
@@ -92,29 +138,33 @@ class SupabaseGenerator(GeneratorInterface):
         return classes
 
     def _table_name(self, cls):
-        return cls.name.lower()
+        """Pre-escaped, lowercased class name, ready to drop inside ``"..."``."""
+        return self._safe_ident(cls.name.lower())
 
-    def _build_table_columns(self, cls, user_root, per_user, fkeys):
+    # ---------------- Column / table builders ----------------
+
+    def _build_table_columns(self, cls, user_root, per_user):
         """Return list of column-definition strings for a class."""
         is_user_root = (user_root is not None and cls is user_root)
         cols = []
         emitted_pk = False
 
         for attr in sort_by_timestamp(cls.attributes):
+            attr_name = self._safe_ident(attr.name)
             if attr.is_id:
                 if is_user_root:
                     cols.append(
-                        f'"{attr.name}" UUID PRIMARY KEY '
+                        f'"{attr_name}" UUID PRIMARY KEY '
                         f'REFERENCES auth.users(id) ON DELETE CASCADE'
                     )
                 else:
                     cols.append(
-                        f'"{attr.name}" UUID PRIMARY KEY DEFAULT gen_random_uuid()'
+                        f'"{attr_name}" UUID PRIMARY KEY DEFAULT gen_random_uuid()'
                     )
                 emitted_pk = True
             else:
                 null_clause = "" if attr.is_optional else " NOT NULL"
-                cols.append(f'"{attr.name}" {self._pg_type(attr)}{null_clause}')
+                cols.append(f'"{attr_name}" {self._pg_type(attr)}{null_clause}')
 
         # The user-root MUST have an id column referencing auth.users. If the
         # modeler forgot is_id on every attribute, force-emit the canonical id
@@ -155,7 +205,7 @@ class SupabaseGenerator(GeneratorInterface):
             fk_col_names = []
             for end in ends:
                 target_tbl = self._table_name(end.type)
-                col_name = f"{end.name}_id"
+                col_name = self._safe_ident(f"{end.name}_id")
                 fk_col_names.append(col_name)
                 cols.append(
                     f'"{col_name}" UUID NOT NULL '
@@ -180,18 +230,19 @@ class SupabaseGenerator(GeneratorInterface):
             cols.append(f"PRIMARY KEY ({pk_cols})")
 
             yield {
-                "name": assoc.name.lower(),
+                "cls": None,
+                "name": self._safe_ident(assoc.name.lower()),
                 "columns": cols,
                 "is_user_root": False,
                 "is_per_user": is_per_user,
                 "fk_col_names": fk_col_names,
             }
 
-    def _association_fks(self, user_root, per_user, fkeys):
+    def _association_fks(self, user_root, fkeys):
         """
-        Yield (table_name, column_name, target_table, nullable) for each
-        association FK to emit. Suppresses FKs pointing at the user-root,
-        since the denormalized user_id covers them.
+        Yield ``(table, column, target_table, nullable)`` for each association
+        FK to emit via ALTER TABLE. Suppresses FKs pointing AT the user-root
+        because the denormalized ``user_id`` already covers that relationship.
         """
         for assoc in self.model.associations:
             if len(assoc.ends) != 2:
@@ -200,24 +251,37 @@ class SupabaseGenerator(GeneratorInterface):
             if not entry:
                 continue
             fk_class_name, fk_end_name = entry
-            # Locate the end pointing to the FK target
             target_end = next(
                 (e for e in assoc.ends if e.name == fk_end_name), None
             )
             if target_end is None:
                 continue
             target_cls = target_end.type
-            # Suppress FKs pointing at the user-root -- denorm user_id covers it
             if user_root is not None and target_cls is user_root:
                 continue
             yield (
-                fk_class_name.lower(),
-                f"{fk_end_name}_id",
+                self._safe_ident(fk_class_name.lower()),
+                self._safe_ident(f"{fk_end_name}_id"),
                 self._table_name(target_cls),
                 target_end.multiplicity.min == 0,
             )
 
-    def generate(self):
+    def _build_safe_enums(self):
+        """Pre-sanitize enums for the template. Skips enums with no literals."""
+        safe = []
+        for enum in self.model.get_enumerations():
+            if not enum.literals:
+                continue
+            safe.append({
+                "name": self._safe_ident(enum.name.lower()),
+                "literals": [self._safe_string(lit.name) for lit in enum.literals],
+            })
+        return safe
+
+    # ---------------- Render ----------------
+
+    def generate(self) -> None:
+        """Render the SQL file to ``output_dir``. Filename is a Supabase migration-style ``<timestamp>_<slug>.sql``."""
         templates_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")
         env = Environment(
             loader=FileSystemLoader(templates_path),
@@ -227,26 +291,28 @@ class SupabaseGenerator(GeneratorInterface):
         )
         template = env.get_template("supabase_template.sql.j2")
 
+        # Validate model name now so injection attempts via the comment header
+        # surface as a clean ValueError rather than a corrupted SQL file.
+        self._reject_control_chars(self.model.name, "model name")
+
         user_root = self._find_user_root()
         per_user = self._per_user_classes(user_root)
         fkeys = get_foreign_keys(self.model)
 
         classes = self._classes_for_emit(user_root)
-        # Pre-compute column lists so the template stays declarative
         tables = []
         for cls in classes:
             tables.append({
                 "cls": cls,
                 "name": self._table_name(cls),
-                "columns": self._build_table_columns(cls, user_root, per_user, fkeys),
+                "columns": self._build_table_columns(cls, user_root, per_user),
                 "is_user_root": user_root is not None and cls is user_root,
                 "is_per_user": cls in per_user,
             })
-
-        # M:N junction tables come after class tables so their FKs resolve
         tables.extend(self._junction_tables(user_root, per_user))
 
-        fk_alters = list(self._association_fks(user_root, per_user, fkeys))
+        fk_alters = list(self._association_fks(user_root, fkeys))
+        safe_enums = self._build_safe_enums()
 
         # Migration-ready filename: <YYYYMMDDHHMMSS>_<model_slug>.sql is the
         # naming convention expected by `supabase db reset` (which applies
@@ -262,6 +328,7 @@ class SupabaseGenerator(GeneratorInterface):
             user_root=user_root,
             user_root_tbl=self._table_name(user_root) if user_root else None,
             fk_alters=fk_alters,
+            enums=safe_enums,
             filename=filename,
         )
 

--- a/besser/generators/supabase/templates/supabase_template.sql.j2
+++ b/besser/generators/supabase/templates/supabase_template.sql.j2
@@ -21,16 +21,15 @@
 -- project. If targeting a non-Supabase Postgres, uncomment the line below:
 -- CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
-{% set non_empty_enums = model.get_enumerations() | selectattr("literals") | list %}
-{% if non_empty_enums %}
+{% if enums %}
 -- =============================================================================
 -- Enumerations
 -- =============================================================================
-{% for enum in non_empty_enums %}
+{% for enum in enums %}
 DO $$ BEGIN
-    CREATE TYPE "{{ enum.name | lower }}" AS ENUM (
+    CREATE TYPE "{{ enum.name }}" AS ENUM (
 {% for lit in enum.literals %}
-        '{{ lit.name }}'{{ "," if not loop.last else "" }}
+        '{{ lit }}'{{ "," if not loop.last else "" }}
 {% endfor %}
     );
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/besser/utilities/web_modeling_editor/backend/routers/generation_router.py
+++ b/besser/utilities/web_modeling_editor/backend/routers/generation_router.py
@@ -8,6 +8,7 @@ import ast
 import logging
 import os
 import io
+import re
 import uuid
 import zipfile
 import shutil
@@ -862,12 +863,27 @@ async def _generate_sql(buml_model, generator_class, config: dict, temp_dir: str
     return _create_file_response(temp_dir, "sql")
 
 
+_SUPABASE_USER_ROOT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$")
+
+
 async def _generate_supabase(buml_model, generator_class, config: dict, temp_dir: str):
     """Generate Supabase Postgres DDL."""
     user_root = DEFAULT_SUPABASE_USER_ROOT
     if config and "user_root" in config:
-        # Empty string means "skip auth integration entirely"
-        user_root = config["user_root"] or None
+        raw = config["user_root"]
+        if raw == "" or raw is None:
+            # Empty / None means "skip auth integration entirely"
+            user_root = None
+        else:
+            if not isinstance(raw, str) or not _SUPABASE_USER_ROOT_RE.match(raw):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "Invalid user_root: must be a class name matching "
+                        "[A-Za-z_][A-Za-z0-9_]{0,62} (or empty to skip auth integration)."
+                    ),
+                )
+            user_root = raw
 
     generator_instance = generator_class(
         buml_model, output_dir=temp_dir, user_root=user_root

--- a/tests/generators/supabase/test_supabase_generator.py
+++ b/tests/generators/supabase/test_supabase_generator.py
@@ -1,0 +1,213 @@
+"""
+Tests for the Supabase generator.
+
+The generator writes a timestamped filename so each test resolves the
+output via glob rather than a fixed name.
+"""
+import glob
+import os
+
+import pytest
+
+from besser.BUML.metamodel.structural import (
+    BinaryAssociation, Class, DomainModel, Enumeration, EnumerationLiteral,
+    Multiplicity, Property, StringType,
+)
+from besser.generators.supabase import SupabaseGenerator
+
+
+def _read_generated_sql(output_dir: str) -> str:
+    matches = glob.glob(os.path.join(output_dir, "*.sql"))
+    assert len(matches) == 1, f"Expected one .sql file in {output_dir}, got {matches}"
+    with open(matches[0], encoding="utf-8") as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# Library / Book / Author -- shared fixture (no is_id, no user-root)
+# ---------------------------------------------------------------------------
+
+def test_library_model_emits_tables_and_mn_junction(library_book_author_model, tmp_path):
+    out = tmp_path / "out"
+    out.mkdir()
+    SupabaseGenerator(
+        model=library_book_author_model, output_dir=str(out), user_root="User",
+    ).generate()
+    sql = _read_generated_sql(str(out))
+
+    for table in ("library", "book", "author"):
+        assert f'CREATE TABLE IF NOT EXISTS public."{table}"' in sql
+
+    # Author <-->> Book is M:N -> junction with composite PK and both FK columns.
+    assert 'CREATE TABLE IF NOT EXISTS public."book_author"' in sql
+    assert 'REFERENCES public."book"(id) ON DELETE CASCADE' in sql
+    assert 'REFERENCES public."author"(id) ON DELETE CASCADE' in sql
+    assert "PRIMARY KEY (" in sql
+
+    # No user-root in the fixture, so no auth integration and no RLS.
+    assert "handle_new_user" not in sql
+    assert "ENABLE ROW LEVEL SECURITY" not in sql
+
+
+# ---------------------------------------------------------------------------
+# User-rooted model -- exercises auth.users mirror, denormalization, RLS
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def user_rooted_model():
+    """User --< Note (Note transitively per-user)."""
+    user = Class(name="User", attributes={
+        Property(name="id", type=StringType, is_id=True),
+    })
+    note = Class(name="Note", attributes={
+        Property(name="id", type=StringType, is_id=True),
+        Property(name="title", type=StringType),
+        Property(name="body", type=StringType, is_optional=True),
+    })
+
+    user_note = BinaryAssociation(
+        name="user_note",
+        ends={
+            Property(name="user", type=user, multiplicity=Multiplicity(1, 1)),
+            Property(name="notes", type=note, multiplicity=Multiplicity(0, "*")),
+        },
+    )
+
+    return DomainModel(name="UserRootedDemo", types={user, note}, associations={user_note})
+
+
+def test_user_root_mirrors_auth_users(user_rooted_model, tmp_path):
+    out = tmp_path / "out"
+    out.mkdir()
+    SupabaseGenerator(
+        model=user_rooted_model, output_dir=str(out), user_root="User",
+    ).generate()
+    sql = _read_generated_sql(str(out))
+
+    assert 'CREATE TABLE IF NOT EXISTS public."user"' in sql
+    assert "REFERENCES auth.users(id) ON DELETE CASCADE" in sql
+
+    assert "CREATE OR REPLACE FUNCTION public.handle_new_user" in sql
+    assert "SECURITY DEFINER" in sql
+    assert "SET search_path = ''" in sql
+    assert "ON CONFLICT (id) DO NOTHING" in sql
+    assert "AFTER INSERT ON auth.users" in sql
+
+
+def test_per_user_table_gets_denormalized_user_id_and_rls(user_rooted_model, tmp_path):
+    out = tmp_path / "out"
+    out.mkdir()
+    SupabaseGenerator(
+        model=user_rooted_model, output_dir=str(out), user_root="User",
+    ).generate()
+    sql = _read_generated_sql(str(out))
+
+    assert 'CREATE TABLE IF NOT EXISTS public."note"' in sql
+    assert '"user_id" UUID NOT NULL REFERENCES public."user"(id) ON DELETE CASCADE' in sql
+    assert 'CREATE INDEX IF NOT EXISTS "idx_note_user_id" ON public."note"("user_id")' in sql
+
+    # RLS policies follow Supabase best practices.
+    assert 'ALTER TABLE public."note" ENABLE ROW LEVEL SECURITY' in sql
+    assert "TO authenticated" in sql
+    assert '(SELECT auth.uid()) = "user_id"' in sql
+    assert 'WITH CHECK ((SELECT auth.uid()) = "user_id")' in sql
+
+    # Idempotency: every CREATE POLICY is preceded by DROP POLICY IF EXISTS.
+    assert sql.count("DROP POLICY IF EXISTS") >= 4
+    assert sql.count("CREATE POLICY") >= 4
+
+
+def test_is_id_yields_uuid_pk_with_gen_random_uuid(user_rooted_model, tmp_path):
+    """Non-user-root classes with is_id get UUID PRIMARY KEY DEFAULT gen_random_uuid()."""
+    out = tmp_path / "out"
+    out.mkdir()
+    SupabaseGenerator(
+        model=user_rooted_model, output_dir=str(out), user_root="User",
+    ).generate()
+    sql = _read_generated_sql(str(out))
+    assert "UUID PRIMARY KEY DEFAULT gen_random_uuid()" in sql
+
+
+# ---------------------------------------------------------------------------
+# Sanitization -- the security blocker
+#
+# The metamodel rejects names with spaces / hyphens but does NOT reject
+# double-quote, single-quote, or semicolon, so a malicious model can still
+# carry an injection payload past construction. The generator must
+# defang it before emission.
+# ---------------------------------------------------------------------------
+
+def test_double_quote_in_class_name_is_escaped_not_injected(tmp_path):
+    evil = Class(name='evil";DROP_TABLE_x;SELECT_1', attributes={
+        Property(name="id", type=StringType, is_id=True),
+    })
+    model = DomainModel(name="EvilDemo", types={evil}, associations=set())
+
+    out = tmp_path / "out"
+    out.mkdir()
+    SupabaseGenerator(model=model, output_dir=str(out), user_root=None).generate()
+    sql = _read_generated_sql(str(out))
+
+    # The embedded " is doubled so the identifier still terminates correctly.
+    # Table name is lowercased by _table_name(), but the escape rule is the same.
+    assert 'CREATE TABLE IF NOT EXISTS public."evil"";drop_table_x;select_1"' in sql
+    # No raw DROP statement leaked outside the identifier.
+    for line in sql.splitlines():
+        stripped = line.strip().upper()
+        assert not stripped.startswith("DROP TABLE")
+
+
+def test_single_quote_in_enum_literal_is_escaped_not_injected(tmp_path):
+    """Enum literal containing ' must be doubled to '' so it stays inside the string."""
+    evil_enum = Enumeration(name="Status", literals={
+        EnumerationLiteral(name="ok"),
+        EnumerationLiteral(name="bad');DROP_TABLE_x;SELECT_1"),
+    })
+    cls = Class(name="Thing", attributes={
+        Property(name="id", type=StringType, is_id=True),
+        Property(name="status", type=evil_enum),
+    })
+    model = DomainModel(name="EnumEvil", types={cls, evil_enum}, associations=set())
+
+    out = tmp_path / "out"
+    out.mkdir()
+    SupabaseGenerator(model=model, output_dir=str(out), user_root=None).generate()
+    sql = _read_generated_sql(str(out))
+
+    assert "'bad'');DROP_TABLE_x;SELECT_1'" in sql
+    for line in sql.splitlines():
+        stripped = line.strip().upper()
+        assert not stripped.startswith("DROP TABLE")
+
+
+def test_rejects_newline_in_identifier(tmp_path):
+    """NUL/CR/LF surface a clean ValueError instead of corrupting the output."""
+    bad = Class(name="Foo\nbar", attributes={
+        Property(name="id", type=StringType, is_id=True),
+    })
+    model = DomainModel(name="BadName", types={bad}, associations=set())
+
+    out = tmp_path / "out"
+    out.mkdir()
+    with pytest.raises(ValueError, match="Invalid character"):
+        SupabaseGenerator(model=model, output_dir=str(out), user_root=None).generate()
+
+
+# ---------------------------------------------------------------------------
+# Filename / determinism guard
+# ---------------------------------------------------------------------------
+
+def test_filename_is_migration_style(user_rooted_model, tmp_path):
+    out = tmp_path / "out"
+    out.mkdir()
+    SupabaseGenerator(
+        model=user_rooted_model, output_dir=str(out), user_root="User",
+    ).generate()
+
+    matches = glob.glob(os.path.join(str(out), "*.sql"))
+    assert len(matches) == 1
+    name = os.path.basename(matches[0])
+    # <YYYYMMDDHHMMSS>_<slug>.sql
+    assert name.endswith("_userrooteddemo.sql")
+    timestamp = name.split("_", 1)[0]
+    assert timestamp.isdigit() and len(timestamp) == 14


### PR DESCRIPTION
## Summary

Closes the three blockers surfaced by the besser-review on the Supabase generator (PR #537):

1. **SQL identifier injection** — every name flowing into the SQL template now passes through a generator-side \`_safe_ident()\` that doubles embedded double-quotes and rejects NUL/CR/LF. Applied uniformly to class names, attribute names, association end names, FK column names, junction-table names, and enum type names so the template renders pre-sanitized values verbatim.

2. **Enum literal injection** — \`_safe_string()\` doubles single quotes in enum literal values before they reach the \`CREATE TYPE ... AS ENUM\` template. NUL/CR/LF rejected.

3. **user_root not validated at the HTTP boundary** — \`/generate-output\` now rejects \`user_root\` values that don't match \`^[A-Za-z_][A-Za-z0-9_]{0,62}\$\` with HTTP 400, so a malformed config surfaces a clean error instead of flowing through the generator.

Adds \`tests/generators/supabase/\` with 8 cases:
- structural emission on the shared \`library_book_author_model\` fixture
- M:N junction (Author ⇄ Book) composite PK + cascading FKs
- \`auth.users\` mirror via \`handle_new_user\` (SECURITY DEFINER, empty search_path, ON CONFLICT DO NOTHING)
- denormalized \`user_id\` + index + four RLS policies on per-user tables
- UUID PK + \`gen_random_uuid()\` on non-user-root classes with \`is_id\`
- two injection blockers (double-quote in class name, single-quote in enum literal)
- NUL/newline rejection (ValueError)
- migration-style \`<timestamp>_<slug>.sql\` filename

## Test plan

- [x] \`python -m pytest tests/generators/supabase/ -v\` — all 8 pass
- [x] \`python -m pytest tests/generators/ --ignore=tests/generators/nn\` — 190 pass, no regressions
- [x] \`ruff check besser/generators/supabase besser/utilities/web_modeling_editor/backend/routers/generation_router.py tests/generators/supabase/\` — clean
- [ ] CI: backend lint + tests green
- [ ] Manual: regenerate against a real Supabase project, confirm the SQL still applies cleanly after the sanitization changes