### PR TITLE
fix(agent): BAF v4.4.0 compliance — new_skill source positional

### DIFF
--- a/besser/generators/agents/templates/baf_agent_template.py.j2
+++ b/besser/generators/agents/templates/baf_agent_template.py.j2
@@ -391,8 +391,8 @@ agent.new_tool({{ tool.name }}, description={{ tool.description | string | tojso
 ##############################
 {% for skill in agent.skills %}
 agent.new_skill(
-    name={{ skill.name | string | tojson }},
-    content={{ skill.content | string | tojson }}{% if skill.description %},
+    {{ skill.content | string | tojson }},
+    name={{ skill.name | string | tojson }}{% if skill.description %},
     description={{ skill.description | string | tojson }}{% endif %}
 )
 {% endfor %}

--- a/tests/generators/agents/test_baf_generator_reasoning.py
+++ b/tests/generators/agents/test_baf_generator_reasoning.py
@@ -108,6 +108,10 @@ class TestBAFGeneratorReasoning:
             code = f.read()
         assert "agent.new_skill(" in code
         assert "GreetByName" in code
+        # BAF's new_skill takes the skill text as the positional ``source``
+        # argument, not a ``content=`` kwarg (which would raise TypeError).
+        assert "content=" not in code
+        assert "Always greet the user by name when introduced." in code
 
     def test_emits_workspace_registration(self, reasoning_agent_model, tmp_path):
         path = _generate(reasoning_agent_model, str(tmp_path))


### PR DESCRIPTION
Compliance check of the generated agent code against **BESSER-Agentic-Framework v4.4.0** (latest, released today).

## Bug fixed
BAF `Agent.new_skill(source: str, name=None, description=None)` takes the skill text as the positional **`source`**. The BAF generator template emitted `agent.new_skill(name=..., content=..., description=...)` — `content` is not a BAF parameter, so any generated agent defining a skill crashed at construction:
`TypeError: new_skill() got an unexpected keyword argument 'content'` (and missing required `source`).

Now emits the content as the positional `source`; test strengthened to assert `content=` is absent and the skill text is present.

## Confirmed compliant with v4.4.0 (no change needed)
- `from baf.library.state import new_reasoning_state` — exported in `__all__`.
- `new_reasoning_state(agent, llm: LLM, name, initial, max_steps, system_prompt, fallback_message, enable_task_planning, stream_steps)` — generated kwargs all valid; passes the LLM object.
- `new_tool(fn: Callable, name=None, description=None)` — generated `new_tool(<fn>, description=...)` matches (the earlier "divergence from the code builder" was a false alarm; the builder targets the B-UML metamodel, the template targets the BAF runtime).
- `new_workspace(path, name="workspace", description=None, writable=True, max_read_bytes=200_000)` — generated kwargs all valid.

Targets `development`; flows into the v7.8.0 release PR #543.