### PR TITLE
release: v7.8.3 — agent transition normalization + variant edit persistence

### DIFF
--- a/docs/source/releases/v7.rst
+++ b/docs/source/releases/v7.rst
@@ -4,6 +4,7 @@ Version 7
 .. toctree::
    :maxdepth: 1
 
+   v7/v7.8.3
    v7/v7.8.2
    v7/v7.8.1
    v7/v7.8.0

--- a/docs/source/releases/v7/v7.8.3.rst
+++ b/docs/source/releases/v7/v7.8.3.rst
@@ -1,0 +1,53 @@
+Version 7.8.3
+=============
+
+Patch release: **agent transitions no longer collapse to**
+``when_no_intent_matched`` **when a personalized agent project is imported**,
+and free-hand edits to a personalized variant are no longer discarded when
+switching between the base and a variant. This is a **frontend-only** release —
+no metamodel, generator, or backend API changes; the only backend-repo change is
+the web-modeling-editor submodule pointer bump (frontend PR
+`#139 <https://github.com/BESSER-PEARL/BESSER-Web-Modeling-Editor/pull/139>`_,
+thanks to Aaron).
+
+Fixes
+-----
+
+* **Imported agent base models flattened every transition**: agent transitions
+  exist in two JSON shapes — a legacy *flat* shape (top-level ``condition`` /
+  ``conditionValue``) and the canonical *nested* shape (``transitionType`` plus
+  ``predefined`` / ``custom`` blocks). The Apollon editor upgrades flat to nested
+  whenever a diagram is loaded, but the ``agentBaseModels`` snapshot bundled in an
+  imported project (e.g. the *Personalized Gym Agent* template) was written
+  straight to ``localStorage`` in the flat shape, bypassing that upgrade. The
+  backend agent processor only understands the nested shape, so on Save & Apply it
+  defaulted every flat transition to ``when_no_intent_matched`` — silently
+  destroying the agent's routing. The fix normalizes agent models to the canonical
+  nested shape at the single storage write boundary (reusing the editor's own
+  ``AgentStateTransition`` serializer rather than a second mapper), so the flat
+  shape can no longer be persisted. A one-time ``v3 → v4`` storage migration
+  upgrades snapshots already sitting in users' ``localStorage`` from before the
+  fix, and the legacy flat shape is purged from the bundled project and agent
+  templates at rest.
+
+* **Variant edits lost on base ⇄ variant switch**: switching between the
+  un-personalized base and a personalized variant replaced the live diagram with
+  the stored snapshot without first writing back the current canvas edits, so any
+  unsaved change made while viewing a variant (or the base) was discarded on
+  switch. The switch handler now persists the live model back into its source —
+  the active variant's inline snapshot, or the stored base model — before loading
+  the target.
+
+* **BAF generation now ships the un-personalized base**: generating with
+  "Personalization (all)" previously shipped whichever variant happened to be
+  active in the editor as the primary model, so every other variant was layered on
+  top of that variant instead of the original base. Generation now injects the
+  stored un-personalized base model; "None" mode is unchanged.
+
+Tests
+-----
+
+* Frontend unit tests cover the agent-model normalizer (flat → nested across each
+  predefined condition type, idempotency, geometry preservation,
+  ``AgentStateTransitionInit`` left untouched) and the storage normalization path
+  (``saveAgentBaseModel`` and the ``v4`` migration).

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = besser
-version = 7.8.2
+version = 7.8.3
 author = Luxembourg Institute of Science and Technology
 description = BESSER
 long_description = file: README.md


### PR DESCRIPTION
## Summary
Frontend-only patch release (v7.8.3). No backend, metamodel, generator, or API changes — the only backend-repo change is the web-modeling-editor submodule pointer bump.

- **Agent transitions no longer collapse to `when_no_intent_matched`** on import: the bundled `agentBaseModels` snapshot was persisted to `localStorage` in the legacy flat shape, bypassing the editor's nested-shape upgrade. Models are now normalized to the canonical nested shape at the single storage write boundary (reusing the editor's `AgentStateTransition` serializer), with a one-time `v3 → v4` migration for snapshots already in users' storage, and the flat shape is purged from the templates at rest.
- **Variant edits no longer lost on base ⇄ variant switch**: the switch handler now writes the live model back into its source (variant snapshot or stored base) before loading the target.
- **BAF generation with "Personalization (all)"** ships the un-personalized base instead of the active variant.

Frontend changes merged via [#139](https://github.com/BESSER-PEARL/BESSER-Web-Modeling-Editor/pull/139); frontend `develop` → `main` sync PR opened alongside this one.

## Test plan
- [ ] Import the **Personalized Gym Agent** project → Save & Apply → transitions stay `when_intent_matched` / `auto` (not `when_no_intent_matched`).
- [ ] Generate → BAF Agent → "Personalization (all)" → each ZIP variant derives from the un-personalized base; "None" still emits the active model.
- [ ] On the agent diagram, edit a variant → switch to base → switch back → edits persist.
- [ ] Existing `besser_agentBaseModels` with a flat snapshot is normalized on next launch (`migrateToV4`).
- [ ] Full docs build: `cd docs && make html` — new v7.8.3 page renders.