### PR TITLE
release: v7.7.1 — wire Supabase config dialog in WME frontend

### DIFF
--- a/docs/source/releases/v7.rst
+++ b/docs/source/releases/v7.rst
@@ -4,6 +4,7 @@ Version 7
 .. toctree::
    :maxdepth: 1
 
+   v7/v7.7.1
    v7/v7.7.0
    v7/v7.6.0
    v7/v7.5.1

--- a/docs/source/releases/v7/v7.7.1.rst
+++ b/docs/source/releases/v7/v7.7.1.rst
@@ -1,0 +1,26 @@
+Version 7.7.1
+=============
+
+Patch release: makes the **Supabase generator** actually reachable from
+the Web Modeling Editor UI. v7.7.0 shipped the generator and the
+backend wiring, but the editor's generator-config dialog was missing
+the prop forwarding for the new Supabase entry, so the dialog crashed
+the moment a user tried to use it. No backend, metamodel, or API
+contract changes — frontend submodule bump only.
+
+Fixes
+-----
+
+* **Web Modeling Editor — Supabase config dialog wiring**: in
+  ``packages/webapp/src/main/app/application.tsx``, the
+  ``GeneratorConfigDialogs`` component destructures
+  ``supabaseUserRoot``, ``onSupabaseUserRootChange`` and
+  ``onSupabaseGenerate``, but ``application.tsx`` never forwarded
+  them from ``useGeneratorExecution``. At runtime the handlers were
+  ``undefined``, so typing in the **User-root class** field or
+  clicking **Generate** threw ``W is not a function`` in the
+  minified bundle and the dialog became unusable. The three props
+  are now forwarded so the dialog behaves as designed in v7.7.0.
+
+Frontend submodule pointer moves from ``fa0fa92b`` to ``077afbdf``;
+that range contains only the prop-forwarding fix above.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = besser
-version = 7.7.0
+version = 7.7.1
 author = Luxembourg Institute of Science and Technology
 description = BESSER
 long_description = file: README.md


### PR DESCRIPTION
## Summary
- Patch release v7.7.1 — fixes the Web Modeling Editor's Supabase config dialog, which crashed with `W is not a function` in the minified v7.7.0 bundle, making the new Supabase generator unreachable from the UI.
- Frontend submodule bump `fa0fa92b → 077afbdf` forwards `supabaseUserRoot`, `onSupabaseUserRootChange` and `onSupabaseGenerate` from `useGeneratorExecution` through `application.tsx` into `GeneratorConfigDialogs`.
- Backend: no code changes — the backend wiring already shipped in v7.7.0 via `e503bb89`.
- `setup.cfg` 7.7.0 → 7.7.1; new `docs/source/releases/v7/v7.7.1.rst`.

## Test plan
- [x] Open the editor, **File → Generate Code → Database → Supabase**, type a user-root class, click Generate — no console crash, SQL file downloads.
- [x] Full docs build: `cd docs && make html` — new v7.7.1 page renders and is indexed under v7.
- [x] CI green (backend tests + ruff + frontend lint/build).
