### PR TITLE
fix(agent): harden BAF generation + docs + round-trip test (7.8.0 review)

### DIFF
--- a/besser/BUML/metamodel/state_machine/agent.py
+++ b/besser/BUML/metamodel/state_machine/agent.py
@@ -2016,6 +2016,14 @@ class Agent(StateMachine):
                     f"Tool '{tool.name}' code must contain at least one "
                     f"top-level 'def' definition."
                 )
+            # The tool name is emitted as a bare function reference in the
+            # generated agent (``agent.new_tool(<name>, ...)``), so it must be
+            # a valid Python identifier matching the callable defined in code.
+            if not (isinstance(tool.name, str) and tool.name.isidentifier()):
+                errors.append(
+                    f"Tool name '{tool.name}' must be a valid Python "
+                    f"identifier matching the function defined in its code."
+                )
 
         # Skill: must have non-empty content.
         for skill in self.skills:

--- a/besser/generators/agents/baf_generator.py
+++ b/besser/generators/agents/baf_generator.py
@@ -15,6 +15,7 @@ from besser.generators.agents.agent_personalization import configure_agent, flat
 
 # BESSER utilities
 from besser.utilities.buml_code_builder.agent_model_builder import agent_model_to_code
+from besser.utilities.buml_code_builder.common import safe_var_name
 from besser.utilities.web_modeling_editor.backend.services.converters import agent_buml_to_json
 
 logger = logging.getLogger(__name__)
@@ -179,6 +180,9 @@ class BAFGenerator(GeneratorInterface):
         env.globals['is_class'] = is_class
         env.globals['is_type'] = is_type
         env.globals['replace_bot_session_with_session_in_signature'] = replace_agent_session_with_session_in_signature
+        # Shared helper so generated identifiers match the code builder and are
+        # always valid Python (handles leading digits, dashes, dots, spaces, …).
+        env.globals['safe_var_name'] = safe_var_name
         agent_template = env.get_template('baf_agent_template.py.j2')
         agent_path = self.build_generation_path(file_name=f"{self.model.name}.py")
         personalized_agent_path = self.build_generation_path(file_name="personalized_agent_model.py")

--- a/besser/generators/agents/templates/baf_agent_template.py.j2
+++ b/besser/generators/agents/templates/baf_agent_template.py.j2
@@ -288,7 +288,7 @@ tts = OpenAIText2Speech(agent=agent, model_name="gpt-4o-mini-tts")
 {% set ic_config_set = namespace(value=false) %}
 {% if config and "intentRecognitionTechnology" in config and config["intentRecognitionTechnology"] == 'llm-based' %}
 ic_config = LLMIntentClassifierConfiguration(
-    llm_name='{{ ic_llm_ns.name }}',
+    llm_name={{ ic_llm_ns.name | string | tojson }},
     parameters={},
     use_intent_descriptions=True,
     use_training_sentences=True,
@@ -323,9 +323,9 @@ agent.set_default_ic_config(ic_config)
 # LLMs
 {% set default_llm_ns = namespace(name=None) %}
 {% for llm in agent.llms %}
-{{ llm.name | replace('-', '_') | replace('.', '_') | replace(' ', '_') }} = {{ llm.__class__.__name__ }}(
+{{ safe_var_name(llm.name) }} = {{ llm.__class__.__name__ }}(
     agent=agent,
-    name='{{ llm.name }}',
+    name={{ llm.name | string | tojson }},
     {% if llm.parameters %}
     parameters={{ llm.parameters }},
     {% else %}
@@ -342,7 +342,7 @@ agent.set_default_ic_config(ic_config)
 {% set default_llm_ns.name = llm.name %}
 {% endif %}
 {% endfor %}
-default_llm = {{ default_llm_ns.name | replace('-', '_') | replace('.', '_') | replace(' ', '_') }}
+default_llm = {{ safe_var_name(default_llm_ns.name) }}
 {% set has_default_llm_state.value = true %}
 {% endif %}
 {% if not has_default_llm_state.value %}
@@ -365,7 +365,7 @@ agent.set_default_ic_config({{ write_ic_config(agent.default_ic_config) }})
 {% if not ic_config_set.value %}
 # Default to LLM-based intent classification (avoids PyTorch dependency)
 ic_config = LLMIntentClassifierConfiguration(
-    llm_name='{{ ic_llm_ns.name }}',
+    llm_name={{ ic_llm_ns.name | string | tojson }},
     parameters={},
     use_intent_descriptions=True,
     use_training_sentences=True,
@@ -533,7 +533,7 @@ router_initial_state = agent.new_state('router_initial_state', initial=True)
 {{ state.name }} = new_reasoning_state(
     agent=agent,
     {% if state.llm %}
-    llm={{ state.llm | replace('-', '_') | replace('.', '_') | replace(' ', '_') }},
+    llm={{ safe_var_name(state.llm) }},
     {% else %}
     llm=default_llm,
     {% endif %}

--- a/besser/utilities/buml_code_builder/agent_model_builder.py
+++ b/besser/utilities/buml_code_builder/agent_model_builder.py
@@ -181,7 +181,7 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
                     f"{llm_var} = {model_var_name}.new_llm(\n"
                     f"    name={repr(llm.name)},\n"
                     f"    provider={repr(provider)},\n"
-                    f"    parameters={repr(params)},\n"
+                    f"    parameters={repr(dict(sorted(params.items())))},\n"
                 )
                 num_prev = getattr(llm, 'num_previous_messages', None)
                 if num_prev is not None and num_prev != 1:

--- a/docs/source/releases/v7/v7.8.0.rst
+++ b/docs/source/releases/v7/v7.8.0.rst
@@ -3,9 +3,12 @@ Version 7.8.0
 
 Minor release headlined by **agent reasoning state support** and
 **multi-LLM configuration** in the BAF (BESSER Agent Framework) code
-generator.  The changes are entirely contained in the BAF generator
-template and the agent-model code builder; no metamodel or API contract
-changes.
+generator.  It adds new agent metamodel classes (``ReasoningState``,
+``Tool``, ``Skill``, ``Workspace``) and multi-LLM factory methods on
+``Agent`` (``new_llm``, ``set_default_llm``, ``new_tool``, ``new_skill``,
+``new_workspace``, ``new_reasoning_state``), surfaced through the BAF
+generator template, the agent-model code builder, and the JSON↔B-UML
+converters.
 
 Agent Reasoning State and Multi-LLM Support
 --------------------------------------------------
@@ -50,10 +53,11 @@ Reasoning State support
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 * Added code generation for ``ReasoningState`` objects: the generator
-  detects reasoning states in the agent model, instantiates them with
-  the appropriate LLM reference and configuration, and emits the
-  necessary import (``from besser.agent.core.reasoning.reasoning_state
-  import ReasoningState``).
+  detects reasoning states in the agent model and emits a
+  ``new_reasoning_state(...)`` call with the appropriate LLM reference
+  (falling back to ``default_llm``) and configuration
+  (``max_steps``, ``enable_task_planning``, ``stream_steps``,
+  ``system_prompt``, ``fallback_message``).
 
 Internal refactoring
 ~~~~~~~~~~~~~~~~~~~~
@@ -61,7 +65,7 @@ Internal refactoring
 * Updated imports in ``besser/utilities/buml_code_builder/agent_model_builder.py``
   to include ``ReasoningState``, ``Tool``, ``Skill``, and ``Workspace``
   as well as the helper functions required by the new generation logic.
-* The BAF generator template (``besser/generators/baf/templates/``) has
-  been refactored for improved modularity, readability, and
+* The BAF generator template (``besser/generators/agents/templates/``)
+  has been refactored for improved modularity, readability, and
   extensibility.
 

--- a/tests/utilities/web_modeling_editor/backend/services/converters/test_agent_converter_roundtrip.py
+++ b/tests/utilities/web_modeling_editor/backend/services/converters/test_agent_converter_roundtrip.py
@@ -1,0 +1,62 @@
+"""Round-trip tests for the agent converters covering the multi-LLM and
+reasoning-extension surface added in 7.8.0.
+
+Direction exercised: Agent (B-UML) -> generated B-UML code -> JSON (buml_to_json)
+-> Agent (json_to_buml). The new fields (multiple LLMs + designated default,
+per-reasoning-state LLM, tools/skills/workspaces) must survive the trip.
+"""
+import os
+
+from besser.BUML.metamodel.state_machine.agent import Agent, ReasoningState
+from besser.utilities.buml_code_builder.agent_model_builder import agent_model_to_code
+from besser.utilities.web_modeling_editor.backend.services.converters import (
+    agent_buml_to_json,
+    process_agent_diagram,
+)
+
+
+def _build_reasoning_agent() -> Agent:
+    agent = Agent("RoundTripAgent")
+    agent.new_llm(name="fast", provider="openai", parameters={"model": "gpt-4o-mini"})
+    agent.new_llm(name="big", provider="openai", parameters={"model": "gpt-4o"})
+    agent.set_default_llm("big")
+    agent.new_tool(name="lookup", description="Look things up", code="def lookup(x):\n    return x")
+    agent.new_skill(name="greet", content="Be friendly", description="greeting skill")
+    agent.new_workspace(
+        name="docs", path="/tmp/docs", description="doc store", writable=True, max_read_bytes=1000
+    )
+    initial = agent.new_state("initial", initial=True)
+    reason = agent.new_reasoning_state(name="reason", llm="fast", max_steps=5, system_prompt="Think.")
+    initial.go_to(reason)
+    return agent
+
+
+def test_agent_roundtrip_preserves_multi_llm_and_reasoning(tmp_path):
+    agent = _build_reasoning_agent()
+    code_path = os.path.join(str(tmp_path), "agent.py")
+    agent_model_to_code(agent, code_path)
+    with open(code_path, encoding="utf-8") as handle:
+        content = handle.read()
+
+    json_model = agent_buml_to_json(content)
+    # process_agent_diagram consumes the frontend envelope: the apollon model
+    # under "model" and the diagram config surfaced at the top level.
+    restored = process_agent_diagram({"model": json_model, "config": json_model.get("config", {})})
+
+    # Multi-LLM: both LLMs and the designated default survive.
+    assert {llm.name for llm in restored.llms} == {"fast", "big"}
+    assert restored.default_llm_name == "big"
+
+    # Reasoning state: present, bound to its LLM by name, config preserved.
+    reasoning_states = [s for s in restored.states if isinstance(s, ReasoningState)]
+    assert len(reasoning_states) == 1
+    assert reasoning_states[0].llm == "fast"
+    assert reasoning_states[0].max_steps == 5
+
+    # Reasoning primitives survive with their distinguishing fields.
+    assert {t.name for t in restored.tools} == {"lookup"}
+    assert {s.name for s in restored.skills} == {"greet"}
+    workspaces = {w.name: w for w in restored.workspaces}
+    assert set(workspaces) == {"docs"}
+    assert workspaces["docs"].path == "/tmp/docs"
+    assert workspaces["docs"].writable is True


### PR DESCRIPTION
Addresses the blocker + most majors from the 7.8.0 release review (backend side).

## Fixed
- **[blocker] Invalid/unsafe generated identifiers** — the BAF template built LLM/reasoning-state variable names with a naive `replace()` chain (broke on leading digits, special chars; diverged from the code builder). Now uses the shared `safe_var_name` helper, exposed as a Jinja global.
- **[major] Unescaped string interpolation** — LLM `name` and IC `llm_name` were emitted as raw single-quoted `'{{ … }}'`; now via `| tojson` (matches the skill/workspace fields).
- **[major] Tool name safety (root cause)** — `Tool.name` is emitted as a bare function reference in the generated agent, so the metamodel now rejects names that are not valid Python identifiers (collected in `validate()`).
- **[major] Non-deterministic output** — LLM `parameters` dict is now emitted sorted in the code builder.
- **[major] Inaccurate release notes** — v7.8.0 notes claimed "no metamodel or API contract changes" (it adds `ReasoningState/Tool/Skill/Workspace` + factories); fixed that, the reasoning-state import wording, and the generator template path (`agents/`, not `baf/`).
- **[major] Missing round-trip test** — added a JSON↔B-UML agent converter round-trip covering multi-LLM + default, per-state LLM, reasoning state, and tools/skills/workspaces. (Writing it surfaced — and confirmed — that the two converters compose only via the `{model, config}` frontend envelope; symmetry itself holds.)

## Deferred (need installed BAF runtime to verify — not done here)
- The generated reasoning-state import path (`from baf.library.state import new_reasoning_state`) and the `new_tool(..., code=)` signature parity between template and code builder. BAF is not importable in this environment, so I left these and flag them for verification against the installed package.

Verified: `ruff` (CI ruleset) clean; 174 agent/reasoning/baf/round-trip tests pass.