### PR TITLE
release: v7.9.0 — agent action types, reasoning states & editor expansion

### DIFF
--- a/besser/BUML/metamodel/state_machine/agent.py
+++ b/besser/BUML/metamodel/state_machine/agent.py
@@ -187,6 +187,91 @@ class WebCrawlLLMReply(Action):
         )
 
 
+class WebSocketReplyMarkdown(Action):
+    """Send a Markdown-formatted text reply via WebSocketPlatform.reply_markdown()."""
+
+    def __init__(self, message: str = ""):
+        super().__init__()
+        self.message: str = message
+
+    def __repr__(self):
+        return f"WebSocketReplyMarkdown(message={self.message!r})"
+
+
+class WebSocketReplyHTML(Action):
+    """Send an HTML-formatted text reply via WebSocketPlatform.reply_html()."""
+
+    def __init__(self, message: str = ""):
+        super().__init__()
+        self.message: str = message
+
+    def __repr__(self):
+        return f"WebSocketReplyHTML(message={self.message!r})"
+
+
+class WebSocketReplySpeech(Action):
+    """Convert text to speech and send the audio via WebSocketPlatform.reply_speech()."""
+
+    def __init__(self, message: str = "", audio_speed: Optional[float] = None):
+        super().__init__()
+        self.message: str = message
+        self.audio_speed: Optional[float] = audio_speed
+
+    def __repr__(self):
+        return f"WebSocketReplySpeech(message={self.message!r}, audio_speed={self.audio_speed!r})"
+
+
+class WebSocketReplyOptions(Action):
+    """Send a list of selectable options via WebSocketPlatform.reply_options()."""
+
+    def __init__(self, options: Optional[list] = None):
+        super().__init__()
+        self.options: list = options if options is not None else []
+
+    def __repr__(self):
+        return f"WebSocketReplyOptions(options={self.options!r})"
+
+
+class WebSocketReplyLocation(Action):
+    """Send a geographic location reply via WebSocketPlatform.reply_location()."""
+
+    def __init__(self, latitude: float = 0.0, longitude: float = 0.0):
+        super().__init__()
+        self.latitude: float = latitude
+        self.longitude: float = longitude
+
+    def __repr__(self):
+        return f"WebSocketReplyLocation(latitude={self.latitude!r}, longitude={self.longitude!r})"
+
+
+class WebSocketReplyFile(Action):
+    """Send a file reply via WebSocketPlatform.reply_file(). Requires a runtime File object."""
+
+    def __repr__(self):
+        return "WebSocketReplyFile()"
+
+
+class WebSocketReplyImage(Action):
+    """Send an image reply via WebSocketPlatform.reply_image(). Requires a runtime numpy ndarray."""
+
+    def __repr__(self):
+        return "WebSocketReplyImage()"
+
+
+class WebSocketReplyDataframe(Action):
+    """Send a DataFrame reply via WebSocketPlatform.reply_dataframe(). Requires a runtime pandas DataFrame."""
+
+    def __repr__(self):
+        return "WebSocketReplyDataframe()"
+
+
+class WebSocketReplyPlotly(Action):
+    """Send a Plotly figure reply via WebSocketPlatform.reply_plotly(). Requires a runtime plotly Figure."""
+
+    def __repr__(self):
+        return "WebSocketReplyPlotly()"
+
+
 class DBReply(Action):
     """Primitive action that represents fetching information from a database.
 

--- a/besser/BUML/metamodel/state_machine/agent.py
+++ b/besser/BUML/metamodel/state_machine/agent.py
@@ -117,6 +117,76 @@ class RAGReply(Action):
         return f"RAGReply(rag_db_name={self.rag_db_name!r}, prompt={self.prompt!r})"
 
 
+class WebCrawlLLMReply(Action):
+    """Crawls a website (or reuses a cached result) and queries an LLM with the content.
+
+    Args:
+        initial_url (str): Target URL. Used as BFS start point when run_crawl=True,
+            or as the session-key suffix when run_crawl=False.
+        max_depth (int): Maximum link depth to follow. Used only when run_crawl=True.
+        max_pages (int): Maximum number of pages to fetch. Used only when run_crawl=True.
+        crawl_format (str): Output format for crawled content ("markdown" or "html").
+        base_url_prefix (str, optional): Only URLs starting with this prefix are included.
+            Used only when run_crawl=True.
+        run_crawl (bool): When True, the crawl runs and its result is stored in the session
+            under the key ``f"web_crawl_{initial_url}"``. When False, reads from that key.
+        no_crawl_error_message (str): Reply sent when run_crawl=False and no cached result
+            is found in the session.
+        system_message_prefix (str, optional): Prepended to the crawl result when building
+            the LLM system message. Defaults to a generic instruction when None.
+        llm_name (str, optional): Name of the LLM to use. Falls back to the agent default.
+
+    Attributes:
+        initial_url (str): Target URL.
+        max_depth (int): Maximum link depth.
+        max_pages (int): Maximum number of pages.
+        crawl_format (str): Output format ("markdown" or "html").
+        base_url_prefix (str | None): Optional URL prefix filter.
+        run_crawl (bool): Whether to execute the crawl.
+        no_crawl_error_message (str): Error reply when no cached data exists.
+        system_message_prefix (str | None): Prefix for the LLM system message.
+        llm_name (str | None): Name of the LLM to use.
+    """
+
+    def __init__(
+        self,
+        initial_url: str = "",
+        max_depth: int = 2,
+        max_pages: int = 20,
+        crawl_format: str = "markdown",
+        base_url_prefix: Optional[str] = None,
+        run_crawl: bool = True,
+        no_crawl_error_message: str = "No web crawl data is available yet.",
+        system_message_prefix: Optional[str] = None,
+        llm_name: Optional[str] = None,
+    ):
+        super().__init__()
+        self.initial_url: str = initial_url
+        self.max_depth: int = max_depth
+        self.max_pages: int = max_pages
+        self.crawl_format: str = crawl_format
+        self.base_url_prefix: Optional[str] = base_url_prefix
+        self.run_crawl: bool = run_crawl
+        self.no_crawl_error_message: str = no_crawl_error_message
+        self.system_message_prefix: Optional[str] = system_message_prefix
+        self.llm_name: Optional[str] = llm_name
+
+    def __repr__(self):
+        return (
+            "WebCrawlLLMReply("
+            f"initial_url={self.initial_url!r}, "
+            f"max_depth={self.max_depth!r}, "
+            f"max_pages={self.max_pages!r}, "
+            f"crawl_format={self.crawl_format!r}, "
+            f"base_url_prefix={self.base_url_prefix!r}, "
+            f"run_crawl={self.run_crawl!r}, "
+            f"no_crawl_error_message={self.no_crawl_error_message!r}, "
+            f"system_message_prefix={self.system_message_prefix!r}, "
+            f"llm_name={self.llm_name!r}"
+            ")"
+        )
+
+
 class DBReply(Action):
     """Primitive action that represents fetching information from a database.
 

--- a/besser/BUML/metamodel/state_machine/agent.py
+++ b/besser/BUML/metamodel/state_machine/agent.py
@@ -597,7 +597,15 @@ class RAG(NamedElement):
 
         vector_store = Chroma(...)
         splitter = RecursiveCharacterTextSplitter(...)
-        rag = RAG(agent=agent, vector_store=vector_store, splitter=splitter, llm_name='gpt-4o-mini', k=4, num_previous_messages=0)
+        rag = RAG(
+            agent=agent,
+            vector_store=vector_store,
+            splitter=splitter,
+            llm_name='gpt-4o-mini',
+            llm_prompt='Use only trusted corpus facts.',
+            k=4,
+            num_previous_messages=0,
+        )
 
     Args:
         name (str): Logical name of the RAG resource.
@@ -605,6 +613,7 @@ class RAG(NamedElement):
         vector_store (RAGVectorStore): Vector store definition.
         splitter (RAGTextSplitter): Chunking strategy definition.
         llm_name (str): Identifier of the LLM used to synthesize answers.
+        llm_prompt (str | None): Optional prefix instructions injected before each RAG prompt.
         k (int): Number of chunks retrieved per question.
         num_previous_messages (int): Conversation context depth forwarded to the LLM.
     """
@@ -616,6 +625,7 @@ class RAG(NamedElement):
             vector_store: RAGVectorStore,
             splitter: RAGTextSplitter,
             llm_name: str,
+            llm_prompt: Optional[str] = None,
             k: int = 4,
             num_previous_messages: int = 0,
     ):
@@ -624,6 +634,7 @@ class RAG(NamedElement):
         self.vector_store: RAGVectorStore = vector_store
         self.splitter: RAGTextSplitter = splitter
         self.llm_name: str = llm_name
+        self.llm_prompt: Optional[str] = llm_prompt
         self.k: int = k
         self.num_previous_messages: int = num_previous_messages
 
@@ -1768,6 +1779,7 @@ class Agent(StateMachine):
             vector_store: RAGVectorStore,
             splitter: RAGTextSplitter,
             llm_name: str,
+            llm_prompt: Optional[str] = None,
             k: int = 4,
             num_previous_messages: int = 0,
     ) -> RAG:
@@ -1781,6 +1793,7 @@ class Agent(StateMachine):
             vector_store=vector_store,
             splitter=splitter,
             llm_name=llm_name,
+            llm_prompt=llm_prompt,
             k=k,
             num_previous_messages=num_previous_messages,
         )

--- a/besser/BUML/metamodel/state_machine/agent.py
+++ b/besser/BUML/metamodel/state_machine/agent.py
@@ -73,6 +73,29 @@ class LLMReply(Action):
         return f"LLMReply(prompt={self.prompt!r}, llm_name={self.llm_name!r})"
 
 
+class LLMChatReply(Action):
+    """Primitive action that represents sending a chat-style reply using an LLM.
+
+    Args:
+        prompt (str, optional): Additional system prompt injected in the chat call.
+        llm_name (str, optional): Name of the LLM (registered on the agent via
+            :meth:`Agent.new_llm`) that should serve this reply. ``None`` lets
+            the generator fall back to the agent's default LLM.
+
+    Attributes:
+        prompt (str | None): Optional system prompt used by ``llm.chat(...)``.
+        llm_name (str | None): Name of the LLM used for this reply.
+    """
+
+    def __init__(self, prompt: Optional[str] = None, llm_name: Optional[str] = None):
+        super().__init__()
+        self.prompt: Optional[str] = prompt
+        self.llm_name: Optional[str] = llm_name
+
+    def __repr__(self):
+        return f"LLMChatReply(prompt={self.prompt!r}, llm_name={self.llm_name!r})"
+
+
 class RAGReply(Action):
     """Primitive action that represents sending a reply using a configured RAG pipeline.
 
@@ -1972,9 +1995,9 @@ class Agent(StateMachine):
                 if body is None or not getattr(body, "actions", None):
                     continue
                 for action in body.actions:
-                    if isinstance(action, LLMReply):
+                    if isinstance(action, (LLMReply, LLMChatReply)):
                         _check(
-                            f"State '{state.name}' {label} LLMReply",
+                            f"State '{state.name}' {label} {action.__class__.__name__}",
                             action.llm_name,
                         )
                     elif isinstance(action, DBReply) and action.db_query_mode == "llm_query":

--- a/besser/BUML/metamodel/state_machine/state_machine.py
+++ b/besser/BUML/metamodel/state_machine/state_machine.py
@@ -63,11 +63,11 @@ class CustomCodeAction(Action):
 
     def __init__(self, source: str = None, callable: Callable = None):
         if callable is not None:
-            src = inspect.getsource(callable)
-            self.code = textwrap.dedent(src)
+            self.code = inspect.getsource(callable)
+        elif source is not None:
+            self.code = textwrap.dedent(source)
         else:
-            self.code = textwrap.dedent(source) if source else ""
-
+            self.code = None
     def to_code(self) -> str:
         return self.code
 

--- a/besser/generators/agents/agent_personalization.py
+++ b/besser/generators/agents/agent_personalization.py
@@ -173,18 +173,15 @@ def translate_text_api(text, target_language):
 def style_text_batch(texts, style, model="gpt-5", openai_api_key=None, config=None):
     """
     Rewrites each text in `texts` to the requested `style` while preserving meaning and content.
-    `style` should be 'formal' or 'informal'.
+    `style` should be one of 'formal', 'informal', 'friendly', or 'technical'.
     Returns a list of rewritten texts in the same order as input.
     """
     if not isinstance(texts, (list, tuple)):
         raise TypeError("texts must be a list or tuple of strings")
 
     style = (style or '').lower()
-    if style not in ('formal', 'informal'):
-        raise ValueError("style must be 'formal' or 'informal'")
-
-    if style == 'formal':
-        system_prompt = (
+    style_prompts = {
+        'formal': (
             "you are a professional editor specializing in formal writing. "
             "for each numbered text below, transform it into a formal, polished version while preserving its original meaning and intent. "
             "requirements: - use formal tone and vocabulary suitable for professional or academic contexts "
@@ -193,9 +190,8 @@ def style_text_batch(texts, style, model="gpt-5", openai_api_key=None, config=No
             "- keep the length and structure close to the original unless improvement requires rephrasing "
             "- maintain clarity and natural flow. "
             "return the rewritten texts as a numbered list, matching the input order, with no explanations."
-        )
-    else:  # informal
-        system_prompt = (
+        ),
+        'informal': (
             "you are a professional writer specializing in natural, conversational language. "
             "for each numbered text below, transform it into an informal, friendly version while keeping its original meaning and intent. "
             "requirements: - use a casual and approachable tone "
@@ -204,7 +200,32 @@ def style_text_batch(texts, style, model="gpt-5", openai_api_key=None, config=No
             "- make it sound like something someone would say in conversation "
             "- keep the length and structure close to the original unless rewording improves flow. "
             "return the rewritten texts as a numbered list, matching the input order, with no explanations."
-        )
+        ),
+        'friendly': (
+            "you are a warm, personable writer specializing in welcoming, encouraging language. "
+            "for each numbered text below, transform it into a friendly version while keeping its original meaning and intent. "
+            "requirements: - use a warm, approachable, and supportive tone "
+            "- prefer positive, encouraging phrasing and inclusive language (e.g. 'let's', 'happy to help') "
+            "- contractions and light, genuine enthusiasm are welcome, but avoid being over-the-top or using slang "
+            "- keep grammar correct and the message clear "
+            "- keep the length and structure close to the original unless rewording improves warmth. "
+            "return the rewritten texts as a numbered list, matching the input order, with no explanations."
+        ),
+        'technical': (
+            "you are a technical writer specializing in precise, domain-accurate language. "
+            "for each numbered text below, transform it into a technical version while preserving its original meaning and intent. "
+            "requirements: - use precise terminology and unambiguous phrasing suitable for an expert audience "
+            "- be concise and direct; remove filler, hedging, and colloquialisms "
+            "- preserve any specific facts, values, or steps exactly "
+            "- keep grammar and punctuation correct "
+            "- keep the length and structure close to the original unless precision requires rephrasing. "
+            "return the rewritten texts as a numbered list, matching the input order, with no explanations."
+        ),
+    }
+    if style not in style_prompts:
+        raise ValueError(f"style must be one of {', '.join(sorted(style_prompts))}")
+
+    system_prompt = style_prompts[style]
 
     # Combine all texts into a single prompt with numbering for clarity
     user_prompt = "\n".join(f"{i+1}. {text}" for i, text in enumerate(texts))

--- a/besser/generators/agents/baf_generator.py
+++ b/besser/generators/agents/baf_generator.py
@@ -302,6 +302,30 @@ class BAFGenerator(GeneratorInterface):
                 f.write(generated_code)
             logger.info("Agent readme file generated at %s", readme_path)
 
+            # Generate tools.py — one file containing all tool function definitions
+            tools = getattr(self.model, 'tools', []) or []
+            if tools:
+                tools_path = self.build_generation_path(file_name="tools.py")
+                with open(tools_path, mode="w", encoding="utf-8") as f:
+                    f.write("# Auto-generated tool definitions\n\n")
+                    for tool in tools:
+                        f.write(tool.code)
+                        if not tool.code.endswith('\n'):
+                            f.write('\n')
+                        f.write('\n')
+                logger.info("Tools file generated at %s", tools_path)
+
+            # Generate skills/ directory — one .md file per skill
+            skills = getattr(self.model, 'skills', []) or []
+            if skills:
+                skills_dir = os.path.join(self.build_generation_dir(), "skills")
+                os.makedirs(skills_dir, exist_ok=True)
+                for skill in skills:
+                    skill_file = os.path.join(skills_dir, f"{skill.name}.md")
+                    with open(skill_file, mode="w", encoding="utf-8") as f:
+                        f.write(skill.content)
+                logger.info("Skills directory generated at %s", skills_dir)
+
             rag_configs = getattr(self.model, 'rags', []) or []
             if rag_configs:
                 rag_base_dir = self.build_generation_dir()

--- a/besser/generators/agents/baf_generator.py
+++ b/besser/generators/agents/baf_generator.py
@@ -2,6 +2,7 @@ import logging
 import os
 import textwrap
 from enum import Enum
+from typing import Optional
 
 from jinja2 import Environment, FileSystemLoader
 import json
@@ -100,9 +101,11 @@ class BAFGenerator(GeneratorInterface):
         config: dict = None,
         openai_api_key: str = None,
         generation_mode: GenerationMode | str = GenerationMode.FULL,
+        config_yaml: Optional[str] = None,
     ):
         super().__init__(model, output_dir)
         self.config = flatten_agent_config_structure(config) if isinstance(config, dict) else config
+        self.config_yaml = config_yaml
         self.openai_api_key = openai_api_key
         if isinstance(generation_mode, GenerationMode):
             self.generation_mode = generation_mode
@@ -282,12 +285,14 @@ class BAFGenerator(GeneratorInterface):
                 f.write(generated_code)
             logger.info("Agent script generated at %s", agent_path)
         if generate_code_assets:
-            config_template = env.get_template('baf_config_template.py.j2')
             config_path = self.build_generation_path(file_name="config.yaml")
             with open(config_path, mode="w", encoding="utf-8") as f:
-                properties = sorted(self.model.properties, key=lambda prop: prop.section)
-                generated_code = config_template.render(properties=properties)
-                f.write(generated_code)
+                if self.config_yaml is not None:
+                    f.write(self.config_yaml)
+                else:
+                    config_template = env.get_template('baf_config_template.py.j2')
+                    properties = sorted(self.model.properties, key=lambda prop: prop.section)
+                    f.write(config_template.render(properties=properties))
             logger.info("Agent config file generated at %s", config_path)
             # Generate readme.txt using the Jinja2 template
             readme_template = env.get_template('readme.txt.j2')

--- a/besser/generators/agents/baf_generator.py
+++ b/besser/generators/agents/baf_generator.py
@@ -168,6 +168,30 @@ class BAFGenerator(GeneratorInterface):
             if not slug:
                 slug = f"rag_{index}"
             return slug
+
+        def resolve_rag_var_name(agent: Agent, rag_db_name: str) -> str:
+            """Return the generated RAG variable name for ``rag_db_name``.
+
+            The template falls back to ``session.run_rag(...)`` when this helper
+            returns an empty string.
+            """
+            if not rag_db_name:
+                logger.warning(
+                    "RAGReply in agent '%s' has empty rag_db_name. Falling back to session.run_rag().",
+                    agent.name,
+                )
+                return ''
+
+            for rag in agent.rags:
+                if rag.name == rag_db_name:
+                    return safe_var_name(rag.name)
+
+            logger.warning(
+                "RAGReply in agent '%s' references unknown rag_db_name '%s'. Falling back to session.run_rag().",
+                agent.name,
+                rag_db_name,
+            )
+            return ''
         generate_personalized_assets = self.generation_mode in (
             GenerationMode.FULL,
             GenerationMode.PERSONALIZED_ONLY,
@@ -190,6 +214,7 @@ class BAFGenerator(GeneratorInterface):
         # Shared helper so generated identifiers match the code builder and are
         # always valid Python (handles leading digits, dashes, dots, spaces, …).
         env.globals['safe_var_name'] = safe_var_name
+        env.globals['resolve_rag_var_name'] = resolve_rag_var_name
         agent_template = env.get_template('baf_agent_template.py.j2')
         agent_path = self.build_generation_path(file_name=f"{self.model.name}.py")
         personalized_agent_path = self.build_generation_path(file_name="personalized_agent_model.py")

--- a/besser/generators/agents/baf_generator.py
+++ b/besser/generators/agents/baf_generator.py
@@ -157,6 +157,12 @@ class BAFGenerator(GeneratorInterface):
             else:
                 return None
 
+        def extract_function_name(code: str) -> str:
+            if not code:
+                return ''
+            match = re.search(r'def\s+(\w+)\s*\(', code)
+            return match.group(1) if match else ''
+
         def rag_slug(name: str, index: int) -> str:
             slug = (name or '').strip().lower().replace(' ', '_').replace('-', '_')
             if not slug:
@@ -180,6 +186,7 @@ class BAFGenerator(GeneratorInterface):
         env.globals['is_class'] = is_class
         env.globals['is_type'] = is_type
         env.globals['replace_bot_session_with_session_in_signature'] = replace_agent_session_with_session_in_signature
+        env.globals['extract_function_name'] = extract_function_name
         # Shared helper so generated identifiers match the code builder and are
         # always valid Python (handles leading digits, dashes, dots, spaces, …).
         env.globals['safe_var_name'] = safe_var_name

--- a/besser/generators/agents/templates/baf_agent_template.py.j2
+++ b/besser/generators/agents/templates/baf_agent_template.py.j2
@@ -217,7 +217,7 @@ tts = OpenAIText2Speech(agent=agent, model_name="gpt-4o-mini-tts")
     {% endif %}
     {% set vector_var = rag_slug ~ '_vector_store' %}
     {% set splitter_var = rag_slug ~ '_splitter' %}
-    {% set rag_var = rag_slug ~ '_rag' %}
+    {% set rag_var = safe_var_name(rag.name) %}
     {% if rag.vector_store and rag.vector_store.persist_directory %}
         {% set persist_dir = rag.vector_store.persist_directory %}
     {% else %}
@@ -243,6 +243,7 @@ tts = OpenAIText2Speech(agent=agent, model_name="gpt-4o-mini-tts")
     vector_store={{ vector_var }},
     splitter={{ splitter_var }},
     llm_name='{{ ((rag.llm_name if rag.llm_name else (agent.default_llm_name if agent.default_llm_name else '')) | string) | replace('\\', '\\\\') | replace("'", "\\'") }}',
+    llm_prompt={% if rag.llm_prompt %}'{{ rag.llm_prompt | replace('\\', '\\\\') | replace("'", "\\'") }}'{% else %}None{% endif %},
     k={{ rag.k if rag.k is not none else 4 }},
     num_previous_messages={{ rag.num_previous_messages if rag.num_previous_messages is not none else 0 }}
 )
@@ -708,10 +709,19 @@ def {{ body_name }}(session: Session):
     platform.reply_speech(session, message)
     {% endif %}
     {% elif is_class(action, 'RAGReply') %}
+    {% set rag_var_name = resolve_rag_var_name(agent, action.rag_db_name) %}
+    {% if rag_var_name %}
+    {% if action.prompt %}
+    rag_message = {{ rag_var_name }}.run(session.event.message, llm_prompt='{{ action.prompt | replace('\\', '\\\\') | replace("'", "\\'") }}')
+    {% else %}
+    rag_message = {{ rag_var_name }}.run(session.event.message)
+    {% endif %}
+    {% else %}
     {% if action.prompt %}
     rag_message = session.run_rag(session.event.message, llm_prompt='{{ action.prompt | replace('\\', '\\\\') | replace("'", "\\'") }}')
     {% else %}
     rag_message = session.run_rag(session.event.message)
+    {% endif %}
     {% endif %}
     platform.reply_rag(session, rag_message)
     {% elif is_class(action, 'DBReply') %}
@@ -759,10 +769,19 @@ def {{ fallback_name }}(session: Session):
     platform.reply_speech(session, message)
     {% endif %}
     {% elif is_class(action, 'RAGReply') %}
+    {% set rag_var_name = resolve_rag_var_name(agent, action.rag_db_name) %}
+    {% if rag_var_name %}
+    {% if action.prompt %}
+    rag_message = {{ rag_var_name }}.run(session.event.message, llm_prompt='{{ action.prompt | replace('\\', '\\\\') | replace("'", "\\'") }}')
+    {% else %}
+    rag_message = {{ rag_var_name }}.run(session.event.message)
+    {% endif %}
+    {% else %}
     {% if action.prompt %}
     rag_message = session.run_rag(session.event.message, llm_prompt='{{ action.prompt | replace('\\', '\\\\') | replace("'", "\\'") }}')
     {% else %}
     rag_message = session.run_rag(session.event.message)
+    {% endif %}
     {% endif %}
     platform.reply_rag(session, rag_message)
     {% elif is_class(action, 'DBReply') %}

--- a/besser/generators/agents/templates/baf_agent_template.py.j2
+++ b/besser/generators/agents/templates/baf_agent_template.py.j2
@@ -708,6 +708,17 @@ def {{ body_name }}(session: Session):
     {% if speech_enabled %}
     platform.reply_speech(session, message)
     {% endif %}
+    {% elif is_class(action, 'LLMChatReply') %}
+    {% set llm_ns = namespace(name='default_llm') %}{% if action.llm_name %}{% set llm_ns.name = action.llm_name | replace('-', '_') | replace('.', '_') | replace(' ', '_') %}{% endif %}
+    {% if action.prompt %}
+    message = {{ llm_ns.name }}.chat(session=session, system_message='{{ action.prompt | replace('\\', '\\\\') | replace("'", "\\'") }}')
+    {% else %}
+    message = {{ llm_ns.name }}.chat(session=session)
+    {% endif %}
+    session.reply(message)
+    {% if speech_enabled %}
+    platform.reply_speech(session, message)
+    {% endif %}
     {% elif is_class(action, 'RAGReply') %}
     {% set rag_var_name = resolve_rag_var_name(agent, action.rag_db_name) %}
     {% if rag_var_name %}
@@ -763,6 +774,17 @@ def {{ fallback_name }}(session: Session):
     message = {{ llm_ns.name }}.predict(message=session.event.message, session=session, system_message='{{ action.prompt | replace('\\', '\\\\') | replace("'", "\\'") }}')
     {% else %}
     message = {{ llm_ns.name }}.predict(message=session.event.message, session=session)
+    {% endif %}
+    session.reply(message)
+    {% if speech_enabled %}
+    platform.reply_speech(session, message)
+    {% endif %}
+    {% elif is_class(action, 'LLMChatReply') %}
+    {% set llm_ns = namespace(name='default_llm') %}{% if action.llm_name %}{% set llm_ns.name = action.llm_name | replace('-', '_') | replace('.', '_') | replace(' ', '_') %}{% endif %}
+    {% if action.prompt %}
+    message = {{ llm_ns.name }}.chat(session=session, system_message='{{ action.prompt | replace('\\', '\\\\') | replace("'", "\\'") }}')
+    {% else %}
+    message = {{ llm_ns.name }}.chat(session=session)
     {% endif %}
     session.reply(message)
     {% if speech_enabled %}

--- a/besser/generators/agents/templates/baf_agent_template.py.j2
+++ b/besser/generators/agents/templates/baf_agent_template.py.j2
@@ -5,6 +5,7 @@
 import json
 import logging
 import operator
+import os
 
 from baf.core.agent import Agent
 from baf.library.transition.events.base_events import *
@@ -49,6 +50,8 @@ from baf.utils.web_crawl import crawl_website
 
 # Configure the logging module
 logging.basicConfig(level=logging.INFO, format='{levelname} - {asctime}: {message}', style='{')
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
 
 {% if personalization_mapping is defined and personalization_mapping %}
 def build_agent_configuration_prompt(agent_configuration: dict) -> str:
@@ -392,23 +395,14 @@ agent.set_default_ic_config(ic_config)
 ##############################
 # TOOLS
 ##############################
-{% for tool in agent.tools %}
-{{ tool.code }}
-agent.new_tool({{ tool.name }}, description={{ tool.description | string | tojson }})
-{% endfor %}
+agent.load_tools(os.path.join(_HERE, "tools.py"))
 {% endif %}
 
 {% if agent.skills and agent.skills|length > 0 %}
 ##############################
 # SKILLS
 ##############################
-{% for skill in agent.skills %}
-agent.new_skill(
-    {{ skill.content | string | tojson }},
-    name={{ skill.name | string | tojson }}{% if skill.description %},
-    description={{ skill.description | string | tojson }}{% endif %}
-)
-{% endfor %}
+agent.load_skills(os.path.join(_HERE, "skills"))
 {% endif %}
 
 {% if agent.workspaces and agent.workspaces|length > 0 %}

--- a/besser/generators/agents/templates/baf_agent_template.py.j2
+++ b/besser/generators/agents/templates/baf_agent_template.py.j2
@@ -34,6 +34,18 @@ from baf.nlp.rag.rag import RAG
 {% if has_reasoning_states %}
 from baf.library.state import new_reasoning_state
 {% endif %}
+{% set has_web_crawl_import_ns = namespace(value=false) %}
+{% for state in agent.states %}
+{% for action in (state.body.actions if state.body and state.body.actions else []) %}
+{% if is_class(action, 'WebCrawlLLMReply') and action.run_crawl %}{% set has_web_crawl_import_ns.value = true %}{% endif %}
+{% endfor %}
+{% for action in (state.fallback_body.actions if state.fallback_body and state.fallback_body.actions else []) %}
+{% if is_class(action, 'WebCrawlLLMReply') and action.run_crawl %}{% set has_web_crawl_import_ns.value = true %}{% endif %}
+{% endfor %}
+{% endfor %}
+{% if has_web_crawl_import_ns.value %}
+from baf.utils.web_crawl import crawl_website
+{% endif %}
 
 # Configure the logging module
 logging.basicConfig(level=logging.INFO, format='{levelname} - {asctime}: {message}', style='{')
@@ -737,6 +749,34 @@ def {{ body_name }}(session: Session):
     platform.reply_rag(session, rag_message)
     {% elif is_class(action, 'DBReply') %}
 {{ render_db_reply_actions([action], speech_enabled) }}
+    {% elif is_class(action, 'WebCrawlLLMReply') %}
+    {% set web_crawl_llm_ns = namespace(name='default_llm') %}{% if action.llm_name %}{% set web_crawl_llm_ns.name = action.llm_name | replace('-', '_') | replace('.', '_') | replace(' ', '_') %}{% endif %}
+    {% if action.run_crawl %}
+    webpages = crawl_website(
+        initial_url='{{ action.initial_url | replace('\\', '\\\\') | replace("'", "\\'") }}',
+        max_depth={{ action.max_depth }},
+        max_pages={{ action.max_pages }},
+        format='{{ action.crawl_format }}'{% if action.base_url_prefix %},
+        base_url_prefix='{{ action.base_url_prefix | replace('\\', '\\\\') | replace("'", "\\'") }}'{% endif %}
+
+    )
+    session.set('web_crawl_{{ action.initial_url | replace('\\', '\\\\') | replace("'", "\\'") }}', webpages)
+    {% else %}
+    webpages = session.get('web_crawl_{{ action.initial_url | replace('\\', '\\\\') | replace("'", "\\'") }}')
+    if webpages is None:
+        session.reply('{{ action.no_crawl_error_message | replace('\\', '\\\\') | replace("'", "\\'") }}')
+        return
+    {% endif %}
+    {% if action.system_message_prefix %}
+    system_message = '{{ action.system_message_prefix | replace('\\', '\\\\') | replace("'", "\\'") }}' + str(webpages)
+    {% else %}
+    system_message = 'Use the following webpage content to answer the question:\n' + str(webpages)
+    {% endif %}
+    message = {{ web_crawl_llm_ns.name }}.predict(message=session.event.message, session=session, system_message=system_message)
+    session.reply(message)
+    {% if speech_enabled %}
+    platform.reply_speech(session, message)
+    {% endif %}
     {% endif %}
     {% endfor %}
     {% if speech_enabled %}
@@ -808,6 +848,34 @@ def {{ fallback_name }}(session: Session):
     platform.reply_rag(session, rag_message)
     {% elif is_class(action, 'DBReply') %}
 {{ render_db_reply_actions([action], speech_enabled) }}
+    {% elif is_class(action, 'WebCrawlLLMReply') %}
+    {% set web_crawl_llm_ns = namespace(name='default_llm') %}{% if action.llm_name %}{% set web_crawl_llm_ns.name = action.llm_name | replace('-', '_') | replace('.', '_') | replace(' ', '_') %}{% endif %}
+    {% if action.run_crawl %}
+    webpages = crawl_website(
+        initial_url='{{ action.initial_url | replace('\\', '\\\\') | replace("'", "\\'") }}',
+        max_depth={{ action.max_depth }},
+        max_pages={{ action.max_pages }},
+        format='{{ action.crawl_format }}'{% if action.base_url_prefix %},
+        base_url_prefix='{{ action.base_url_prefix | replace('\\', '\\\\') | replace("'", "\\'") }}'{% endif %}
+
+    )
+    session.set('web_crawl_{{ action.initial_url | replace('\\', '\\\\') | replace("'", "\\'") }}', webpages)
+    {% else %}
+    webpages = session.get('web_crawl_{{ action.initial_url | replace('\\', '\\\\') | replace("'", "\\'") }}')
+    if webpages is None:
+        session.reply('{{ action.no_crawl_error_message | replace('\\', '\\\\') | replace("'", "\\'") }}')
+        return
+    {% endif %}
+    {% if action.system_message_prefix %}
+    system_message = '{{ action.system_message_prefix | replace('\\', '\\\\') | replace("'", "\\'") }}' + str(webpages)
+    {% else %}
+    system_message = 'Use the following webpage content to answer the question:\n' + str(webpages)
+    {% endif %}
+    message = {{ web_crawl_llm_ns.name }}.predict(message=session.event.message, session=session, system_message=system_message)
+    session.reply(message)
+    {% if speech_enabled %}
+    platform.reply_speech(session, message)
+    {% endif %}
     {% endif %}
     {% endfor %}
     {% if speech_enabled %}

--- a/besser/generators/agents/templates/baf_agent_template.py.j2
+++ b/besser/generators/agents/templates/baf_agent_template.py.j2
@@ -159,7 +159,7 @@ rules = json.loads(r'''{{ config['personalizationrules'] | tojson(indent=2) }}''
 
 {% set platform_name = config['agentPlatform'] if config and 'agentPlatform' in config else None %}
 {% if platform_name == 'websocket' %}
-platform = agent.use_websocket_platform()
+platform = agent.use_websocket_platform(use_ui=False)
 {% elif platform_name == 'telegram' %}
 platform = agent.use_telegram_platform()
 {% elif platform_name == 'streamlit' %}
@@ -777,6 +777,32 @@ def {{ body_name }}(session: Session):
     {% if speech_enabled %}
     platform.reply_speech(session, message)
     {% endif %}
+    {% elif is_class(action, 'WebSocketReplyMarkdown') %}
+    platform.reply_markdown(session, '{{ action.message | replace('\\', '\\\\') | replace("'", "\\'") }}')
+    {% elif is_class(action, 'WebSocketReplyHTML') %}
+    platform.reply_html(session, '{{ action.message | replace('\\', '\\\\') | replace("'", "\\'") }}')
+    {% elif is_class(action, 'WebSocketReplySpeech') %}
+    {% if action.audio_speed is not none %}
+    platform.reply_speech(session, '{{ action.message | replace('\\', '\\\\') | replace("'", "\\'") }}', audio_speed={{ action.audio_speed }})
+    {% else %}
+    platform.reply_speech(session, '{{ action.message | replace('\\', '\\\\') | replace("'", "\\'") }}')
+    {% endif %}
+    {% elif is_class(action, 'WebSocketReplyOptions') %}
+    platform.reply_options(session, [{% for opt in action.options %}'{{ opt | replace('\\', '\\\\') | replace("'", "\\'") }}'{% if not loop.last %}, {% endif %}{% endfor %}])
+    {% elif is_class(action, 'WebSocketReplyLocation') %}
+    platform.reply_location(session, {{ action.latitude }}, {{ action.longitude }})
+    {% elif is_class(action, 'WebSocketReplyFile') %}
+    # TODO: Assign a baf.types.File object to `reply_file_obj` before this state is reached
+    platform.reply_file(session, reply_file_obj)
+    {% elif is_class(action, 'WebSocketReplyImage') %}
+    # TODO: Assign a numpy.ndarray image to `reply_image_arr` before this state is reached
+    platform.reply_image(session, reply_image_arr)
+    {% elif is_class(action, 'WebSocketReplyDataframe') %}
+    # TODO: Assign a pandas.DataFrame to `reply_df` before this state is reached
+    platform.reply_dataframe(session, reply_df)
+    {% elif is_class(action, 'WebSocketReplyPlotly') %}
+    # TODO: Assign a plotly.graph_objs.Figure to `reply_plot` before this state is reached
+    platform.reply_plotly(session, reply_plot)
     {% endif %}
     {% endfor %}
     {% if speech_enabled %}
@@ -876,6 +902,32 @@ def {{ fallback_name }}(session: Session):
     {% if speech_enabled %}
     platform.reply_speech(session, message)
     {% endif %}
+    {% elif is_class(action, 'WebSocketReplyMarkdown') %}
+    platform.reply_markdown(session, '{{ action.message | replace('\\', '\\\\') | replace("'", "\\'") }}')
+    {% elif is_class(action, 'WebSocketReplyHTML') %}
+    platform.reply_html(session, '{{ action.message | replace('\\', '\\\\') | replace("'", "\\'") }}')
+    {% elif is_class(action, 'WebSocketReplySpeech') %}
+    {% if action.audio_speed is not none %}
+    platform.reply_speech(session, '{{ action.message | replace('\\', '\\\\') | replace("'", "\\'") }}', audio_speed={{ action.audio_speed }})
+    {% else %}
+    platform.reply_speech(session, '{{ action.message | replace('\\', '\\\\') | replace("'", "\\'") }}')
+    {% endif %}
+    {% elif is_class(action, 'WebSocketReplyOptions') %}
+    platform.reply_options(session, [{% for opt in action.options %}'{{ opt | replace('\\', '\\\\') | replace("'", "\\'") }}'{% if not loop.last %}, {% endif %}{% endfor %}])
+    {% elif is_class(action, 'WebSocketReplyLocation') %}
+    platform.reply_location(session, {{ action.latitude }}, {{ action.longitude }})
+    {% elif is_class(action, 'WebSocketReplyFile') %}
+    # TODO: Assign a baf.types.File object to `reply_file_obj` before this state is reached
+    platform.reply_file(session, reply_file_obj)
+    {% elif is_class(action, 'WebSocketReplyImage') %}
+    # TODO: Assign a numpy.ndarray image to `reply_image_arr` before this state is reached
+    platform.reply_image(session, reply_image_arr)
+    {% elif is_class(action, 'WebSocketReplyDataframe') %}
+    # TODO: Assign a pandas.DataFrame to `reply_df` before this state is reached
+    platform.reply_dataframe(session, reply_df)
+    {% elif is_class(action, 'WebSocketReplyPlotly') %}
+    # TODO: Assign a plotly.graph_objs.Figure to `reply_plot` before this state is reached
+    platform.reply_plotly(session, reply_plot)
     {% endif %}
     {% endfor %}
     {% if speech_enabled %}

--- a/besser/generators/agents/templates/baf_agent_template.py.j2
+++ b/besser/generators/agents/templates/baf_agent_template.py.j2
@@ -174,24 +174,24 @@ platform = agent.use_websocket_platform(use_ui=True)
 {% set has_default_llm_state = namespace(value=false) %}
 {% set has_db_reply_state = namespace(value=false) %}
 {% for state in agent.states %}
-{% if state.body and state.body.actions and is_class(state.body.actions[0], 'DBReply') %}
-{% set has_db_reply_state.value = true %}
-{% endif %}
-{% if state.fallback_body and state.fallback_body.actions and is_class(state.fallback_body.actions[0], 'DBReply') %}
-{% set has_db_reply_state.value = true %}
-{% endif %}
+{% for action in (state.body.actions if state.body and state.body.actions else []) %}
+{% if is_class(action, 'DBReply') %}{% set has_db_reply_state.value = true %}{% endif %}
+{% endfor %}
+{% for action in (state.fallback_body.actions if state.fallback_body and state.fallback_body.actions else []) %}
+{% if is_class(action, 'DBReply') %}{% set has_db_reply_state.value = true %}{% endif %}
+{% endfor %}
 {% endfor %}
 {% if personalization_mapping is defined and personalization_mapping %}
 {% for mapping in personalization_mapping %}
 {% set profile_agent = mapping.agent_model if mapping.agent_model is defined else mapping.model %}
 {% if profile_agent and profile_agent.states %}
 {% for state in profile_agent.states %}
-{% if state.body and state.body.actions and is_class(state.body.actions[0], 'DBReply') %}
-{% set has_db_reply_state.value = true %}
-{% endif %}
-{% if state.fallback_body and state.fallback_body.actions and is_class(state.fallback_body.actions[0], 'DBReply') %}
-{% set has_db_reply_state.value = true %}
-{% endif %}
+{% for action in (state.body.actions if state.body and state.body.actions else []) %}
+{% if is_class(action, 'DBReply') %}{% set has_db_reply_state.value = true %}{% endif %}
+{% endfor %}
+{% for action in (state.fallback_body.actions if state.fallback_body and state.fallback_body.actions else []) %}
+{% if is_class(action, 'DBReply') %}{% set has_db_reply_state.value = true %}{% endif %}
+{% endfor %}
 {% endfor %}
 {% endif %}
 {% endfor %}
@@ -661,19 +661,23 @@ router_initial_state.when_variable_matches_operation('user_profile', operator.eq
 {% if state.body != None %}
 {% set body_name = state.body.name ~ suffix_part %}
 {% if body_name not in ns.bodies %}
-{% if state.body.actions and is_class(state.body.actions[0], 'AgentReply') %}
+{% set body_has_custom_ns = namespace(value=false, func_name='') %}
+{% for action in state.body.actions %}{% if is_class(action, 'CustomCodeAction') %}{% set body_has_custom_ns.value = true %}{% set body_has_custom_ns.func_name = extract_function_name(action.code) %}{% endif %}{% endfor %}
+{% if state.body.actions and body_has_custom_ns.value %}
+{{ replace_bot_session_with_session_in_signature(state.body) | replace(state.body.name, body_name) }}
+{% elif state.body.actions %}
 def {{ body_name }}(session: Session):
     {% if inject_profile_context and has_default_llm %}
     default_llm.add_user_context(
         session=session,
         context=context_prompts.get('{{ suffix }}'),
-        context_name='agent_configuration_{{ suffix }}'
+        context_name='agent_configuration'
     )
     {% if configuration.adaptContentToUserProfile %}
     default_llm.add_user_context(
         session=session,
         context=profile_prompts.get('{{ suffix }}'),
-        context_name='user_profile_{{ suffix }}'
+        context_name='user_profile'
     )
     {% endif %}
     {% endif %}
@@ -681,6 +685,8 @@ def {{ body_name }}(session: Session):
     speech_messages = []
     {% endif %}
     {% for action in state.body.actions %}
+    # Action {{ loop.index }}
+    {% if is_class(action, 'AgentReply') %}
     {% if personalized_messages is defined and personalized_messages and not suffix %}
     reply_text = choose_variant_for_message('{{ action.message }}', session)
     {% else %}
@@ -690,137 +696,87 @@ def {{ body_name }}(session: Session):
     {% if speech_enabled %}
     speech_messages.append(reply_text)
     {% endif %}
-    {% endfor %}
-    {% if speech_enabled %}
-    if speech_messages:
-        platform.reply_speech(session, ' '.join(speech_messages))
-    {% endif %}
-{% elif state.body.actions and is_class(state.body.actions[0], 'LLMReply') %}
-def {{ body_name }}(session: Session):
-    {% if inject_profile_context and has_default_llm %}
-    default_llm.add_user_context(
-        session=session,
-        context=context_prompts.get('{{ suffix }}'),
-        context_name='agent_configuration'
-    )
-    {% if configuration.adaptContentToUserProfile %}
-    default_llm.add_user_context(
-        session=session,
-        context=profile_prompts.get('{{ suffix }}'),
-        context_name='user_profile'
-    )
-    {% endif %}
-    {% endif %}
-    {% set llm_action = state.body.actions[0] %}
-    {% if llm_action.llm_name %}{% set chosen_llm = llm_action.llm_name | replace('-', '_') | replace('.', '_') | replace(' ', '_') %}{% else %}{% set chosen_llm = 'default_llm' %}{% endif %}
-    {% if llm_action.prompt %}
-    message = {{ chosen_llm }}.predict(message=session.event.message, session=session, system_message='{{ llm_action.prompt | replace('\\', '\\\\') | replace("'", "\\'") }}')
+    {% elif is_class(action, 'LLMReply') %}
+    {% set llm_ns = namespace(name='default_llm') %}{% if action.llm_name %}{% set llm_ns.name = action.llm_name | replace('-', '_') | replace('.', '_') | replace(' ', '_') %}{% endif %}
+    {% if action.prompt %}
+    message = {{ llm_ns.name }}.predict(message=session.event.message, session=session, system_message='{{ action.prompt | replace('\\', '\\\\') | replace("'", "\\'") }}')
     {% else %}
-    message = {{ chosen_llm }}.predict(message=session.event.message, session=session)
+    message = {{ llm_ns.name }}.predict(message=session.event.message, session=session)
     {% endif %}
     session.reply(message)
     {% if speech_enabled %}
     platform.reply_speech(session, message)
     {% endif %}
-{% elif state.body.actions and is_class(state.body.actions[0], 'RAGReply') %}
-def {{ body_name }}(session: Session):
-    {% if inject_profile_context and has_default_llm %}
-    default_llm.add_user_context(
-        session=session,
-        context=context_prompts.get('{{ suffix }}'),
-        context_name='agent_configuration'
-    )
-    {% if configuration.adaptContentToUserProfile %}
-    default_llm.add_user_context(
-        session=session,
-        context=profile_prompts.get('{{ suffix }}'),
-        context_name='user_profile'
-    )
-    {% endif %}
-    {% endif %}
-    {% for action in state.body.actions %}
+    {% elif is_class(action, 'RAGReply') %}
     {% if action.prompt %}
     rag_message = session.run_rag(session.event.message, llm_prompt='{{ action.prompt | replace('\\', '\\\\') | replace("'", "\\'") }}')
     {% else %}
     rag_message = session.run_rag(session.event.message)
     {% endif %}
     platform.reply_rag(session, rag_message)
+    {% elif is_class(action, 'DBReply') %}
+{{ render_db_reply_actions([action], speech_enabled) }}
+    {% endif %}
     {% endfor %}
-{% elif state.body.actions and is_class(state.body.actions[0], 'DBReply') %}
-def {{ body_name }}(session: Session):
-    {% if inject_profile_context and has_default_llm %}
-    default_llm.add_user_context(
-        session=session,
-        context=context_prompts.get('{{ suffix }}'),
-        context_name='agent_configuration'
-    )
-    {% if configuration.adaptContentToUserProfile %}
-    default_llm.add_user_context(
-        session=session,
-        context=profile_prompts.get('{{ suffix }}'),
-        context_name='user_profile'
-    )
+    {% if speech_enabled %}
+    if speech_messages:
+        platform.reply_speech(session, ' '.join(speech_messages))
     {% endif %}
-    {% endif %}
-{{ render_db_reply_actions(state.body.actions, speech_enabled) }}
-{% else %}
-{{ replace_bot_session_with_session_in_signature(state.body) | replace(state.body.name, body_name) }}
 {% endif %}
 {% set ns.bodies = ns.bodies + [body_name] %}
 {% endif %}
-{{ state_name }}.set_body({{ body_name }})
+{{ state_name }}.set_body({{ body_has_custom_ns.func_name if body_has_custom_ns.value and body_has_custom_ns.func_name else body_name }})
 {% endif %}
 {% if state.fallback_body != None %}
 {% set fallback_name = state.fallback_body.name ~ suffix_part %}
 {% if fallback_name not in ns.bodies %}
-{% if state.fallback_body.actions and is_class(state.fallback_body.actions[0], 'AgentReply') %}
+{% set fallback_has_custom_ns = namespace(value=false, func_name='') %}
+{% for action in state.fallback_body.actions %}{% if is_class(action, 'CustomCodeAction') %}{% set fallback_has_custom_ns.value = true %}{% set fallback_has_custom_ns.func_name = extract_function_name(action.code) %}{% endif %}{% endfor %}
+{% if state.fallback_body.actions and fallback_has_custom_ns.value %}
+{{ replace_bot_session_with_session_in_signature(state.fallback_body) | replace(state.fallback_body.name, fallback_name) }}
+{% elif state.fallback_body.actions %}
 def {{ fallback_name }}(session: Session):
     {% if speech_enabled %}
     speech_messages = []
     {% endif %}
     {% for action in state.fallback_body.actions %}
+    # Action {{ loop.index }}
+    {% if is_class(action, 'AgentReply') %}
     reply_text = '{{ action.message | replace('\\', '\\\\') | replace("'", "\\'")}}'
     session.reply(reply_text)
     {% if speech_enabled %}
     speech_messages.append(reply_text)
     {% endif %}
-    {% endfor %}
-    {% if speech_enabled %}
-    if speech_messages:
-        platform.reply_speech(session, ' '.join(speech_messages))
-    {% endif %}
-{% elif state.fallback_body.actions and is_class(state.fallback_body.actions[0], 'LLMReply') %}
-def {{ fallback_name }}(session: Session):
-    {% set llm_action = state.fallback_body.actions[0] %}
-    {% if llm_action.llm_name %}{% set chosen_llm = llm_action.llm_name | replace('-', '_') | replace('.', '_') | replace(' ', '_') %}{% else %}{% set chosen_llm = 'default_llm' %}{% endif %}
-    {% if llm_action.prompt %}
-    message = {{ chosen_llm }}.predict(message=session.event.message, session=session, system_message='{{ llm_action.prompt | replace('\\', '\\\\') | replace("'", "\\'") }}')
+    {% elif is_class(action, 'LLMReply') %}
+    {% set llm_ns = namespace(name='default_llm') %}{% if action.llm_name %}{% set llm_ns.name = action.llm_name | replace('-', '_') | replace('.', '_') | replace(' ', '_') %}{% endif %}
+    {% if action.prompt %}
+    message = {{ llm_ns.name }}.predict(message=session.event.message, session=session, system_message='{{ action.prompt | replace('\\', '\\\\') | replace("'", "\\'") }}')
     {% else %}
-    message = {{ chosen_llm }}.predict(message=session.event.message, session=session)
+    message = {{ llm_ns.name }}.predict(message=session.event.message, session=session)
     {% endif %}
     session.reply(message)
     {% if speech_enabled %}
     platform.reply_speech(session, message)
     {% endif %}
-{% elif state.fallback_body.actions and is_class(state.fallback_body.actions[0], 'RAGReply') %}
-def {{ fallback_name }}(session: Session):
-    {% for action in state.fallback_body.actions %}
+    {% elif is_class(action, 'RAGReply') %}
     {% if action.prompt %}
     rag_message = session.run_rag(session.event.message, llm_prompt='{{ action.prompt | replace('\\', '\\\\') | replace("'", "\\'") }}')
     {% else %}
     rag_message = session.run_rag(session.event.message)
     {% endif %}
     platform.reply_rag(session, rag_message)
+    {% elif is_class(action, 'DBReply') %}
+{{ render_db_reply_actions([action], speech_enabled) }}
+    {% endif %}
     {% endfor %}
-{% elif state.fallback_body.actions and is_class(state.fallback_body.actions[0], 'DBReply') %}
-def {{ fallback_name }}(session: Session):
-{{ render_db_reply_actions(state.fallback_body.actions, speech_enabled) }}
-{% else %}
-{{ replace_bot_session_with_session_in_signature(state.fallback_body) | replace(state.fallback_body.name, fallback_name) }}
+    {% if speech_enabled %}
+    if speech_messages:
+        platform.reply_speech(session, ' '.join(speech_messages))
+    {% endif %}
 {% endif %}
 {% set ns.bodies = ns.bodies + [fallback_name] %}
 {% endif %}
-{{ state_name }}.set_fallback_body({{ fallback_name }})
+{{ state_name }}.set_fallback_body({{ fallback_has_custom_ns.func_name if fallback_has_custom_ns.value and fallback_has_custom_ns.func_name else fallback_name }})
 {% endif %}
 {% set auto_ns = namespace(found=False) %}
 {% for transition in state.transitions %}

--- a/besser/generators/web_app/web_app_generator.py
+++ b/besser/generators/web_app/web_app_generator.py
@@ -47,7 +47,8 @@ class WebAppGenerator(GeneratorInterface):
 
     def __init__(self, model: DomainModel, gui_model: GUIModel, output_dir: str = None,
                  agent_models=None, agent_configs=None,
-                 agent_model=None, agent_config=None):
+                 agent_model=None, agent_config=None,
+                 agent_config_yamls=None):
         super().__init__(model, output_dir)
         self.gui_model = gui_model
         if agent_model is not None and not agent_models:
@@ -57,6 +58,7 @@ class WebAppGenerator(GeneratorInterface):
             agent_configs = {name: agent_config}
         self.agent_models = list(agent_models or [])
         self.agent_configs = dict(agent_configs or {})
+        self.agent_config_yamls = dict(agent_config_yamls or {})
         # Jinja environment configuration
         templates_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")
         self.env = Environment(loader=FileSystemLoader(templates_path), trim_blocks=True,
@@ -126,7 +128,8 @@ class WebAppGenerator(GeneratorInterface):
             agent_dir = os.path.join(agents_root, slug)
             os.makedirs(agent_dir, exist_ok=True)
             cfg = self.agent_configs.get(getattr(agent, "name", None))
-            BAFGenerator(agent, output_dir=agent_dir, config=cfg).generate()
+            cfg_yaml = self.agent_config_yamls.get(getattr(agent, "name", None))
+            BAFGenerator(agent, output_dir=agent_dir, config=cfg, config_yaml=cfg_yaml).generate()
 
     def _generate_docker_files(self, env):
         """

--- a/besser/utilities/buml_code_builder/agent_model_builder.py
+++ b/besser/utilities/buml_code_builder/agent_model_builder.py
@@ -159,6 +159,7 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
                 f.write(f"    vector_store={vector_var},\n")
                 f.write(f"    splitter={splitter_var},\n")
                 f.write(f"    llm_name={repr(rag.llm_name)},\n")
+                f.write(f"    llm_prompt={repr(getattr(rag, 'llm_prompt', None))},\n")
                 f.write(f"    k={rag.k},\n")
                 f.write(f"    num_previous_messages={rag.num_previous_messages},\n")
                 f.write(")\n\n")

--- a/besser/utilities/buml_code_builder/agent_model_builder.py
+++ b/besser/utilities/buml_code_builder/agent_model_builder.py
@@ -7,7 +7,7 @@ This module generates Python code for BUML agent models.
 import os
 from re import search
 from besser.BUML.metamodel.state_machine.agent import (
-    Agent, AgentReply, LLMReply, RAGReply, DBReply,
+    Agent, AgentReply, LLMReply, LLMChatReply, RAGReply, DBReply,
     ReasoningState, llm_provider_key,
 )
 from besser.BUML.metamodel.state_machine.state_machine import CustomCodeAction
@@ -49,7 +49,7 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
         )
         f.write(
             "from besser.BUML.metamodel.state_machine.agent import "
-            "Agent, AgentReply, LLMReply, RAGReply, DBReply, "
+            "Agent, AgentReply, LLMReply, LLMChatReply, RAGReply, DBReply, "
             "LLMOpenAI, LLMHuggingFace, LLMHuggingFaceAPI, LLMReplicate, "
             "RAGVectorStore, RAGTextSplitter, "
             "Tool, Skill, Workspace, ReasoningState, "
@@ -311,6 +311,16 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
                                 kwargs.append(f"llm_name={repr(llm_name)}")
                             args = ", ".join(kwargs)
                             f.write(f"{state_var}_body.add_action(LLMReply({args}))\n")
+                        elif isinstance(action, LLMChatReply):
+                            kwargs = []
+                            prompt = getattr(action, 'prompt', None)
+                            if prompt:
+                                kwargs.append(f"prompt='{_escape_python_string(prompt)}'")
+                            llm_name = getattr(action, 'llm_name', None)
+                            if llm_name:
+                                kwargs.append(f"llm_name={repr(llm_name)}")
+                            args = ", ".join(kwargs)
+                            f.write(f"{state_var}_body.add_action(LLMChatReply({args}))\n")
                         elif isinstance(action, RAGReply):
                             rag_name = _escape_python_string(action.rag_db_name or '')
                             prompt = getattr(action, 'prompt', None)
@@ -369,6 +379,16 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
                                 kwargs.append(f"llm_name={repr(llm_name)}")
                             args = ", ".join(kwargs)
                             f.write(f"{state_var}_fallback_body.add_action(LLMReply({args}))\n")
+                        elif isinstance(action, LLMChatReply):
+                            kwargs = []
+                            prompt = getattr(action, 'prompt', None)
+                            if prompt:
+                                kwargs.append(f"prompt='{_escape_python_string(prompt)}'")
+                            llm_name = getattr(action, 'llm_name', None)
+                            if llm_name:
+                                kwargs.append(f"llm_name={repr(llm_name)}")
+                            args = ", ".join(kwargs)
+                            f.write(f"{state_var}_fallback_body.add_action(LLMChatReply({args}))\n")
                         elif isinstance(action, RAGReply):
                             rag_name = _escape_python_string(action.rag_db_name or '')
                             prompt = getattr(action, 'prompt', None)

--- a/besser/utilities/buml_code_builder/agent_model_builder.py
+++ b/besser/utilities/buml_code_builder/agent_model_builder.py
@@ -7,8 +7,11 @@ This module generates Python code for BUML agent models.
 import os
 from re import search
 from besser.BUML.metamodel.state_machine.agent import (
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           Agent, AgentReply, LLMReply, LLMChatReply, RAGReply, DBReply,
+    Agent, AgentReply, LLMReply, LLMChatReply, RAGReply, DBReply,
     WebCrawlLLMReply, ReasoningState, llm_provider_key,
+    WebSocketReplyMarkdown, WebSocketReplyHTML, WebSocketReplySpeech,
+    WebSocketReplyOptions, WebSocketReplyLocation,
+    WebSocketReplyFile, WebSocketReplyImage, WebSocketReplyDataframe, WebSocketReplyPlotly,
 )
 from besser.BUML.metamodel.state_machine.state_machine import CustomCodeAction
 from besser.utilities.buml_code_builder.common import _escape_python_string, safe_var_name
@@ -51,6 +54,9 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
             "from besser.BUML.metamodel.state_machine.agent import "
             "Agent, AgentReply, LLMReply, LLMChatReply, RAGReply, DBReply, "
             "WebCrawlLLMReply, "
+            "WebSocketReplyMarkdown, WebSocketReplyHTML, WebSocketReplySpeech, "
+            "WebSocketReplyOptions, WebSocketReplyLocation, "
+            "WebSocketReplyFile, WebSocketReplyImage, WebSocketReplyDataframe, WebSocketReplyPlotly, "
             "LLMOpenAI, LLMHuggingFace, LLMHuggingFaceAPI, LLMReplicate, "
             "RAGVectorStore, RAGTextSplitter, "
             "Tool, Skill, Workspace, ReasoningState, "
@@ -365,6 +371,27 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
                             if getattr(action, 'llm_name', None):
                                 wc_args.append(f"llm_name={repr(action.llm_name)}")
                             f.write(f"{state_var}_body.add_action(WebCrawlLLMReply({', '.join(wc_args)}))\n")
+                        elif isinstance(action, WebSocketReplyMarkdown):
+                            f.write(f"{state_var}_body.add_action(WebSocketReplyMarkdown(message={repr(action.message)}))\n")
+                        elif isinstance(action, WebSocketReplyHTML):
+                            f.write(f"{state_var}_body.add_action(WebSocketReplyHTML(message={repr(action.message)}))\n")
+                        elif isinstance(action, WebSocketReplySpeech):
+                            args = f"message={repr(action.message)}"
+                            if action.audio_speed is not None:
+                                args += f", audio_speed={action.audio_speed!r}"
+                            f.write(f"{state_var}_body.add_action(WebSocketReplySpeech({args}))\n")
+                        elif isinstance(action, WebSocketReplyOptions):
+                            f.write(f"{state_var}_body.add_action(WebSocketReplyOptions(options={action.options!r}))\n")
+                        elif isinstance(action, WebSocketReplyLocation):
+                            f.write(f"{state_var}_body.add_action(WebSocketReplyLocation(latitude={action.latitude!r}, longitude={action.longitude!r}))\n")
+                        elif isinstance(action, WebSocketReplyFile):
+                            f.write(f"{state_var}_body.add_action(WebSocketReplyFile())\n")
+                        elif isinstance(action, WebSocketReplyImage):
+                            f.write(f"{state_var}_body.add_action(WebSocketReplyImage())\n")
+                        elif isinstance(action, WebSocketReplyDataframe):
+                            f.write(f"{state_var}_body.add_action(WebSocketReplyDataframe())\n")
+                        elif isinstance(action, WebSocketReplyPlotly):
+                            f.write(f"{state_var}_body.add_action(WebSocketReplyPlotly())\n")
                         elif isinstance(action, AgentReply):
                             f.write(f"{state_var}_body.add_action(AgentReply('{_escape_python_string(action.message)}'))\n")
                 f.write("\n")
@@ -452,6 +479,27 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
                             if getattr(action, 'llm_name', None):
                                 wc_args.append(f"llm_name={repr(action.llm_name)}")
                             f.write(f"{state_var}_fallback_body.add_action(WebCrawlLLMReply({', '.join(wc_args)}))\n")
+                        elif isinstance(action, WebSocketReplyMarkdown):
+                            f.write(f"{state_var}_fallback_body.add_action(WebSocketReplyMarkdown(message={repr(action.message)}))\n")
+                        elif isinstance(action, WebSocketReplyHTML):
+                            f.write(f"{state_var}_fallback_body.add_action(WebSocketReplyHTML(message={repr(action.message)}))\n")
+                        elif isinstance(action, WebSocketReplySpeech):
+                            args = f"message={repr(action.message)}"
+                            if action.audio_speed is not None:
+                                args += f", audio_speed={action.audio_speed!r}"
+                            f.write(f"{state_var}_fallback_body.add_action(WebSocketReplySpeech({args}))\n")
+                        elif isinstance(action, WebSocketReplyOptions):
+                            f.write(f"{state_var}_fallback_body.add_action(WebSocketReplyOptions(options={action.options!r}))\n")
+                        elif isinstance(action, WebSocketReplyLocation):
+                            f.write(f"{state_var}_fallback_body.add_action(WebSocketReplyLocation(latitude={action.latitude!r}, longitude={action.longitude!r}))\n")
+                        elif isinstance(action, WebSocketReplyFile):
+                            f.write(f"{state_var}_fallback_body.add_action(WebSocketReplyFile())\n")
+                        elif isinstance(action, WebSocketReplyImage):
+                            f.write(f"{state_var}_fallback_body.add_action(WebSocketReplyImage())\n")
+                        elif isinstance(action, WebSocketReplyDataframe):
+                            f.write(f"{state_var}_fallback_body.add_action(WebSocketReplyDataframe())\n")
+                        elif isinstance(action, WebSocketReplyPlotly):
+                            f.write(f"{state_var}_fallback_body.add_action(WebSocketReplyPlotly())\n")
                         elif isinstance(action, AgentReply):
                             f.write(f"{state_var}_fallback_body.add_action(AgentReply('{_escape_python_string(action.message)}'))\n")
                 f.write("\n")

--- a/besser/utilities/buml_code_builder/agent_model_builder.py
+++ b/besser/utilities/buml_code_builder/agent_model_builder.py
@@ -282,18 +282,25 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
             state_var = state_var_names[state.name]
             f.write(f"# {state.name} state\n")
             # Write body function if it exists
-            if state.body:
-                # Check if the body has a messages attribute
-                if hasattr(state.body, 'actions') and state.body.actions:
-                    if isinstance(state.body.actions[0], AgentReply):
-                        f.write(f"{state_var}_body = Body('{_escape_python_string(state.name)}_body')\n")
-                        for action in state.body.actions:
-                            f.write(f"{state_var}_body.add_action(AgentReply('{_escape_python_string(action.message)}'))\n")
-                        f.write("\n")
-                        f.write(f"{state_var}.set_body({state_var}_body)\n")
-                    elif isinstance(state.body.actions[0], LLMReply):
-                        f.write(f"{state_var}_body = Body('{_escape_python_string(state.name)}_body')\n")
-                        for action in state.body.actions:
+            if state.body and hasattr(state.body, 'actions') and state.body.actions:
+                # Check if this is a custom code body (singleton, emitted before Body creation)
+                if any(isinstance(a, CustomCodeAction) for a in state.body.actions):
+                    # CustomCodeAction is always a singleton in a custom body
+                    action = next(a for a in state.body.actions if isinstance(a, CustomCodeAction))
+                    f.write(f"{action.to_code()}\n")
+                    function_match = search(r'def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(', action.code)
+                    function_name = function_match.group(1) if function_match else f"custom_action_{safe_var_name(action.name)}"
+                    f.write(
+                        f"CustomCodeAction_{state_var} = "
+                        f"CustomCodeAction(callable={function_name})\n"
+                    )
+                    f.write(f"{state_var}_body = Body('{_escape_python_string(state.name)}_body')\n")
+                    f.write(f"{state_var}_body.add_action(CustomCodeAction_{state_var})\n")
+                else:
+                    # Predefined body: dispatch each action individually by its own type
+                    f.write(f"{state_var}_body = Body('{_escape_python_string(state.name)}_body')\n")
+                    for action in state.body.actions:
+                        if isinstance(action, LLMReply):
                             kwargs = []
                             prompt = getattr(action, 'prompt', None)
                             if prompt:
@@ -303,24 +310,14 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
                                 kwargs.append(f"llm_name={repr(llm_name)}")
                             args = ", ".join(kwargs)
                             f.write(f"{state_var}_body.add_action(LLMReply({args}))\n")
-                        f.write("\n")
-                        f.write(f"{state_var}.set_body({state_var}_body)\n")
-                    elif isinstance(state.body.actions[0], RAGReply):
-                        f.write(f"{state_var}_body = Body('{_escape_python_string(state.name)}_body')\n")
-                        for action in state.body.actions:
+                        elif isinstance(action, RAGReply):
                             rag_name = _escape_python_string(action.rag_db_name or '')
                             prompt = getattr(action, 'prompt', None)
                             if prompt:
-                                f.write(
-                                    f"{state_var}_body.add_action(RAGReply('{rag_name}', prompt='{_escape_python_string(prompt)}'))\n"
-                                )
+                                f.write(f"{state_var}_body.add_action(RAGReply('{rag_name}', prompt='{_escape_python_string(prompt)}'))\n")
                             else:
                                 f.write(f"{state_var}_body.add_action(RAGReply('{rag_name}'))\n")
-                        f.write("\n")
-                        f.write(f"{state_var}.set_body({state_var}_body)\n")
-                    elif isinstance(state.body.actions[0], DBReply):
-                        f.write(f"{state_var}_body = Body('{_escape_python_string(state.name)}_body')\n")
-                        for action in state.body.actions:
+                        elif isinstance(action, DBReply):
                             db_args = []
                             if getattr(action, 'db_selection_type', 'default') != 'default':
                                 db_args.append(f"db_selection_type={action.db_selection_type!r}")
@@ -337,37 +334,31 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
                                 db_args.append(f"llm_name={repr(llm_name)}")
                             args = ", ".join(db_args)
                             f.write(f"{state_var}_body.add_action(DBReply({args}))\n" if args else f"{state_var}_body.add_action(DBReply())\n")
-                        f.write("\n")
-                        f.write(f"{state_var}.set_body({state_var}_body)\n")
-                    elif isinstance(state.body.actions[0], CustomCodeAction):
-                        action = state.body.actions[0]
-                        f.write(f"{action.to_code()}\n")
-                        function_match = search(r'def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(', action.code)
-                        if function_match:
-                            function_name = function_match.group(1)
-                        else:
-                            function_name = f"custom_action_{safe_var_name(action.name)}"
-                        f.write(
-                            f"CustomCodeAction_{state_var} = "
-                            f"CustomCodeAction(callable={function_name})\n"
-                        )
-                        f.write(f"{state_var}_body = Body('{_escape_python_string(state.name)}_body')\n")
-                        f.write(f"{state_var}_body.add_action(CustomCodeAction_{state_var})\n")
-                        f.write(f"{state_var}.set_body({state_var}_body)\n")
+                        elif isinstance(action, AgentReply):
+                            f.write(f"{state_var}_body.add_action(AgentReply('{_escape_python_string(action.message)}'))\n")
+                f.write("\n")
+                f.write(f"{state_var}.set_body({state_var}_body)\n")
 
             # Write fallback body function if it exists
-            if state.fallback_body:
-                # Check if the fallback body has a messages attribute
-                if hasattr(state.fallback_body, 'actions') and state.fallback_body.actions:
-                    if isinstance(state.fallback_body.actions[0], AgentReply):
-                        f.write(f"{state_var}_fallback_body = Body('{_escape_python_string(state.name)}_fallback_body')\n")
-                        for action in state.fallback_body.actions:
-                            f.write(f"{state_var}_fallback_body.add_action(AgentReply('{_escape_python_string(action.message)}'))\n")
-                        f.write("\n")
-                        f.write(f"{state_var}.set_fallback_body({state_var}_fallback_body)\n")
-                    elif isinstance(state.fallback_body.actions[0], LLMReply):
-                        f.write(f"{state_var}_fallback_body = Body('{_escape_python_string(state.name)}_fallback_body')\n")
-                        for action in state.fallback_body.actions:
+            if state.fallback_body and hasattr(state.fallback_body, 'actions') and state.fallback_body.actions:
+                # Check if this is a custom code fallback body (singleton, emitted before Body creation)
+                if any(isinstance(a, CustomCodeAction) for a in state.fallback_body.actions):
+                    # CustomCodeAction is always a singleton in a custom body
+                    action = next(a for a in state.fallback_body.actions if isinstance(a, CustomCodeAction))
+                    f.write(f"{action.to_code()}\n")
+                    function_match = search(r'def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(', action.code)
+                    function_name = function_match.group(1) if function_match else f"custom_action_{safe_var_name(action.name)}"
+                    f.write(
+                        f"CustomCodeAction_{state_var}_fallback = "
+                        f"CustomCodeAction(callable={function_name})\n"
+                    )
+                    f.write(f"{state_var}_fallback_body = Body('{_escape_python_string(state.name)}_fallback_body')\n")
+                    f.write(f"{state_var}_fallback_body.add_action(CustomCodeAction_{state_var}_fallback)\n")
+                else:
+                    # Predefined fallback body: dispatch each action individually by its own type
+                    f.write(f"{state_var}_fallback_body = Body('{_escape_python_string(state.name)}_fallback_body')\n")
+                    for action in state.fallback_body.actions:
+                        if isinstance(action, LLMReply):
                             kwargs = []
                             prompt = getattr(action, 'prompt', None)
                             if prompt:
@@ -377,24 +368,14 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
                                 kwargs.append(f"llm_name={repr(llm_name)}")
                             args = ", ".join(kwargs)
                             f.write(f"{state_var}_fallback_body.add_action(LLMReply({args}))\n")
-                        f.write("\n")
-                        f.write(f"{state_var}.set_fallback_body({state_var}_fallback_body)\n")
-                    elif isinstance(state.fallback_body.actions[0], RAGReply):
-                        f.write(f"{state_var}_fallback_body = Body('{_escape_python_string(state.name)}_fallback_body')\n")
-                        for action in state.fallback_body.actions:
+                        elif isinstance(action, RAGReply):
                             rag_name = _escape_python_string(action.rag_db_name or '')
                             prompt = getattr(action, 'prompt', None)
                             if prompt:
-                                f.write(f"{state_var}_fallback_body.add_action(\n")
-                                f.write(f"    RAGReply('{rag_name}', prompt='{_escape_python_string(prompt)}')\n")
-                                f.write(")\n")
+                                f.write(f"{state_var}_fallback_body.add_action(RAGReply('{rag_name}', prompt='{_escape_python_string(prompt)}'))\n")
                             else:
                                 f.write(f"{state_var}_fallback_body.add_action(RAGReply('{rag_name}'))\n")
-                        f.write("\n")
-                        f.write(f"{state_var}.set_fallback_body({state_var}_fallback_body)\n")
-                    elif isinstance(state.fallback_body.actions[0], DBReply):
-                        f.write(f"{state_var}_fallback_body = Body('{_escape_python_string(state.name)}_fallback_body')\n")
-                        for action in state.fallback_body.actions:
+                        elif isinstance(action, DBReply):
                             db_args = []
                             if getattr(action, 'db_selection_type', 'default') != 'default':
                                 db_args.append(f"db_selection_type={action.db_selection_type!r}")
@@ -411,23 +392,10 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
                                 db_args.append(f"llm_name={repr(llm_name)}")
                             args = ", ".join(db_args)
                             f.write(f"{state_var}_fallback_body.add_action(DBReply({args}))\n" if args else f"{state_var}_fallback_body.add_action(DBReply())\n")
-                        f.write("\n")
-                        f.write(f"{state_var}.set_fallback_body({state_var}_fallback_body)\n")
-                    elif isinstance(state.fallback_body.actions[0], CustomCodeAction):
-                        action = state.fallback_body.actions[0]
-                        f.write(f"{action.to_code()}\n")
-                        function_match = search(r'def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(', action.code)
-                        if function_match:
-                            function_name = function_match.group(1)
-                        else:
-                            function_name = f"custom_action_{safe_var_name(action.name)}"
-                        f.write(
-                            f"CustomCodeAction_{state_var}_fallback = "
-                            f"CustomCodeAction(callable={function_name})\n"
-                        )
-                        f.write(f"{state_var}_fallback_body = Body('{_escape_python_string(state.name)}_fallback_body')\n")
-                        f.write(f"{state_var}_fallback_body.add_action(CustomCodeAction_{state_var}_fallback)\n")
-                        f.write(f"{state_var}.set_fallback_body({state_var}_fallback_body)\n")
+                        elif isinstance(action, AgentReply):
+                            f.write(f"{state_var}_fallback_body.add_action(AgentReply('{_escape_python_string(action.message)}'))\n")
+                f.write("\n")
+                f.write(f"{state_var}.set_fallback_body({state_var}_fallback_body)\n")
 
             # Write transitions
             for transition in state.transitions:

--- a/besser/utilities/buml_code_builder/agent_model_builder.py
+++ b/besser/utilities/buml_code_builder/agent_model_builder.py
@@ -7,8 +7,8 @@ This module generates Python code for BUML agent models.
 import os
 from re import search
 from besser.BUML.metamodel.state_machine.agent import (
-    Agent, AgentReply, LLMReply, LLMChatReply, RAGReply, DBReply,
-    ReasoningState, llm_provider_key,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           Agent, AgentReply, LLMReply, LLMChatReply, RAGReply, DBReply,
+    WebCrawlLLMReply, ReasoningState, llm_provider_key,
 )
 from besser.BUML.metamodel.state_machine.state_machine import CustomCodeAction
 from besser.utilities.buml_code_builder.common import _escape_python_string, safe_var_name
@@ -50,6 +50,7 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
         f.write(
             "from besser.BUML.metamodel.state_machine.agent import "
             "Agent, AgentReply, LLMReply, LLMChatReply, RAGReply, DBReply, "
+            "WebCrawlLLMReply, "
             "LLMOpenAI, LLMHuggingFace, LLMHuggingFaceAPI, LLMReplicate, "
             "RAGVectorStore, RAGTextSplitter, "
             "Tool, Skill, Workspace, ReasoningState, "
@@ -345,6 +346,25 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
                                 db_args.append(f"llm_name={repr(llm_name)}")
                             args = ", ".join(db_args)
                             f.write(f"{state_var}_body.add_action(DBReply({args}))\n" if args else f"{state_var}_body.add_action(DBReply())\n")
+                        elif isinstance(action, WebCrawlLLMReply):
+                            wc_args = [f"initial_url={repr(action.initial_url)}"]
+                            if action.max_depth != 2:
+                                wc_args.append(f"max_depth={action.max_depth!r}")
+                            if action.max_pages != 20:
+                                wc_args.append(f"max_pages={action.max_pages!r}")
+                            if action.crawl_format != 'markdown':
+                                wc_args.append(f"crawl_format={action.crawl_format!r}")
+                            if action.base_url_prefix:
+                                wc_args.append(f"base_url_prefix={repr(action.base_url_prefix)}")
+                            if not action.run_crawl:
+                                wc_args.append("run_crawl=False")
+                            if action.no_crawl_error_message != 'No web crawl data is available yet.':
+                                wc_args.append(f"no_crawl_error_message={repr(action.no_crawl_error_message)}")
+                            if action.system_message_prefix:
+                                wc_args.append(f"system_message_prefix={repr(action.system_message_prefix)}")
+                            if getattr(action, 'llm_name', None):
+                                wc_args.append(f"llm_name={repr(action.llm_name)}")
+                            f.write(f"{state_var}_body.add_action(WebCrawlLLMReply({', '.join(wc_args)}))\n")
                         elif isinstance(action, AgentReply):
                             f.write(f"{state_var}_body.add_action(AgentReply('{_escape_python_string(action.message)}'))\n")
                 f.write("\n")
@@ -413,6 +433,25 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
                                 db_args.append(f"llm_name={repr(llm_name)}")
                             args = ", ".join(db_args)
                             f.write(f"{state_var}_fallback_body.add_action(DBReply({args}))\n" if args else f"{state_var}_fallback_body.add_action(DBReply())\n")
+                        elif isinstance(action, WebCrawlLLMReply):
+                            wc_args = [f"initial_url={repr(action.initial_url)}"]
+                            if action.max_depth != 2:
+                                wc_args.append(f"max_depth={action.max_depth!r}")
+                            if action.max_pages != 20:
+                                wc_args.append(f"max_pages={action.max_pages!r}")
+                            if action.crawl_format != 'markdown':
+                                wc_args.append(f"crawl_format={action.crawl_format!r}")
+                            if action.base_url_prefix:
+                                wc_args.append(f"base_url_prefix={repr(action.base_url_prefix)}")
+                            if not action.run_crawl:
+                                wc_args.append("run_crawl=False")
+                            if action.no_crawl_error_message != 'No web crawl data is available yet.':
+                                wc_args.append(f"no_crawl_error_message={repr(action.no_crawl_error_message)}")
+                            if action.system_message_prefix:
+                                wc_args.append(f"system_message_prefix={repr(action.system_message_prefix)}")
+                            if getattr(action, 'llm_name', None):
+                                wc_args.append(f"llm_name={repr(action.llm_name)}")
+                            f.write(f"{state_var}_fallback_body.add_action(WebCrawlLLMReply({', '.join(wc_args)}))\n")
                         elif isinstance(action, AgentReply):
                             f.write(f"{state_var}_fallback_body.add_action(AgentReply('{_escape_python_string(action.message)}'))\n")
                 f.write("\n")

--- a/besser/utilities/web_modeling_editor/backend/models/diagram.py
+++ b/besser/utilities/web_modeling_editor/backend/models/diagram.py
@@ -21,6 +21,7 @@ class DiagramInput(BaseModel):
     lastUpdate: Optional[datetime] = None
     generator: Optional[str] = None
     config: Optional[dict] = None
+    configYaml: Optional[str] = None
     referenceDiagramData: Optional[Dict[str, Any]] = None
     references: Optional[Dict[str, str]] = None  # Per-diagram cross-references by ID (e.g. {"ClassDiagram": "uuid-..."})
 

--- a/besser/utilities/web_modeling_editor/backend/routers/conversion_router.py
+++ b/besser/utilities/web_modeling_editor/backend/routers/conversion_router.py
@@ -12,6 +12,8 @@ import tempfile
 import uuid
 import importlib.util
 import json
+
+import requests
 from copy import deepcopy
 from datetime import datetime, timezone
 
@@ -580,6 +582,49 @@ async def get_single_json_model(buml_file: UploadFile = File(...)):
         "exportedAt": datetime.now(timezone.utc).isoformat(),
         "version": API_VERSION
     }
+
+@router.post("/get-svg")
+@handle_endpoint_errors("get_svg")
+async def get_svg(buml_file: UploadFile = File(...)):
+    """
+    Convert a B-UML class-diagram file to an auto-laid-out SVG image.
+
+    Pipeline: parse the B-UML to a DomainModel, convert it to the editor JSON
+    model, then delegate rendering to the WME Node server (Apollon, headless),
+    which runs ELK auto-layout and exports SVG. The Node server base URL is read
+    from the WME_NODE_SERVER_URL env var (default http://localhost:8080).
+    """
+    content = await buml_file.read()
+    _validate_upload(buml_file, max_size=MAX_BUML_SIZE, allowed_extensions=ALLOWED_BUML_EXTENSIONS, content=content)
+    _validate_file_content(content, buml_file.filename or "")
+    buml_content = content.decode("utf-8")
+
+    domain_model = parse_buml_content(buml_content)
+    if not domain_model or len(domain_model.types) == 0:
+        raise HTTPException(status_code=400, detail="No class/enumeration types found in the B-UML model")
+
+    diagram_json = class_buml_to_json(domain_model)
+
+    node_server_url = os.environ.get("WME_NODE_SERVER_URL", "http://localhost:8080").rstrip("/")
+    try:
+        render_response = requests.post(
+            f"{node_server_url}/api/svg",
+            json={"model": diagram_json, "autoLayout": True},
+            timeout=30,
+        )
+        render_response.raise_for_status()
+    except requests.RequestException as exc:
+        raise HTTPException(status_code=502, detail=f"SVG render service unavailable: {exc}") from exc
+
+    svg = render_response.json().get("svg")
+    if not svg:
+        raise HTTPException(status_code=502, detail="SVG render service returned no SVG content")
+
+    return Response(
+        content=svg,
+        media_type="image/svg+xml",
+        headers={"Content-Disposition": 'inline; filename="diagram.svg"'},
+    )
 
 @router.post("/csv-to-domain-model", response_model=DiagramExportResponse)
 @handle_endpoint_errors("csv_to_domain_model_endpoint")

--- a/besser/utilities/web_modeling_editor/backend/routers/generation_router.py
+++ b/besser/utilities/web_modeling_editor/backend/routers/generation_router.py
@@ -283,6 +283,7 @@ def generate_agent_files(
     agent_model,
     config,
     generation_mode: GenerationMode = GenerationMode.FULL,
+    config_yaml: Optional[str] = None,
 ):
     """
     Generate agent files from an agent model.
@@ -341,6 +342,7 @@ def generate_agent_files(
                     config=config,
                     openai_api_key=openai_api_key,
                     generation_mode=generation_mode,
+                    config_yaml=config_yaml,
                 )
             else:
                 # Fall back to the original agent model
@@ -350,6 +352,7 @@ def generate_agent_files(
                     config=config,
                     openai_api_key=openai_api_key,
                     generation_mode=generation_mode,
+                    config_yaml=config_yaml,
                 )
 
             generator.generate()
@@ -454,6 +457,7 @@ async def generate_code_output_from_project(input_data: ProjectInput):
             lastUpdate=diagram.lastUpdate,
             generator=generator_type,
             config=config,
+            configYaml=diagram.configYaml,
             referenceDiagramData=getattr(diagram, "referenceDiagramData", None),
         )
         return await generate_code_output(diagram_input)
@@ -474,6 +478,7 @@ async def generate_code_output_from_project(input_data: ProjectInput):
         lastUpdate=current_diagram.lastUpdate,
         generator=generator_type,
         config=config,
+        configYaml=current_diagram.configYaml,
         referenceDiagramData=current_diagram.referenceDiagramData
     )
 
@@ -576,12 +581,13 @@ async def _handle_web_app_project_generation(input_data: ProjectInput, generator
         # satisfy any binding — we don't filter to the active reference here.
         agent_models = []
         agent_configs = {}
+        agent_config_yamls: dict = {}
         has_agent_components = _check_for_agent_components(gui_model)
 
         if has_agent_components:
             project_agent_config = config.get('agentConfig') if isinstance(config, dict) else None
             default_cfg = project_agent_config or config
-            agent_models, agent_configs = collect_agents_from_diagrams(
+            agent_models, agent_configs, agent_config_yamls = collect_agents_from_diagrams(
                 input_data.diagrams.get("AgentDiagram", []),
                 default_config=default_cfg,
             )
@@ -601,6 +607,7 @@ async def _handle_web_app_project_generation(input_data: ProjectInput, generator
         return await _generate_web_app(
             buml_model, gui_model, generator_class, config, temp_dir,
             agent_models=agent_models, agent_configs=agent_configs,
+            agent_config_yamls=agent_config_yamls,
         )
 
 
@@ -617,6 +624,7 @@ def _streaming_zip(zip_buffer: io.BytesIO, file_name: str) -> StreamingResponse:
 async def _handle_agent_generation(json_data: dict):
     """Handle agent diagram generation by dispatching to specialized helpers."""
     config = json_data.get('config', {})
+    config_yaml: Optional[str] = json_data.get('configYaml') if isinstance(json_data.get('configYaml'), str) else None
     sanitized_config_log = (
         json.dumps(sanitize_config(config), indent=2, default=str) if config else 'None'
     )
@@ -624,7 +632,9 @@ async def _handle_agent_generation(json_data: dict):
 
     if config is None:
         agent_model = process_agent_diagram(json_data)
-        zip_buffer, file_name = await asyncio.to_thread(generate_agent_files, agent_model, config)
+        zip_buffer, file_name = await asyncio.to_thread(
+            generate_agent_files, agent_model, config, config_yaml=config_yaml
+        )
         return _streaming_zip(zip_buffer, file_name)
 
     is_config_dict = isinstance(config, dict)
@@ -647,22 +657,26 @@ async def _handle_agent_generation(json_data: dict):
     if base_model_snapshot is not None and isinstance(variation_entries, list):
         buf, name = handle_variation_generation(
             json_data, config, base_model_snapshot, variation_entries, generate_agent_files,
+            config_yaml=config_yaml,
         )
         return _streaming_zip(buf, name)
 
     if configuration_variants and isinstance(configuration_variants, list):
         buf, name = handle_configuration_variants(
             json_data, configuration_variants, generate_agent_files,
+            config_yaml=config_yaml,
         )
         return _streaming_zip(buf, name)
 
     if is_config_dict and 'personalizationMapping' in config:
-        buf, name = handle_personalized_agent(json_data, config, generate_agent_files)
+        buf, name = handle_personalized_agent(json_data, config, generate_agent_files, config_yaml=config_yaml)
         return _streaming_zip(buf, name)
 
     # Single agent fallback
     agent_model = process_agent_diagram(json_data)
-    zip_buffer, file_name = await asyncio.to_thread(generate_agent_files, agent_model, config)
+    zip_buffer, file_name = await asyncio.to_thread(
+        generate_agent_files, agent_model, config, config_yaml=config_yaml
+    )
     return _streaming_zip(zip_buffer, file_name)
 
 
@@ -1058,7 +1072,7 @@ def _check_container_for_agent_components(container):
     return False
 
 async def _generate_web_app(buml_model, gui_model, generator_class, config: dict, temp_dir: str,
-                            agent_models=None, agent_configs=None):
+                            agent_models=None, agent_configs=None, agent_config_yamls=None):
     """Generate web application files.
 
     Supports multi-agent projects: ``agent_models`` is a list and each is emitted
@@ -1067,6 +1081,7 @@ async def _generate_web_app(buml_model, gui_model, generator_class, config: dict
     generator_instance = generator_class(
         buml_model, gui_model, output_dir=temp_dir,
         agent_models=agent_models, agent_configs=agent_configs,
+        agent_config_yamls=agent_config_yamls,
     )
     await asyncio.to_thread(generator_instance.generate)
     return _create_zip_response(temp_dir, "web_app")

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
@@ -1033,7 +1033,11 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                     elements[state_id] = {
                         "id": state_id,
                         "name": state_name,
-                        "type": "AgentReasoningState",
+                        # Reasoning states are modelled as an AgentState with
+                        # stateType "reasoning" (the editor no longer registers a
+                        # separate AgentReasoningState element type, so emitting the
+                        # legacy type would fail to deserialize on import).
+                        "type": "AgentState",
                         "stateType": "reasoning",
                         "owner": None,
                         "bounds": {

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
@@ -167,7 +167,7 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                 body_id = str(uuid.uuid4())
                 elements[body_id] = {
                     "id": body_id,
-                    "name": action.get("prompt") or "AI response",
+                    "name": "LLM Reply",
                     "type": element_type,
                     "owner": state_id,
                     "bounds": {
@@ -177,6 +177,8 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                         "height": 30,
                     },
                     "actionType": "LLMReplyAction",
+                    "replyType": "llm",
+                    "system_message": action.get("prompt") or "",
                     "llm_name": action.get("llm_name", "") or "",
                 }
                 elements[state_id][state_key].append(body_id)
@@ -1183,7 +1185,7 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                     body_id = str(uuid.uuid4())
                                     elements[body_id] = {
                                         "id": body_id,
-                                        "name": "AI response",
+                                        "name": "LLM Reply",
                                         "type": "AgentStateBody",
                                         "owner": state["id"],
                                         "bounds": {
@@ -1193,6 +1195,8 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                             "height": 30,
                                         },
                                         "actionType": "LLMReplyAction",
+                                        "replyType": "llm",
+                                        "system_message": "",
                                     }
                                     elements[state["id"]]["actions"].append(body_id)
                                 elif result["replyType"] == "code":
@@ -1216,7 +1220,7 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                     body_id = str(uuid.uuid4())
                                     elements[body_id] = {
                                         "id": body_id,
-                                        "name": "AI response",
+                                        "name": "LLM Reply",
                                         "type": "AgentStateBody",
                                         "owner": state["id"],
                                         "bounds": {
@@ -1226,6 +1230,8 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                             "height": 30,
                                         },
                                         "actionType": "LLMReplyAction",
+                                        "replyType": "llm",
+                                        "system_message": "",
                                     }
                                     elements[state["id"]]["actions"].append(body_id)
                                 elif isinstance(actions[function_name], list):
@@ -1324,7 +1330,7 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                     body_id = str(uuid.uuid4())
                                     elements[body_id] = {
                                         "id": body_id,
-                                        "name": "AI response",
+                                        "name": "LLM Reply",
                                         "type": "AgentStateFallbackBody",
                                         "owner": state["id"],
                                         "bounds": {
@@ -1334,6 +1340,8 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                             "height": 30,
                                         },
                                         "actionType": "LLMReplyAction",
+                                        "replyType": "llm",
+                                        "system_message": "",
                                     }
                                     elements[state["id"]]["fallbackActions"].append(body_id)
                                 elif result["replyType"] == "code":
@@ -1358,7 +1366,7 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                     body_id = str(uuid.uuid4())
                                     elements[body_id] = {
                                         "id": body_id,
-                                        "name": "AI response",
+                                        "name": "LLM Reply",
                                         "type": "AgentStateFallbackBody",
                                         "owner": state["id"],
                                         "bounds": {
@@ -1368,6 +1376,8 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                             "height": 30,
                                         },
                                         "actionType": "LLMReplyAction",
+                                        "replyType": "llm",
+                                        "system_message": "",
                                     }
                                     elements[state["id"]]["fallbackActions"].append(body_id)
                                 elif isinstance(actions[function_name], list):

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
@@ -136,7 +136,7 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
 
     def _add_action_elements_to_state(state_id: str, action_data: Any, fallback: bool = False) -> None:
         element_type = "AgentStateFallbackBody" if fallback else "AgentStateBody"
-        state_key = "fallbackBodies" if fallback else "bodies"
+        state_key = "fallbackActions" if fallback else "actions"
 
         if not isinstance(action_data, list):
             return
@@ -160,14 +160,14 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                         "width": 159,
                         "height": 30,
                     },
-                    "replyType": "text",
+                    "actionType": "TextReplyAction",
                 }
                 elements[state_id][state_key].append(body_id)
             elif action_type == "llm":
                 body_id = str(uuid.uuid4())
                 elements[body_id] = {
                     "id": body_id,
-                    "name": action.get("prompt") or "AI response 🪄",
+                    "name": action.get("prompt") or "AI response",
                     "type": element_type,
                     "owner": state_id,
                     "bounds": {
@@ -176,7 +176,7 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                         "width": 159,
                         "height": 30,
                     },
-                    "replyType": "llm",
+                    "actionType": "LLMReplyAction",
                     "llm_name": action.get("llm_name", "") or "",
                 }
                 elements[state_id][state_key].append(body_id)
@@ -199,7 +199,7 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                         "width": 159,
                         "height": 30,
                     },
-                    "replyType": "rag",
+                    "actionType": "RAGReplyAction",
                     "ragDatabaseName": rag_db_name,
                 }
                 elements[state_id][state_key].append(body_id)
@@ -224,7 +224,7 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                         "width": 159,
                         "height": 30,
                     },
-                    "replyType": "db_reply",
+                    "actionType": "DBAction",
                     "dbSelectionType": db_selection_type,
                     "dbCustomName": db_custom_name,
                     "dbQueryMode": db_query_mode,
@@ -780,6 +780,7 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                         "id": state_id,
                         "name": state_name,
                         "type": "AgentReasoningState",
+                        "stateType": "reasoning",
                         "owner": None,
                         "bounds": {
                             "x": states_x,
@@ -844,6 +845,7 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                         "id": state_id,
                         "name": state_name,
                         "type": "AgentState",
+                        "stateType": "standard",
                         "owner": None,
                         "bounds": {
                             "x": states_x,
@@ -851,8 +853,8 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                             "width": 160,
                             "height": 100,
                         },
-                        "bodies": [],
-                        "fallbackBodies": [],
+                        "actions": [],
+                        "fallbackActions": [],
                     }
 
                     # Update position for next element
@@ -881,6 +883,7 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                         "id": state_id,
                         "name": state_name,
                         "type": "AgentState",
+                        "stateType": "standard",
                         "owner": None,
                         "bounds": {
                             "x": states_x,
@@ -888,8 +891,8 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                             "width": 160,
                             "height": 100,
                         },
-                        "bodies": [],
-                        "fallbackBodies": [],
+                        "actions": [],
+                        "fallbackActions": [],
                     }
 
                     # Update position for next element
@@ -1173,14 +1176,14 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                                 "width": 159,
                                                 "height": 30,
                                             },
-                                            "replyType": "text"
+                                            "actionType": "TextReplyAction",
                                         }
-                                        elements[state["id"]]["bodies"].append(body_id)
+                                        elements[state["id"]]["actions"].append(body_id)
                                 elif result["replyType"] == "llm":
                                     body_id = str(uuid.uuid4())
                                     elements[body_id] = {
                                         "id": body_id,
-                                        "name": "AI response 🪄",
+                                        "name": "AI response",
                                         "type": "AgentStateBody",
                                         "owner": state["id"],
                                         "bounds": {
@@ -1189,9 +1192,9 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                             "width": 159,
                                             "height": 30,
                                         },
-                                        "replyType": "llm"
+                                        "actionType": "LLMReplyAction",
                                     }
-                                    elements[state["id"]]["bodies"].append(body_id)
+                                    elements[state["id"]]["actions"].append(body_id)
                                 elif result["replyType"] == "code":
                                     body_id = str(uuid.uuid4())
                                     elements[body_id] = {
@@ -1205,15 +1208,15 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                             "width": 159,
                                             "height": 30,
                                         },
-                                        "replyType": "code"
+                                        "actionType": "CustomCodeAction",
                                     }
-                                    elements[state["id"]]["bodies"].append(body_id)
+                                    elements[state["id"]]["actions"].append(body_id)
                             elif function_name in actions:
                                 if actions[function_name] == 'LLMReply':
                                     body_id = str(uuid.uuid4())
                                     elements[body_id] = {
                                         "id": body_id,
-                                        "name": "AI response 🪄",
+                                        "name": "AI response",
                                         "type": "AgentStateBody",
                                         "owner": state["id"],
                                         "bounds": {
@@ -1222,9 +1225,9 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                             "width": 159,
                                             "height": 30,
                                         },
-                                        "replyType": "llm"
+                                        "actionType": "LLMReplyAction",
                                     }
-                                    elements[state["id"]]["bodies"].append(body_id)
+                                    elements[state["id"]]["actions"].append(body_id)
                                 elif isinstance(actions[function_name], list):
                                     _add_action_elements_to_state(state["id"], actions[function_name], fallback=False)
                                 else:
@@ -1242,9 +1245,9 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                                 "width": 159,
                                                 "height": 30,
                                             },
-                                            "replyType": "text"
+                                            "actionType": "TextReplyAction",
                                         }
-                                        elements[state["id"]]["bodies"].append(body_id)
+                                        elements[state["id"]]["actions"].append(body_id)
 
 
                             else:
@@ -1314,14 +1317,14 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                                 "width": 159,
                                                 "height": 30,
                                             },
-                                            "replyType": "text"
+                                            "actionType": "TextReplyAction",
                                         }
-                                        elements[state["id"]]["fallbackBodies"].append(body_id)
+                                        elements[state["id"]]["fallbackActions"].append(body_id)
                                 elif result["replyType"] == "llm":
                                     body_id = str(uuid.uuid4())
                                     elements[body_id] = {
                                         "id": body_id,
-                                        "name": "AI response 🪄",
+                                        "name": "AI response",
                                         "type": "AgentStateFallbackBody",
                                         "owner": state["id"],
                                         "bounds": {
@@ -1330,9 +1333,9 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                             "width": 159,
                                             "height": 30,
                                         },
-                                        "replyType": "llm"
+                                        "actionType": "LLMReplyAction",
                                     }
-                                    elements[state["id"]]["fallbackBodies"].append(body_id)
+                                    elements[state["id"]]["fallbackActions"].append(body_id)
                                 elif result["replyType"] == "code":
                                     body_id = str(uuid.uuid4())
                                     elements[body_id] = {
@@ -1346,16 +1349,16 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                             "width": 159,
                                             "height": 30,
                                         },
-                                        "replyType": "code"
+                                        "actionType": "CustomCodeAction",
                                     }
-                                    elements[state["id"]]["fallbackBodies"].append(body_id)
+                                    elements[state["id"]]["fallbackActions"].append(body_id)
 
                             elif function_name in actions:
                                 if actions[function_name] == 'LLMReply':
                                     body_id = str(uuid.uuid4())
                                     elements[body_id] = {
                                         "id": body_id,
-                                        "name": "AI response 🪄",
+                                        "name": "AI response",
                                         "type": "AgentStateFallbackBody",
                                         "owner": state["id"],
                                         "bounds": {
@@ -1364,9 +1367,9 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                             "width": 159,
                                             "height": 30,
                                         },
-                                        "replyType": "llm"
+                                        "actionType": "LLMReplyAction",
                                     }
-                                    elements[state["id"]]["fallbackBodies"].append(body_id)
+                                    elements[state["id"]]["fallbackActions"].append(body_id)
                                 elif isinstance(actions[function_name], list):
                                     _add_action_elements_to_state(state["id"], actions[function_name], fallback=True)
                                 else:
@@ -1382,9 +1385,9 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                             "width": 159,
                                             "height": 30,
                                         },
-                                        "replyType": "text"
+                                        "actionType": "TextReplyAction",
                                     }
-                                    elements[state["id"]]["fallbackBodies"].append(body_id)
+                                    elements[state["id"]]["fallbackActions"].append(body_id)
 
                             else:
                                 # Fallback if function not found

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
@@ -284,6 +284,88 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                     "llm_name": action.get("llm_name", "") or "",
                 }
                 elements[state_id][state_key].append(body_id)
+            elif action_type == "ws_markdown":
+                body_id = str(uuid.uuid4())
+                elements[body_id] = {
+                    "id": body_id, "name": "Reply Markdown", "type": element_type, "owner": state_id,
+                    "bounds": {"x": elements[state_id]["bounds"]["x"], "y": elements[state_id]["bounds"]["y"], "width": 159, "height": 30},
+                    "actionType": "WebSocketReplyMarkdownAction", "replyType": "ws_markdown",
+                    "ws_message": action.get("ws_message") or action.get("message") or "",
+                }
+                elements[state_id][state_key].append(body_id)
+            elif action_type == "ws_html":
+                body_id = str(uuid.uuid4())
+                elements[body_id] = {
+                    "id": body_id, "name": "Reply HTML", "type": element_type, "owner": state_id,
+                    "bounds": {"x": elements[state_id]["bounds"]["x"], "y": elements[state_id]["bounds"]["y"], "width": 159, "height": 30},
+                    "actionType": "WebSocketReplyHTMLAction", "replyType": "ws_html",
+                    "ws_message": action.get("ws_message") or action.get("message") or "",
+                }
+                elements[state_id][state_key].append(body_id)
+            elif action_type == "ws_speech":
+                body_id = str(uuid.uuid4())
+                elements[body_id] = {
+                    "id": body_id, "name": "Reply Speech", "type": element_type, "owner": state_id,
+                    "bounds": {"x": elements[state_id]["bounds"]["x"], "y": elements[state_id]["bounds"]["y"], "width": 159, "height": 30},
+                    "actionType": "WebSocketReplySpeechAction", "replyType": "ws_speech",
+                    "ws_message": action.get("ws_message") or action.get("message") or "",
+                    "ws_audio_speed": action.get("ws_audio_speed"),
+                }
+                elements[state_id][state_key].append(body_id)
+            elif action_type == "ws_options":
+                body_id = str(uuid.uuid4())
+                opts = action.get("ws_options") or action.get("options") or ""
+                if isinstance(opts, list):
+                    opts = "\n".join(opts)
+                elements[body_id] = {
+                    "id": body_id, "name": "Reply Options", "type": element_type, "owner": state_id,
+                    "bounds": {"x": elements[state_id]["bounds"]["x"], "y": elements[state_id]["bounds"]["y"], "width": 159, "height": 30},
+                    "actionType": "WebSocketReplyOptionsAction", "replyType": "ws_options",
+                    "ws_options": opts,
+                }
+                elements[state_id][state_key].append(body_id)
+            elif action_type == "ws_location":
+                body_id = str(uuid.uuid4())
+                elements[body_id] = {
+                    "id": body_id, "name": "Reply Location", "type": element_type, "owner": state_id,
+                    "bounds": {"x": elements[state_id]["bounds"]["x"], "y": elements[state_id]["bounds"]["y"], "width": 159, "height": 30},
+                    "actionType": "WebSocketReplyLocationAction", "replyType": "ws_location",
+                    "ws_latitude": float(action.get("ws_latitude") or action.get("latitude") or 0.0),
+                    "ws_longitude": float(action.get("ws_longitude") or action.get("longitude") or 0.0),
+                }
+                elements[state_id][state_key].append(body_id)
+            elif action_type == "ws_file":
+                body_id = str(uuid.uuid4())
+                elements[body_id] = {
+                    "id": body_id, "name": "Reply File", "type": element_type, "owner": state_id,
+                    "bounds": {"x": elements[state_id]["bounds"]["x"], "y": elements[state_id]["bounds"]["y"], "width": 159, "height": 30},
+                    "actionType": "WebSocketReplyFileAction", "replyType": "ws_file",
+                }
+                elements[state_id][state_key].append(body_id)
+            elif action_type == "ws_image":
+                body_id = str(uuid.uuid4())
+                elements[body_id] = {
+                    "id": body_id, "name": "Reply Image", "type": element_type, "owner": state_id,
+                    "bounds": {"x": elements[state_id]["bounds"]["x"], "y": elements[state_id]["bounds"]["y"], "width": 159, "height": 30},
+                    "actionType": "WebSocketReplyImageAction", "replyType": "ws_image",
+                }
+                elements[state_id][state_key].append(body_id)
+            elif action_type == "ws_dataframe":
+                body_id = str(uuid.uuid4())
+                elements[body_id] = {
+                    "id": body_id, "name": "Reply Dataframe", "type": element_type, "owner": state_id,
+                    "bounds": {"x": elements[state_id]["bounds"]["x"], "y": elements[state_id]["bounds"]["y"], "width": 159, "height": 30},
+                    "actionType": "WebSocketReplyDataframeAction", "replyType": "ws_dataframe",
+                }
+                elements[state_id][state_key].append(body_id)
+            elif action_type == "ws_plotly":
+                body_id = str(uuid.uuid4())
+                elements[body_id] = {
+                    "id": body_id, "name": "Reply Plotly", "type": element_type, "owner": state_id,
+                    "bounds": {"x": elements[state_id]["bounds"]["x"], "y": elements[state_id]["bounds"]["y"], "width": 159, "height": 30},
+                    "actionType": "WebSocketReplyPlotlyAction", "replyType": "ws_plotly",
+                }
+                elements[state_id][state_key].append(body_id)
 
     try:
         # First pass: collect all intents and Agent metadata
@@ -711,6 +793,45 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                             actions[body_var] = [web_crawl_action]
                         else:
                             actions[body_var].append(web_crawl_action)
+                    elif node.value.args[0].func.id in (
+                        'WebSocketReplyMarkdown', 'WebSocketReplyHTML', 'WebSocketReplySpeech',
+                        'WebSocketReplyOptions', 'WebSocketReplyLocation',
+                        'WebSocketReplyFile', 'WebSocketReplyImage',
+                        'WebSocketReplyDataframe', 'WebSocketReplyPlotly',
+                    ):
+                        cls_name = node.value.args[0].func.id
+                        type_map = {
+                            'WebSocketReplyMarkdown': 'ws_markdown',
+                            'WebSocketReplyHTML': 'ws_html',
+                            'WebSocketReplySpeech': 'ws_speech',
+                            'WebSocketReplyOptions': 'ws_options',
+                            'WebSocketReplyLocation': 'ws_location',
+                            'WebSocketReplyFile': 'ws_file',
+                            'WebSocketReplyImage': 'ws_image',
+                            'WebSocketReplyDataframe': 'ws_dataframe',
+                            'WebSocketReplyPlotly': 'ws_plotly',
+                        }
+                        ws_action: Dict[str, Any] = {"type": type_map[cls_name]}
+                        for kw in node.value.args[0].keywords:
+                            if kw.arg == 'options' and isinstance(kw.value, ast.List):
+                                opts = [elt.value for elt in kw.value.elts if isinstance(elt, ast.Constant) and isinstance(elt.value, str)]
+                                ws_action["ws_options"] = "\n".join(opts)
+                                continue
+                            if not isinstance(kw.value, ast.Constant):
+                                continue
+                            val = kw.value.value
+                            if kw.arg == 'message' and isinstance(val, str):
+                                ws_action["ws_message"] = val
+                            elif kw.arg == 'audio_speed' and isinstance(val, (int, float)) and not isinstance(val, bool):
+                                ws_action["ws_audio_speed"] = float(val)
+                            elif kw.arg == 'latitude' and isinstance(val, (int, float)) and not isinstance(val, bool):
+                                ws_action["ws_latitude"] = float(val)
+                            elif kw.arg == 'longitude' and isinstance(val, (int, float)) and not isinstance(val, bool):
+                                ws_action["ws_longitude"] = float(val)
+                        if body_var not in actions:
+                            actions[body_var] = [ws_action]
+                        else:
+                            actions[body_var].append(ws_action)
                 elif isinstance(node.value.args[0], ast.Name):
                     # Handle references to CustomCodeAction variables
                     action_var = node.value.args[0].id  # e.g., 'CustomCodeAction_initial'

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
@@ -182,6 +182,25 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                     "llm_name": action.get("llm_name", "") or "",
                 }
                 elements[state_id][state_key].append(body_id)
+            elif action_type == "llm_chat":
+                body_id = str(uuid.uuid4())
+                elements[body_id] = {
+                    "id": body_id,
+                    "name": "LLM Chat",
+                    "type": element_type,
+                    "owner": state_id,
+                    "bounds": {
+                        "x": elements[state_id]["bounds"]["x"],
+                        "y": elements[state_id]["bounds"]["y"],
+                        "width": 159,
+                        "height": 30,
+                    },
+                    "actionType": "LLMChatAction",
+                    "replyType": "llm_chat",
+                    "system_message": action.get("prompt") or "",
+                    "llm_name": action.get("llm_name", "") or "",
+                }
+                elements[state_id][state_key].append(body_id)
             elif action_type == "rag":
                 rag_db_name = action.get("ragDatabaseName") or ""
                 rag_prompt = action.get("prompt") or ""
@@ -550,6 +569,17 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                             actions[body_var] = [llm_action]
                         else:
                             actions[body_var].append(llm_action)
+                    elif node.value.args[0].func.id == 'LLMChatReply':
+                        llm_chat_action: Dict[str, Any] = {"type": "llm_chat"}
+                        for kw in node.value.args[0].keywords:
+                            if kw.arg == 'llm_name' and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                                llm_chat_action["llm_name"] = kw.value.value
+                            elif kw.arg == 'prompt' and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                                llm_chat_action["prompt"] = kw.value.value
+                        if body_var not in actions:
+                            actions[body_var] = [llm_chat_action]
+                        else:
+                            actions[body_var].append(llm_chat_action)
                     elif node.value.args[0].func.id == 'RAGReply':
                         rag_db_name = ""
                         rag_prompt = ""

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
@@ -256,6 +256,34 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                     "llm_name": action.get("llm_name", "") or "",
                 }
                 elements[state_id][state_key].append(body_id)
+            elif action_type == "web_crawl_llm":
+                initial_url = action.get("initial_url") or ""
+                display_name = f"Web Crawl + LLM: {initial_url}" if initial_url else "Web Crawl + LLM Reply"
+                body_id = str(uuid.uuid4())
+                elements[body_id] = {
+                    "id": body_id,
+                    "name": display_name,
+                    "type": element_type,
+                    "owner": state_id,
+                    "bounds": {
+                        "x": elements[state_id]["bounds"]["x"],
+                        "y": elements[state_id]["bounds"]["y"],
+                        "width": 159,
+                        "height": 30,
+                    },
+                    "actionType": "WebCrawlLLMAction",
+                    "replyType": "web_crawl_llm",
+                    "initial_url": initial_url,
+                    "max_depth": action.get("max_depth", 2),
+                    "max_pages": action.get("max_pages", 20),
+                    "crawl_format": action.get("crawl_format", "markdown"),
+                    "base_url_prefix": action.get("base_url_prefix", ""),
+                    "run_crawl": action.get("run_crawl", True),
+                    "no_crawl_error_message": action.get("no_crawl_error_message", "No web crawl data is available yet."),
+                    "system_message_prefix": action.get("system_message_prefix", ""),
+                    "llm_name": action.get("llm_name", "") or "",
+                }
+                elements[state_id][state_key].append(body_id)
 
     try:
         # First pass: collect all intents and Agent metadata
@@ -644,6 +672,45 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                             actions[body_var] = [db_action]
                         else:
                             actions[body_var].append(db_action)
+                    elif node.value.args[0].func.id == 'WebCrawlLLMReply':
+                        web_crawl_action: Dict[str, Any] = {
+                            "type": "web_crawl_llm",
+                            "initial_url": "",
+                            "max_depth": 2,
+                            "max_pages": 20,
+                            "crawl_format": "markdown",
+                            "base_url_prefix": "",
+                            "run_crawl": True,
+                            "no_crawl_error_message": "No web crawl data is available yet.",
+                            "system_message_prefix": "",
+                            "llm_name": "",
+                        }
+                        for kw in node.value.args[0].keywords:
+                            if not isinstance(kw.value, ast.Constant):
+                                continue
+                            val = kw.value.value
+                            if kw.arg == 'initial_url' and isinstance(val, str):
+                                web_crawl_action["initial_url"] = val
+                            elif kw.arg == 'max_depth' and isinstance(val, int) and not isinstance(val, bool):
+                                web_crawl_action["max_depth"] = val
+                            elif kw.arg == 'max_pages' and isinstance(val, int) and not isinstance(val, bool):
+                                web_crawl_action["max_pages"] = val
+                            elif kw.arg == 'crawl_format' and isinstance(val, str):
+                                web_crawl_action["crawl_format"] = val
+                            elif kw.arg == 'base_url_prefix':
+                                web_crawl_action["base_url_prefix"] = val if isinstance(val, str) else ""
+                            elif kw.arg == 'run_crawl' and isinstance(val, bool):
+                                web_crawl_action["run_crawl"] = val
+                            elif kw.arg == 'no_crawl_error_message' and isinstance(val, str):
+                                web_crawl_action["no_crawl_error_message"] = val
+                            elif kw.arg == 'system_message_prefix':
+                                web_crawl_action["system_message_prefix"] = val if isinstance(val, str) else ""
+                            elif kw.arg == 'llm_name' and isinstance(val, str):
+                                web_crawl_action["llm_name"] = val
+                        if body_var not in actions:
+                            actions[body_var] = [web_crawl_action]
+                        else:
+                            actions[body_var].append(web_crawl_action)
                 elif isinstance(node.value.args[0], ast.Name):
                     # Handle references to CustomCodeAction variables
                     action_var = node.value.args[0].id  # e.g., 'CustomCodeAction_initial'

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
@@ -184,6 +184,7 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                 elements[state_id][state_key].append(body_id)
             elif action_type == "rag":
                 rag_db_name = action.get("ragDatabaseName") or ""
+                rag_prompt = action.get("prompt") or ""
                 display_name = (
                     f"RAG reply using {rag_db_name} database"
                     if rag_db_name
@@ -203,6 +204,7 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                     },
                     "actionType": "RAGReplyAction",
                     "ragDatabaseName": rag_db_name,
+                    "prompt": rag_prompt,
                 }
                 elements[state_id][state_key].append(body_id)
             elif action_type == "db_reply":
@@ -322,6 +324,9 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                     ):
                         rag_name = None
                         rag_llm_name = ""
+                        rag_llm_prompt = ""
+                        rag_k = 4
+                        rag_num_previous_messages = 0
                         if (
                             node.value.args
                             and isinstance(node.value.args[0], ast.Constant)
@@ -342,6 +347,15 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                 and isinstance(kw.value.value, str)
                             ):
                                 rag_llm_name = kw.value.value
+                            elif kw.arg == "llm_prompt":
+                                if isinstance(kw.value, ast.Constant):
+                                    rag_llm_prompt = kw.value.value or ""
+                            elif kw.arg == "k":
+                                if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, int):
+                                    rag_k = kw.value.value
+                            elif kw.arg == "num_previous_messages":
+                                if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, int):
+                                    rag_num_previous_messages = kw.value.value
 
                         if isinstance(rag_name, str) and rag_name.strip():
                             rag_id = str(uuid.uuid4())
@@ -357,6 +371,11 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                     "height": 110,
                                 },
                                 "llm_name": rag_llm_name,
+                                        "llm": rag_llm_name,
+                                "llm_prompt": rag_llm_prompt,
+                                "k": rag_k,
+                                "num_previous_messages": rag_num_previous_messages,
+                                        "numPreviousMessages": rag_num_previous_messages,
                             }
                             if states_x < 200:
                                 states_x += 300
@@ -533,6 +552,7 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                             actions[body_var].append(llm_action)
                     elif node.value.args[0].func.id == 'RAGReply':
                         rag_db_name = ""
+                        rag_prompt = ""
                         if (
                             len(node.value.args[0].args) >= 1
                             and isinstance(node.value.args[0].args[0], ast.Constant)
@@ -546,11 +566,25 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                 and isinstance(kw.value.value, str)
                             ):
                                 rag_db_name = kw.value.value
+                            elif (
+                                kw.arg == 'prompt'
+                                and isinstance(kw.value, ast.Constant)
+                                and isinstance(kw.value.value, str)
+                            ):
+                                rag_prompt = kw.value.value
 
                         if body_var not in actions:
-                            actions[body_var] = [{"type": "rag", "ragDatabaseName": rag_db_name}]
+                            actions[body_var] = [{
+                                "type": "rag",
+                                "ragDatabaseName": rag_db_name,
+                                "prompt": rag_prompt,
+                            }]
                         else:
-                            actions[body_var].append({"type": "rag", "ragDatabaseName": rag_db_name})
+                            actions[body_var].append({
+                                "type": "rag",
+                                "ragDatabaseName": rag_db_name,
+                                "prompt": rag_prompt,
+                            })
                     elif node.value.args[0].func.id == 'DBReply':
                         db_action = {
                             "type": "db_reply",

--- a/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
@@ -30,6 +30,7 @@ from besser.BUML.metamodel.state_machine.agent import (
     LLMChatReply,
     RAGReply,
     DBReply,
+    WebCrawlLLMReply,
     RAGVectorStore,
     RAGTextSplitter,
 )
@@ -45,6 +46,7 @@ _REPLY_TYPE_TO_ACTION_TYPE = {
     "rag": "RAGReplyAction",
     "db_reply": "DBAction",
     "code": "CustomCodeAction",
+    "web_crawl_llm": "WebCrawlLLMAction",
 }
 
 
@@ -136,6 +138,45 @@ def _build_body_from_action_elements(body_name, action_element_ids, elements,
         elif action_type == "DBAction":
             if build_db_reply_fn:
                 body.add_action(build_db_reply_fn(element))
+                action_added = True
+
+        elif action_type == "WebCrawlLLMAction":
+            initial_url = sanitize_text(element.get("initial_url", ""))
+            max_depth_raw = element.get("max_depth", 2)
+            max_pages_raw = element.get("max_pages", 20)
+            try:
+                max_depth = int(max_depth_raw) if max_depth_raw is not None else 2
+            except (TypeError, ValueError):
+                max_depth = 2
+            try:
+                max_pages = int(max_pages_raw) if max_pages_raw is not None else 20
+            except (TypeError, ValueError):
+                max_pages = 20
+            crawl_format = sanitize_text(element.get("crawl_format", "markdown")) or "markdown"
+            base_url_prefix_raw = element.get("base_url_prefix") or ""
+            base_url_prefix = sanitize_text(base_url_prefix_raw) or None
+            run_crawl_raw = element.get("run_crawl", True)
+            run_crawl = bool(run_crawl_raw) if run_crawl_raw is not None else True
+            no_crawl_error_message = (
+                sanitize_text(element.get("no_crawl_error_message", "No web crawl data is available yet."))
+                or "No web crawl data is available yet."
+            )
+            system_message_prefix_raw = element.get("system_message_prefix") or ""
+            system_message_prefix = sanitize_text(system_message_prefix_raw) or None
+            llm_name_raw = element.get("llm_name") or ""
+            llm_name = sanitize_text(llm_name_raw) or None
+            if initial_url:
+                body.add_action(WebCrawlLLMReply(
+                    initial_url=initial_url,
+                    max_depth=max_depth,
+                    max_pages=max_pages,
+                    crawl_format=crawl_format,
+                    base_url_prefix=base_url_prefix,
+                    run_crawl=run_crawl,
+                    no_crawl_error_message=no_crawl_error_message,
+                    system_message_prefix=system_message_prefix,
+                    llm_name=llm_name,
+                ))
                 action_added = True
 
         elif action_type == "CustomCodeAction":

--- a/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
@@ -36,108 +36,104 @@ from besser.BUML.metamodel.structural import Metadata
 from besser.utilities.web_modeling_editor.backend.services.converters.parsers import sanitize_text
 
 
-def _collect_body_messages(body_elements, elements, language, source_language, translate_text,
-                           serialize_db_reply_payload=None):
+# Maps old informal "replyType" values to new metamodel class names used in "actionType".
+_REPLY_TYPE_TO_ACTION_TYPE = {
+    "text": "TextReplyAction",
+    "llm": "LLMReplyAction",
+    "rag": "RAGReplyAction",
+    "db_reply": "DBAction",
+    "code": "CustomCodeAction",
+}
+
+
+def _resolve_action_type(element: dict) -> str:
     """
-    Collect and classify body messages from body element IDs.
+    Return the normalized actionType string for an action element.
+    Supports both new 'actionType' (metamodel class name) and old 'replyType' (backward compat).
+    """
+    action_type = element.get("actionType")
+    if action_type:
+        return action_type
+    reply_type = element.get("replyType", "")
+    return _REPLY_TYPE_TO_ACTION_TYPE.get(reply_type, "")
+
+
+def _build_body_from_action_elements(body_name, action_element_ids, elements,
+                                     language, source_language, translate_text,
+                                     build_db_reply_fn=None):
+    """
+    Build a Body object from an ordered list of action element IDs using per-element dispatch.
+
+    Each element is classified by its 'actionType' field (new schema, metamodel class name)
+    or its legacy 'replyType' field (backward compat). Actions are added to the body in the
+    order they appear in action_element_ids, preserving execution order.
 
     Args:
-        body_elements: List of body element IDs to process
-        elements: Dict of all elements keyed by ID
-        language: Target translation language (or None)
-        source_language: Source language for translation (or None)
-        translate_text: Translation function
-        serialize_db_reply_payload: Optional function to serialize DB reply payloads
+        body_name: Name for the Body object.
+        action_element_ids: Ordered list of action element IDs.
+        elements: Dict of all diagram elements keyed by ID.
+        language: Target translation language (or None).
+        source_language: Source language for translation (or None).
+        translate_text: Translation function.
+        build_db_reply_fn: Optional callable to build a DBReply from an element dict.
 
     Returns:
-        List of classified message strings (prefixed with LLM:/RAG:/DB:/CODE: or plain text)
+        A Body object with one action per element, or None if no actions were added.
     """
-    messages = []
-    for body_id in body_elements:
-        body_element = elements.get(body_id)
-        if not body_element:
-            continue
-
-        reply_type = body_element.get("replyType")
-        body_content = body_element.get("name", "")
-
-        if reply_type == "text":
-            msg = sanitize_text(body_content)
-            if language:
-                msg = translate_text(msg, language, source_language)
-            messages.append(msg)
-        elif reply_type == "llm":
-            llm_payload = {
-                "prompt": sanitize_text(body_content),
-                "llm_name": sanitize_text(body_element.get("llm_name", "") or ""),
-            }
-            messages.append(f"LLM:{json_lib.dumps(llm_payload)}")
-        elif reply_type == "rag":
-            rag_name = sanitize_text(body_element.get("ragDatabaseName", ""))
-            if not rag_name:
-                rag_name = sanitize_text(body_content)
-            if rag_name:
-                messages.append(f"RAG:{rag_name}")
-        elif reply_type == "db_reply":
-            if serialize_db_reply_payload:
-                messages.append(serialize_db_reply_payload(body_element))
-        elif reply_type == "code":
-            messages.append(f"CODE:{sanitize_text(body_content)}")
-
-    return messages
-
-
-def _build_body_from_messages(body_name, messages, build_db_reply_fn=None):
-    """
-    Build a Body object from classified messages.
-
-    Args:
-        body_name: Name for the Body object
-        messages: List of classified message strings (from _collect_body_messages)
-        build_db_reply_fn: Optional function to build a DBReply from a deserialized payload dict
-
-    Returns:
-        A Body object with appropriate actions, or None if messages is empty
-    """
-    if not messages:
+    if not action_element_ids:
         return None
 
-    has_db = any(m.startswith("DB:") for m in messages)
-    has_rag = any(m.startswith("RAG:") for m in messages)
-    has_llm = any(m.startswith("LLM:") for m in messages)
-    has_code = any(m.startswith("CODE:") for m in messages)
-
     body = Body(body_name)
+    action_added = False
 
-    if has_db and build_db_reply_fn:
-        db_replies = [json_lib.loads(m.split(":", 1)[1]) for m in messages if m.startswith("DB:")]
-        for db_reply in db_replies:
-            body.add_action(build_db_reply_fn(db_reply))
-    elif has_rag:
-        rag_names = [m.split(":", 1)[1] for m in messages if m.startswith("RAG:")]
-        for rag_db_name in rag_names:
-            body.add_action(RAGReply(rag_db_name=rag_db_name))
-    elif has_llm:
-        for m in messages:
-            if not m.startswith("LLM:"):
-                continue
-            payload_str = m.split(":", 1)[1]
-            try:
-                payload = json_lib.loads(payload_str)
-            except (ValueError, TypeError):
-                payload = {"prompt": payload_str, "llm_name": ""}
-            prompt = payload.get("prompt") or None
-            llm_name = payload.get("llm_name") or None
+    for element_id in action_element_ids:
+        element = elements.get(element_id)
+        if not element:
+            continue
+
+        action_type = _resolve_action_type(element)
+        content = element.get("name", "")
+
+        if action_type == "TextReplyAction":
+            msg = sanitize_text(content)
+            if language:
+                msg = translate_text(msg, language, source_language)
+            body.add_action(AgentReply(message=msg))
+            action_added = True
+
+        elif action_type == "LLMReplyAction":
+            # Support both "llmPrompt" (new schema) and using "name" as prompt (old schema)
+            prompt_raw = element.get("llmPrompt") or element.get("name", "")
+            prompt = sanitize_text(prompt_raw) or None
+            # Support "llmName" (new schema key) and "llm_name" (legacy key)
+            llm_name_raw = element.get("llm_name") or element.get("llmName") or ""
+            llm_name = sanitize_text(llm_name_raw) or None
             body.add_action(LLMReply(prompt=prompt, llm_name=llm_name))
-    elif has_code:
-        code_contents = [m[5:] for m in messages if m.startswith("CODE:")]
-        for code_content in code_contents:
-            body.add_action(CustomCodeAction(source=code_content))
-    else:
-        for message in messages:
-            body.add_action(AgentReply(message=message))
+            action_added = True
 
-    return body
+        elif action_type == "RAGReplyAction":
+            rag_name = sanitize_text(element.get("ragDatabaseName", ""))
+            if not rag_name:
+                rag_name = sanitize_text(content)
+            if rag_name:
+                body.add_action(RAGReply(rag_db_name=rag_name))
+                action_added = True
+
+        elif action_type == "DBAction":
+            if build_db_reply_fn:
+                body.add_action(build_db_reply_fn(element))
+                action_added = True
+
+        elif action_type == "CustomCodeAction":
+            # Raw source code must not be sanitized — sanitize_text escapes single quotes
+            # which would corrupt string literals inside the user's Python function.
+            body.add_action(CustomCodeAction(source=content))
+            action_added = True
+
+        else:
+            logger.warning("Unknown actionType '%s' on element '%s'; skipping.", action_type, element_id)
+
+    return body if action_added else None
 
 
 def process_agent_diagram(json_data):
@@ -180,16 +176,6 @@ def process_agent_diagram(json_data):
             llm_name=sanitize_text(element.get("llm_name", "")) or None,
         )
 
-    def serialize_db_reply_payload(element: dict) -> str:
-        payload = {
-            "dbSelectionType": element.get("dbSelectionType", "default") or "default",
-            "dbCustomName": element.get("dbCustomName", "") or "",
-            "dbQueryMode": element.get("dbQueryMode", "llm_query") or "llm_query",
-            "dbOperation": element.get("dbOperation", "any") or "any",
-            "dbSqlQuery": element.get("dbSqlQuery", "") or "",
-            "llm_name": element.get("llm_name", "") or "",
-        }
-        return f"DB:{json_lib.dumps(payload)}"
     """Process Agent Diagram specific elements and return an Agent model."""
     # Create the agent model
     title = json_data.get('title', 'Generated_Agent')
@@ -304,14 +290,13 @@ def process_agent_diagram(json_data):
             )
             continue
         elif element_type == "AgentReasoningState":
-            # Reasoning states are created in the state-construction passes
-            # below (alongside AgentState).
+            # Reasoning states are created in the state-construction passes below.
             continue
         elif element_type == "AgentIntent":
             intent_name = element.get("name")
             training_sentences = []
             intent_description = element.get("intent_description", None)
-            # Collect training sentences
+            # Collect training sentences — AgentIntent still uses "bodies" for sentence IDs.
             for body_id in element.get("bodies", []):
                 body_element = elements.get(body_id)
                 if body_element:
@@ -356,6 +341,20 @@ def process_agent_diagram(json_data):
             )
             rag_dbs_by_id[element_id] = rag_config
             rag_dbs_by_name[rag_name] = rag_config
+
+    def _is_reasoning_element(element: dict) -> bool:
+        """Return True if this element represents a ReasoningState (old or new schema)."""
+        if element.get("type") == "AgentReasoningState":
+            return True
+        if element.get("type") == "AgentState" and element.get("stateType") == "reasoning":
+            return True
+        return False
+
+    def _is_standard_state_element(element: dict) -> bool:
+        """Return True if this element represents a standard AgentState."""
+        if element.get("type") == "AgentState":
+            return element.get("stateType", "standard") != "reasoning"
+        return False
 
     # First identify the initial state
     initial_state_id = None
@@ -402,64 +401,52 @@ def process_agent_diagram(json_data):
         states_by_id[element_id] = rs
         return rs
 
+    def _build_standard_state(element_id: str, element: dict, is_initial: bool):
+        """Create a standard AgentState and its body/fallback body from the new schema."""
+        state_name = element.get("name", "")
+        agent_state = agent.new_state(name=state_name, initial=is_initial)
+        states_by_id[element_id] = agent_state
+
+        # Resolve action element IDs — new key "actions", backward-compat key "bodies"
+        action_ids = element.get("actions", element.get("bodies", []))
+        body = _build_body_from_action_elements(
+            f"{state_name}_body", action_ids, elements,
+            language, source_language, translate_text,
+            build_db_reply_fn=build_db_reply,
+        )
+        if body:
+            agent_state.set_body(body)
+
+        # Only attach a fallback body if fallbackBodyEnabled is absent (legacy) or True
+        fallback_enabled = element.get("fallbackBodyEnabled", True)
+        if fallback_enabled:
+            fallback_ids = element.get("fallbackActions", element.get("fallbackBodies", []))
+            fallback_body = _build_body_from_action_elements(
+                f"{state_name}_fallback_body", fallback_ids, elements,
+                language, source_language, translate_text,
+                build_db_reply_fn=build_db_reply,
+            )
+            if fallback_body:
+                agent_state.set_fallback_body(fallback_body)
+
+        return agent_state
+
     # Process the initial state first if found
     if initial_state_id:
         element = elements.get(initial_state_id)
-        state_name = element.get("name", "")
-
-        if element.get("type") == "AgentReasoningState":
+        if _is_reasoning_element(element):
             _build_reasoning_state(initial_state_id, element, is_initial=True)
         else:
-            agent_state = agent.new_state(name=state_name, initial=True)
-            states_by_id[initial_state_id] = agent_state
-
-            # Process state bodies
-            body_messages = _collect_body_messages(
-                element.get("bodies", []), elements, language, source_language, translate_text,
-                serialize_db_reply_payload=serialize_db_reply_payload
-            )
-            body = _build_body_from_messages(f"{state_name}_body", body_messages, build_db_reply_fn=build_db_reply)
-            if body:
-                agent_state.set_body(body)
-
-            # Process fallback bodies
-            fallback_messages = _collect_body_messages(
-                element.get("fallbackBodies", []), elements, language, source_language, translate_text,
-                serialize_db_reply_payload=serialize_db_reply_payload
-            )
-            fallback_body = _build_body_from_messages(f"{state_name}_fallback_body", fallback_messages, build_db_reply_fn=build_db_reply)
-            if fallback_body:
-                agent_state.set_fallback_body(fallback_body)
+            _build_standard_state(initial_state_id, element, is_initial=True)
 
     # Now process the rest of the states (including reasoning states)
     for element_id, element in elements.items():
-        if element.get("type") == "AgentReasoningState" and element_id != initial_state_id:
-            _build_reasoning_state(element_id, element, is_initial=False)
+        if element_id == initial_state_id:
             continue
-        if element.get("type") == "AgentState" and element_id != initial_state_id:
-            # Create state and add to agent
-            state_name = element.get("name", "")
-
-            agent_state = agent.new_state(name=state_name, initial=False)
-            states_by_id[element_id] = agent_state
-
-            # Process state bodies
-            body_messages = _collect_body_messages(
-                element.get("bodies", []), elements, language, source_language, translate_text,
-                serialize_db_reply_payload=serialize_db_reply_payload
-            )
-            body = _build_body_from_messages(f"{state_name}_body", body_messages, build_db_reply_fn=build_db_reply)
-            if body:
-                agent_state.set_body(body)
-
-            # Process fallback bodies
-            fallback_messages = _collect_body_messages(
-                element.get("fallbackBodies", []), elements, language, source_language, translate_text,
-                serialize_db_reply_payload=serialize_db_reply_payload
-            )
-            fallback_body = _build_body_from_messages(f"{state_name}_fallback_body", fallback_messages, build_db_reply_fn=build_db_reply)
-            if fallback_body:
-                agent_state.set_fallback_body(fallback_body)
+        if _is_reasoning_element(element):
+            _build_reasoning_state(element_id, element, is_initial=False)
+        elif _is_standard_state_element(element):
+            _build_standard_state(element_id, element, is_initial=False)
 
     # Build intent lookup dict for O(1) resolution during transition processing.
     # Intent names are unique case-insensitively in BUML (see Agent._validate_state_intent_name_collisions),

--- a/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
@@ -116,8 +116,10 @@ def _build_body_from_action_elements(body_name, action_element_ids, elements,
             rag_name = sanitize_text(element.get("ragDatabaseName", ""))
             if not rag_name:
                 rag_name = sanitize_text(content)
+            rag_prompt_raw = element.get("prompt") or ""
+            rag_prompt = sanitize_text(rag_prompt_raw) or None
             if rag_name:
-                body.add_action(RAGReply(rag_db_name=rag_name))
+                body.add_action(RAGReply(rag_db_name=rag_name, prompt=rag_prompt))
                 action_added = True
 
         elif action_type == "DBAction":
@@ -331,14 +333,35 @@ def process_agent_diagram(json_data):
                 chunk_size=1000,
                 chunk_overlap=100,
             )
-            rag_llm_name = sanitize_text((element.get("llm_name") or "").strip()) or ""
+            rag_llm_name = sanitize_text((element.get("llm_name") or element.get("llm") or "").strip()) or ""
+            rag_llm_prompt = sanitize_text((element.get("llm_prompt") or element.get("llmPrompt") or "").strip()) or None
+
+            raw_k = element.get("k")
+            try:
+                rag_k = int(raw_k) if raw_k is not None else 4
+            except (TypeError, ValueError):
+                rag_k = 4
+            if rag_k <= 0:
+                rag_k = 4
+
+            raw_npm = element.get("num_previous_messages")
+            if raw_npm is None:
+                raw_npm = element.get("numPreviousMessages")
+            try:
+                rag_num_previous_messages = int(raw_npm) if raw_npm is not None else 0
+            except (TypeError, ValueError):
+                rag_num_previous_messages = 0
+            if rag_num_previous_messages < 0:
+                rag_num_previous_messages = 0
+
             rag_config = agent.new_rag(
                 name=rag_name,
                 vector_store=vector_store,
                 splitter=splitter,
                 llm_name=rag_llm_name,
-                k=4,
-                num_previous_messages=0,
+                llm_prompt=rag_llm_prompt,
+                k=rag_k,
+                num_previous_messages=rag_num_previous_messages,
             )
             rag_dbs_by_id[element_id] = rag_config
             rag_dbs_by_name[rag_name] = rag_config

--- a/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
@@ -239,20 +239,6 @@ def process_agent_diagram(json_data):
 
     agent = Agent(title)
 
-    # Add default configuration properties
-    agent.add_property(ConfigProperty('websocket_platform', 'websocket.host', '0.0.0.0'))
-    agent.add_property(ConfigProperty('websocket_platform', 'websocket.port', 8765))
-    agent.add_property(ConfigProperty('websocket_platform', 'streamlit.host', '0.0.0.0'))
-    agent.add_property(ConfigProperty('websocket_platform', 'streamlit.port', 5000))
-    agent.add_property(ConfigProperty('nlp', 'nlp.language', 'en'))
-    agent.add_property(ConfigProperty('nlp', 'nlp.region', 'US'))
-    agent.add_property(ConfigProperty('nlp', 'nlp.timezone', 'Europe/Madrid'))
-    agent.add_property(ConfigProperty('nlp', 'nlp.pre_processing', True))
-    agent.add_property(ConfigProperty('nlp', 'nlp.intent_threshold', 0.4))
-    agent.add_property(ConfigProperty('nlp', 'nlp.openai.api_key', 'YOUR-API-KEY'))
-    agent.add_property(ConfigProperty('nlp', 'nlp.hf.api_key', 'YOUR-API-KEY'))
-    agent.add_property(ConfigProperty('nlp', 'nlp.replicate.api_key', 'YOUR-API-KEY'))
-
     # Get elements and relationships from the JSON data
     model_data = json_data.get('model') or {}
     elements = model_data.get('elements') or {}

--- a/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
@@ -7,11 +7,9 @@ import operator
 from deep_translator import GoogleTranslator
 
 logger = logging.getLogger(__name__)
-import json as json_lib
 from besser.BUML.metamodel.state_machine.state_machine import (
     Body,
     Condition,
-    ConfigProperty,
     CustomCodeAction,
     TransitionBuilder,
 )

--- a/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
@@ -31,6 +31,15 @@ from besser.BUML.metamodel.state_machine.agent import (
     RAGReply,
     DBReply,
     WebCrawlLLMReply,
+    WebSocketReplyMarkdown,
+    WebSocketReplyHTML,
+    WebSocketReplySpeech,
+    WebSocketReplyOptions,
+    WebSocketReplyLocation,
+    WebSocketReplyFile,
+    WebSocketReplyImage,
+    WebSocketReplyDataframe,
+    WebSocketReplyPlotly,
     RAGVectorStore,
     RAGTextSplitter,
 )
@@ -47,6 +56,15 @@ _REPLY_TYPE_TO_ACTION_TYPE = {
     "db_reply": "DBAction",
     "code": "CustomCodeAction",
     "web_crawl_llm": "WebCrawlLLMAction",
+    "ws_markdown": "WebSocketReplyMarkdownAction",
+    "ws_html": "WebSocketReplyHTMLAction",
+    "ws_speech": "WebSocketReplySpeechAction",
+    "ws_options": "WebSocketReplyOptionsAction",
+    "ws_location": "WebSocketReplyLocationAction",
+    "ws_file": "WebSocketReplyFileAction",
+    "ws_image": "WebSocketReplyImageAction",
+    "ws_dataframe": "WebSocketReplyDataframeAction",
+    "ws_plotly": "WebSocketReplyPlotlyAction",
 }
 
 
@@ -178,6 +196,60 @@ def _build_body_from_action_elements(body_name, action_element_ids, elements,
                     llm_name=llm_name,
                 ))
                 action_added = True
+
+        elif action_type == "WebSocketReplyMarkdownAction":
+            msg = sanitize_text(element.get("ws_message", ""))
+            body.add_action(WebSocketReplyMarkdown(message=msg))
+            action_added = True
+
+        elif action_type == "WebSocketReplyHTMLAction":
+            msg = sanitize_text(element.get("ws_message", ""))
+            body.add_action(WebSocketReplyHTML(message=msg))
+            action_added = True
+
+        elif action_type == "WebSocketReplySpeechAction":
+            msg = sanitize_text(element.get("ws_message", ""))
+            speed_raw = element.get("ws_audio_speed")
+            try:
+                audio_speed = float(speed_raw) if speed_raw not in (None, "") else None
+            except (TypeError, ValueError):
+                audio_speed = None
+            body.add_action(WebSocketReplySpeech(message=msg, audio_speed=audio_speed))
+            action_added = True
+
+        elif action_type == "WebSocketReplyOptionsAction":
+            opts_raw = element.get("ws_options", "")
+            options = [o.strip() for o in opts_raw.split('\n') if o.strip()]
+            body.add_action(WebSocketReplyOptions(options=options))
+            action_added = True
+
+        elif action_type == "WebSocketReplyLocationAction":
+            try:
+                lat = float(element.get("ws_latitude", 0.0))
+            except (TypeError, ValueError):
+                lat = 0.0
+            try:
+                lon = float(element.get("ws_longitude", 0.0))
+            except (TypeError, ValueError):
+                lon = 0.0
+            body.add_action(WebSocketReplyLocation(latitude=lat, longitude=lon))
+            action_added = True
+
+        elif action_type == "WebSocketReplyFileAction":
+            body.add_action(WebSocketReplyFile())
+            action_added = True
+
+        elif action_type == "WebSocketReplyImageAction":
+            body.add_action(WebSocketReplyImage())
+            action_added = True
+
+        elif action_type == "WebSocketReplyDataframeAction":
+            body.add_action(WebSocketReplyDataframe())
+            action_added = True
+
+        elif action_type == "WebSocketReplyPlotlyAction":
+            body.add_action(WebSocketReplyPlotly())
+            action_added = True
 
         elif action_type == "CustomCodeAction":
             # Raw source code must not be sanitized — sanitize_text escapes single quotes

--- a/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
@@ -27,6 +27,7 @@ from besser.BUML.metamodel.state_machine.agent import (
     WildcardEvent,
     AgentReply,
     LLMReply,
+    LLMChatReply,
     RAGReply,
     DBReply,
     RAGVectorStore,
@@ -40,6 +41,7 @@ from besser.utilities.web_modeling_editor.backend.services.converters.parsers im
 _REPLY_TYPE_TO_ACTION_TYPE = {
     "text": "TextReplyAction",
     "llm": "LLMReplyAction",
+    "llm_chat": "LLMChatAction",
     "rag": "RAGReplyAction",
     "db_reply": "DBAction",
     "code": "CustomCodeAction",
@@ -110,6 +112,15 @@ def _build_body_from_action_elements(body_name, action_element_ids, elements,
             llm_name_raw = element.get("llm_name") or element.get("llmName") or ""
             llm_name = sanitize_text(llm_name_raw) or None
             body.add_action(LLMReply(prompt=prompt, llm_name=llm_name))
+            action_added = True
+
+        elif action_type == "LLMChatAction":
+            # Keep the same payload keys as LLMReply for frontend symmetry.
+            prompt_raw = element.get("system_message") or element.get("llmPrompt") or ""
+            prompt = sanitize_text(prompt_raw) or None
+            llm_name_raw = element.get("llm_name") or element.get("llmName") or ""
+            llm_name = sanitize_text(llm_name_raw) or None
+            body.add_action(LLMChatReply(prompt=prompt, llm_name=llm_name))
             action_added = True
 
         elif action_type == "RAGReplyAction":

--- a/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
@@ -102,8 +102,9 @@ def _build_body_from_action_elements(body_name, action_element_ids, elements,
             action_added = True
 
         elif action_type == "LLMReplyAction":
-            # Support both "llmPrompt" (new schema) and using "name" as prompt (old schema)
-            prompt_raw = element.get("llmPrompt") or element.get("name", "")
+            # Prefer dedicated system_message field; fall back to legacy llmPrompt key.
+            # Never use name — it is a display label ("LLM Reply"), not the system message.
+            prompt_raw = element.get("system_message") or element.get("llmPrompt") or ""
             prompt = sanitize_text(prompt_raw) or None
             # Support "llmName" (new schema key) and "llm_name" (legacy key)
             llm_name_raw = element.get("llm_name") or element.get("llmName") or ""

--- a/besser/utilities/web_modeling_editor/backend/services/deployment/github_deploy_api.py
+++ b/besser/utilities/web_modeling_editor/backend/services/deployment/github_deploy_api.py
@@ -234,11 +234,13 @@ async def deploy_webapp_to_github(
                 if not generator_info:
                     raise GenerationError("Agent generator is not configured.")
                 generator_class = generator_info.generator_class
+                raw_yaml = agent_diagram_data.get("configYaml")
                 generator = generator_class(
                     agent_model,
                     output_dir=temp_dir,
                     config=agent_config,
                     openai_api_key=extract_openai_api_key(agent_config),
+                    config_yaml=raw_yaml if isinstance(raw_yaml, str) else None,
                 )
                 generator.generate()
 
@@ -397,11 +399,12 @@ async def deploy_webapp_to_github(
         # Uniqueness enforcement and BUML conversion live in the shared helper.
         agent_models: list = []
         agent_configs: dict = {}
+        agent_config_yamls: dict = {}
         has_agent_components = _has_agent_components(gui_model)
         if has_agent_components:
             settings = body.get("settings", {}) or {}
             settings_config = settings.get("config") or {}
-            agent_models, agent_configs = collect_agents_from_diagrams(
+            agent_models, agent_configs, agent_config_yamls = collect_agents_from_diagrams(
                 _get_all("AgentDiagram"),
                 default_config=settings_config,
             )
@@ -430,6 +433,7 @@ async def deploy_webapp_to_github(
                 output_dir=temp_dir,
                 agent_models=agent_models,
                 agent_configs=agent_configs,
+                agent_config_yamls=agent_config_yamls,
             )
             generator.generate()
 

--- a/besser/utilities/web_modeling_editor/backend/services/utils/agent_config_recommendation_utils.py
+++ b/besser/utilities/web_modeling_editor/backend/services/utils/agent_config_recommendation_utils.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 RECOMMENDATION_ALLOWED_VALUES = {
     "agentLanguage": ["original", "english", "french", "german", "spanish", "luxembourgish", "portuguese"],
-    "agentStyle": ["original", "formal", "informal"],
+    "agentStyle": ["original", "formal", "informal", "friendly", "technical"],
     "languageComplexity": ["original", "simple", "medium", "complex"],
     "sentenceLength": ["original", "concise", "verbose"],
     "font": ["sans", "serif", "monospace", "neutral", "grotesque", "condensed"],

--- a/besser/utilities/web_modeling_editor/backend/services/utils/agent_generation_utils.py
+++ b/besser/utilities/web_modeling_editor/backend/services/utils/agent_generation_utils.py
@@ -75,11 +75,12 @@ def build_configurations_package(
     agent_model: Any,
     configurations: List[Dict[str, Any]],
     generate_agent_zip_fn: AgentZipGenerator,
+    config_yaml: Optional[str] = None,
 ) -> io.BytesIO:
     """Create a zip containing the base agent plus variants for each configuration."""
     zip_buffer = io.BytesIO()
     with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as combined_zip:
-        base_buffer, _ = generate_agent_zip_fn(agent_model, None)
+        base_buffer, _ = generate_agent_zip_fn(agent_model, None, config_yaml=config_yaml)
         append_zip_contents(combined_zip, base_buffer)
 
         used_prefixes: Set[str] = set()
@@ -100,7 +101,7 @@ def build_configurations_package(
                 suffix += 1
             used_prefixes.add(unique_name)
 
-            config_buffer, _ = generate_agent_zip_fn(agent_model, sanitized_payload)
+            config_buffer, _ = generate_agent_zip_fn(agent_model, sanitized_payload, config_yaml=config_yaml)
             append_zip_contents(combined_zip, config_buffer, prefix=unique_name)
 
     zip_buffer.seek(0)
@@ -217,17 +218,20 @@ async def handle_multi_language_generation(
                 generator_info = get_generator_info("agent")
                 generator_class = generator_info.generator_class
                 variant_openai_api_key = extract_openai_api_key(new_config)
+                config_yaml = json_data.get('configYaml')
                 if hasattr(agent_module, 'agent'):
                     generator = generator_class(
                         agent_module.agent,
                         config=new_config,
                         openai_api_key=variant_openai_api_key,
+                        config_yaml=config_yaml,
                     )
                 else:
                     generator = generator_class(
                         agent_model,
                         config=new_config,
                         openai_api_key=variant_openai_api_key,
+                        config_yaml=config_yaml,
                     )
                 generator.generate()
                 zip_file.write(agent_file, f"{lang}/agent_model_{lang}.py")
@@ -246,6 +250,7 @@ def handle_variation_generation(
     base_model_snapshot: Dict[str, Any],
     variation_entries: list,
     generate_agent_files_fn: Callable,
+    config_yaml: Optional[str] = None,
 ) -> Tuple[io.BytesIO, str]:
     """Generate a ZIP containing the base model plus each variation.
 
@@ -264,6 +269,7 @@ def handle_variation_generation(
             base_agent_model,
             config,
             generation_mode=GenerationMode.CODE_ONLY,
+            config_yaml=config_yaml,
         )
         append_zip_contents(zip_file, base_buffer)
 
@@ -290,6 +296,7 @@ def handle_variation_generation(
                 variant_agent_model,
                 entry.get('config'),
                 generation_mode=GenerationMode.CODE_ONLY,
+                config_yaml=config_yaml,
             )
             append_zip_contents(
                 zip_file,
@@ -305,6 +312,7 @@ def handle_configuration_variants(
     json_data: dict,
     configuration_variants: list,
     generate_agent_files_fn: Callable,
+    config_yaml: Optional[str] = None,
 ) -> Tuple[io.BytesIO, str]:
     """Generate a ZIP bundle for each configuration variant.
 
@@ -316,6 +324,7 @@ def handle_configuration_variants(
         agent_model,
         configuration_variants,
         generate_agent_files_fn,
+        config_yaml=config_yaml,
     )
     return bundle_buffer, "agent_output.zip"
 
@@ -324,6 +333,7 @@ def handle_personalized_agent(
     json_data: dict,
     config: dict,
     generate_agent_files_fn: Callable,
+    config_yaml: Optional[str] = None,
 ) -> Tuple[io.BytesIO, str]:
     """Generate agent files with personalization mapping applied.
 
@@ -335,6 +345,7 @@ def handle_personalized_agent(
         agent_model,
         config,
         generation_mode=GenerationMode.CODE_ONLY,
+        config_yaml=config_yaml,
     )
     return zip_buffer, file_name
 
@@ -342,7 +353,7 @@ def handle_personalized_agent(
 def collect_agents_from_diagrams(
     agent_diagrams: List[Any],
     default_config: Any = None,
-) -> Tuple[List[Any], Dict[str, Any]]:
+) -> Tuple[List[Any], Dict[str, Any], Dict[str, Optional[str]]]:
     """Process every AgentDiagram in a project into BUML Agent models.
 
     Used by both the ``/generate-output-from-project`` route and the
@@ -356,8 +367,9 @@ def collect_agents_from_diagrams(
             ``config`` entry.
 
     Returns:
-        ``(agent_models, agent_configs)`` where ``agent_configs`` is keyed by
-        ``agent.name``.
+        ``(agent_models, agent_configs, agent_config_yamls)`` where both dicts are
+        keyed by ``agent.name``. ``agent_config_yamls`` maps each name to the
+        user-authored ``configYaml`` string for that agent, or ``None`` if absent.
 
     Raises:
         HTTPException(400): if two agents share the same ``.name`` — the
@@ -365,6 +377,7 @@ def collect_agents_from_diagrams(
     """
     agent_models: List[Any] = []
     agent_configs: Dict[str, Any] = {}
+    agent_config_yamls: Dict[str, Optional[str]] = {}
     seen: Set[str] = set()
     duplicates: Set[str] = set()
 
@@ -390,6 +403,8 @@ def collect_agents_from_diagrams(
         seen.add(name)
         agent_models.append(agent_model)
         agent_configs[name] = entry_dict.get("config") or default_config
+        raw_yaml = entry_dict.get("configYaml")
+        agent_config_yamls[name] = raw_yaml if isinstance(raw_yaml, str) else None
 
     if duplicates:
         raise HTTPException(
@@ -400,4 +415,4 @@ def collect_agents_from_diagrams(
             ),
         )
 
-    return agent_models, agent_configs
+    return agent_models, agent_configs, agent_config_yamls

--- a/docs/source/buml_language/model_types/agent.rst
+++ b/docs/source/buml_language/model_types/agent.rst
@@ -34,6 +34,54 @@ Beyond the state machine-like elements, the agent metamodel also includes agent 
 
 To read about their meaning and usage, please refer to the `documentation <https://besser-agentic-framework.readthedocs.io/latest/>`_ of the BESSER Agentic Framework.
 
+Actions
+~~~~~~~
+
+Each state body is a sequence of actions.  The following action classes are
+available in ``besser.BUML.metamodel.state_machine.agent``:
+
+**Text and LLM replies**
+
+- ``AgentReply(message)`` — send a plain-text reply.
+- ``LLMReply(prompt, llm_name)`` — generate a reply using an LLM; ``prompt``
+  is an optional system prompt, ``llm_name`` selects a registered LLM (defaults
+  to the agent default).
+- ``LLMChatReply(prompt, llm_name)`` — like ``LLMReply`` but calls
+  ``llm.chat(...)`` with the conversation history, making it suitable for
+  multi-turn dialogue states.
+- ``RAGReply(rag_db_name)`` — answer using a configured RAG database.
+- ``DBReply(query, llm_name)`` — answer from a SQL database using an LLM.
+
+**Web crawling**
+
+- ``WebCrawlLLMReply(initial_url, max_depth, max_pages, crawl_format,
+  base_url_prefix, run_crawl, no_crawl_error_message, system_message_prefix,
+  llm_name)`` — performs a BFS web crawl starting at ``initial_url`` and
+  queries an LLM with the retrieved content.  The crawl result is cached in the
+  session; set ``run_crawl=False`` in subsequent states to reuse the cache
+  without re-fetching.
+
+**WebSocket rich-media replies**
+
+The following actions map to the corresponding ``WebSocketPlatform`` methods and
+require the agent to use a ``WebSocketPlatform``:
+
+- ``WebSocketReplyMarkdown(message)`` — send Markdown-formatted text.
+- ``WebSocketReplyHTML(message)`` — send an HTML-formatted message.
+- ``WebSocketReplySpeech(message, audio_speed)`` — convert text to speech and
+  send the audio.
+- ``WebSocketReplyOptions(options)`` — present a list of selectable options.
+- ``WebSocketReplyLocation(latitude, longitude)`` — send a geographic
+  coordinate.
+- ``WebSocketReplyFile()`` — send a file; the body must supply a ``File``
+  object at runtime.
+- ``WebSocketReplyImage()`` — send an image (NumPy ``ndarray``); body must
+  supply the array at runtime.
+- ``WebSocketReplyDataframe()`` — send a pandas ``DataFrame``; body must supply
+  it at runtime.
+- ``WebSocketReplyPlotly()`` — send a Plotly figure; body must supply a
+  ``plotly.graph_objects.Figure`` at runtime.
+
 RAG (Retrieval-Augmented Generation)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -45,6 +93,19 @@ and an LLM name. Use ``RAGReply`` in a state body to trigger a RAG query.
 When generated, a data folder named after the RAG element is created
 (e.g. ``"Knowledge Base"`` produces ``knowledge_base/``). Place your PDF
 documents in this folder before running the agent.
+
+The optional ``llm_prompt`` parameter injects a fixed prefix instruction before
+every RAG query, useful for enforcing domain-specific constraints or tone:
+
+.. code-block:: python
+
+    kb = agent.new_rag(
+        name='Knowledge Base',
+        vector_store=vector_store,
+        splitter=splitter,
+        llm_name='gpt-4o-mini',
+        llm_prompt='Answer only from the provided documents.',
+    )
 
 Multiple LLMs
 ~~~~~~~~~~~~~

--- a/docs/source/releases/v7.rst
+++ b/docs/source/releases/v7.rst
@@ -4,6 +4,7 @@ Version 7
 .. toctree::
    :maxdepth: 1
 
+   v7/v7.9.0
    v7/v7.8.3
    v7/v7.8.2
    v7/v7.8.1

--- a/docs/source/releases/v7/v7.9.0.rst
+++ b/docs/source/releases/v7/v7.9.0.rst
@@ -1,0 +1,149 @@
+Version 7.9.0
+=============
+
+Minor release headlined by **new agent action types** and **BAF generator
+enhancements**.  It adds ``LLMChatReply`` and ``WebCrawlLLMReply`` actions,
+nine ``WebSocketReply*`` action classes for rich-media replies, a new
+``llm_prompt`` parameter on ``RAG``, and generator improvements including
+pre-rendered YAML config injection, automatic ``tools.py`` generation, and
+per-skill Markdown file output.
+
+New Action Types
+----------------
+
+LLMChatReply
+~~~~~~~~~~~~
+
+* New ``LLMChatReply`` action sends a chat-style reply using an LLM.  Unlike
+  ``LLMReply``, it invokes ``llm.chat(...)`` with the conversation history,
+  making it appropriate for multi-turn dialogue states.
+* Accepts an optional ``prompt`` (system prompt injected into the call) and
+  an optional ``llm_name`` to target a specific registered LLM; falls back
+  to the agent's default LLM when not set.
+
+.. code-block:: python
+
+    from besser.BUML.metamodel.state_machine.agent import LLMChatReply
+
+    my_state.set_body(Body('chat_body', [LLMChatReply(prompt='Be concise.')]))
+
+WebCrawlLLMReply
+~~~~~~~~~~~~~~~~
+
+* New ``WebCrawlLLMReply`` action performs a BFS web crawl starting at
+  ``initial_url`` and queries an LLM with the retrieved content.
+* The crawl result is cached in the agent session under the key
+  ``f"web_crawl_{initial_url}"``; set ``run_crawl=False`` in subsequent
+  states to reuse the cached content without re-fetching.
+* Configurable via ``max_depth``, ``max_pages``, ``crawl_format``
+  (``"markdown"`` or ``"html"``), ``base_url_prefix``, ``system_message_prefix``,
+  ``no_crawl_error_message``, and ``llm_name``.
+
+.. code-block:: python
+
+    from besser.BUML.metamodel.state_machine.agent import WebCrawlLLMReply
+
+    crawl_state.set_body(Body('crawl_body', [
+        WebCrawlLLMReply(
+            initial_url='https://example.com/docs',
+            max_depth=2,
+            max_pages=20,
+            crawl_format='markdown',
+            run_crawl=True,
+        )
+    ]))
+
+WebSocket reply actions
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Nine new action classes map directly to the ``WebSocketPlatform`` rich-media
+reply methods, letting you model structured replies in the B-UML agent
+diagram without writing custom body code:
+
++----------------------------------+-----------------------------------------------+
+| Class                            | Mapped platform method                        |
++==================================+===============================================+
+| ``WebSocketReplyMarkdown``       | ``platform.reply_markdown(message)``          |
++----------------------------------+-----------------------------------------------+
+| ``WebSocketReplyHTML``           | ``platform.reply_html(message)``              |
++----------------------------------+-----------------------------------------------+
+| ``WebSocketReplySpeech``         | ``platform.reply_speech(message, speed)``     |
++----------------------------------+-----------------------------------------------+
+| ``WebSocketReplyOptions``        | ``platform.reply_options(options)``           |
++----------------------------------+-----------------------------------------------+
+| ``WebSocketReplyLocation``       | ``platform.reply_location(lat, lon)``         |
++----------------------------------+-----------------------------------------------+
+| ``WebSocketReplyFile``           | ``platform.reply_file(file)``                 |
++----------------------------------+-----------------------------------------------+
+| ``WebSocketReplyImage``          | ``platform.reply_image(image)``               |
++----------------------------------+-----------------------------------------------+
+| ``WebSocketReplyDataframe``      | ``platform.reply_dataframe(df)``              |
++----------------------------------+-----------------------------------------------+
+| ``WebSocketReplyPlotly``         | ``platform.reply_plotly(fig)``                |
++----------------------------------+-----------------------------------------------+
+
+.. note::
+
+    ``WebSocketReplyFile``, ``WebSocketReplyImage``, ``WebSocketReplyDataframe``,
+    and ``WebSocketReplyPlotly`` generate stub code that requires the developer
+    to supply the runtime object (``File``, NumPy ``ndarray``, pandas
+    ``DataFrame``, or Plotly ``Figure`` respectively) inside the body.
+
+RAG Enhancement
+---------------
+
+* ``RAG`` now accepts an optional ``llm_prompt`` parameter — a string of
+  prefix instructions injected before each RAG prompt at generation time.
+  This allows agents to enforce domain-specific constraints or tone guidelines
+  on every RAG query without modifying the user-facing question.
+* ``Agent.new_rag()`` forwards ``llm_prompt`` transparently to the ``RAG``
+  constructor.
+
+.. code-block:: python
+
+    kb = agent.new_rag(
+        name='Knowledge Base',
+        vector_store=vector_store,
+        splitter=splitter,
+        llm_name='gpt-4o-mini',
+        llm_prompt='Answer only from the provided documents.',
+    )
+
+BAF Generator Enhancements
+---------------------------
+
+Pre-rendered YAML config injection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ``BAFGenerator`` now accepts a ``config_yaml`` parameter.  When provided,
+  its value is written verbatim to ``config.yaml`` instead of rendering the
+  config from the agent model's ``ConfigProperty`` list.  This is useful when
+  the caller has already serialised a YAML configuration (e.g., from the web
+  editor) and wants to preserve it exactly.
+
+tools.py generation
+~~~~~~~~~~~~~~~~~~~
+
+* When the agent model contains one or more ``Tool`` objects, the generator
+  now emits a ``tools.py`` file in the output directory containing the
+  Python implementation of every tool function.  This separates tool
+  definitions from the main agent script and makes them easier to edit and
+  test independently.
+
+skills/ directory generation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* When the agent model contains one or more ``Skill`` objects, the generator
+  creates a ``skills/`` subdirectory and writes one Markdown file per skill
+  (``<skill_name>.md``) containing the skill's ``content`` field.  Reasoning
+  states load skill instructions from these files at runtime.
+
+Internal updates
+----------------
+
+* ``besser/utilities/buml_code_builder/agent_model_builder.py`` updated to
+  handle the new action types in the agent-model-to-code conversion.
+* ``besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py``
+  extended to serialise the new action classes to the frontend JSON format.
+* ``besser/utilities/web_modeling_editor/backend/routers/generation_router.py``
+  updated to pass ``config_yaml`` through the generation pipeline.

--- a/docs/source/releases/v7/v7.9.0.rst
+++ b/docs/source/releases/v7/v7.9.0.rst
@@ -165,6 +165,19 @@ action types and reasoning capabilities directly in the visual editor:
   the canonical nested shape and normalized at the storage boundary, so models
   that bypass the editor round-trip through the backend cleanly.
 
+Auto-layout and headless SVG export
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* **ELK-based auto-layout**: a one-click auto-layout (powered by the Eclipse
+  Layout Kernel) re-arranges any diagram, exposed both as
+  ``ApollonEditor.autoLayout()`` and as an auto-layout button in the editor's
+  zoom control box.
+* **Headless SVG export pipeline**: a new ``POST /besser_api/get-svg`` backend
+  endpoint converts a B-UML model to the editor JSON model and renders it to
+  SVG by delegating to the editor server's new ``POST /api/svg`` route, which
+  draws the diagram headlessly (jsdom + Apollon) with ELK auto-layout enabled
+  by default — a browser-free B-UML → SVG rendering path.
+
 Follow-up correctness fixes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/releases/v7/v7.9.0.rst
+++ b/docs/source/releases/v7/v7.9.0.rst
@@ -138,6 +138,47 @@ skills/ directory generation
   (``<skill_name>.md``) containing the skill's ``content`` field.  Reasoning
   states load skill instructions from these files at runtime.
 
+Web Modeling Editor
+-------------------
+
+The agent diagram editor gains a major UX expansion that surfaces the new
+action types and reasoning capabilities directly in the visual editor:
+
+* **New state and action types**: reasoning states (modelled as an
+  ``AgentState`` with ``stateType: "reasoning"``), plus ``LLM Chat``,
+  ``Web Crawl + LLM`` and the nine WebSocket reply actions, each with a
+  dedicated configuration panel. A state can now hold multiple ordered action
+  bodies, reorderable by drag-and-drop, with a configurable fallback-body
+  toggle.
+* **RAG configuration**: the RAG element exposes the new ``llm_prompt``, ``k``
+  and ``num_previous_messages`` fields, and RAG reply actions accept an
+  optional per-action prompt.
+* **config.yaml editor**: a CodeMirror-based editor authors the agent
+  ``config.yaml`` directly in the tool — a structured form view plus a
+  free-text custom-YAML block — and ships it to the ``BAFGenerator`` through
+  the new ``config_yaml`` parameter. Tool bodies and custom-code actions are
+  edited with syntax-highlighted CodeMirror editors.
+* **Validation and polish**: warnings for WebSocket/LLM/reasoning primitives
+  when a required platform, LLM, or reasoning state is missing, and palette
+  label truncation to prevent layout overflow.
+* **Transition normalization** (#139): agent transitions are always stored in
+  the canonical nested shape and normalized at the storage boundary, so models
+  that bypass the editor round-trip through the backend cleanly.
+
+Follow-up correctness fixes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* The ``buml_to_json`` converter now emits reasoning states as an
+  ``AgentState`` carrying ``stateType: "reasoning"`` instead of the legacy
+  ``AgentReasoningState`` element type (which the editor no longer registers),
+  so exported reasoning states round-trip without failing to deserialize on
+  import.
+* Fixed a crash when dragging an action card between the body and fallback
+  lists, hardened ``config.yaml`` scalar quoting so secrets containing
+  YAML-significant characters cannot corrupt the generated config, and
+  normalized personalization variant models to the canonical transition shape
+  before generation.
+
 Internal updates
 ----------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = besser
-version = 7.8.3
+version = 7.9.0
 author = Luxembourg Institute of Science and Technology
 description = BESSER
 long_description = file: README.md

--- a/tests/generators/agents/test_agent_personalization_style.py
+++ b/tests/generators/agents/test_agent_personalization_style.py
@@ -1,0 +1,70 @@
+"""Tests for ``style_text_batch`` agent-reply restyling.
+
+The OpenAI call is mocked, so these assert the style validation and that each
+supported style selects a distinct, on-topic system prompt — not the model
+output itself.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from besser.generators.agents.agent_personalization import style_text_batch
+
+
+@patch("besser.generators.agents.agent_personalization.call_openai_chat")
+def test_friendly_style_is_supported(mock_chat):
+    mock_chat.return_value = "1. happy to help"
+    result = style_text_batch(["help"], "friendly", openai_api_key="k")
+
+    assert result == ["happy to help"]
+    system_prompt = mock_chat.call_args[0][0].lower()
+    assert "friendly" in system_prompt or "warm" in system_prompt
+
+
+@patch("besser.generators.agents.agent_personalization.call_openai_chat")
+def test_technical_style_is_supported(mock_chat):
+    mock_chat.return_value = "1. invoke the endpoint"
+    result = style_text_batch(["call the api"], "technical", openai_api_key="k")
+
+    assert result == ["invoke the endpoint"]
+    system_prompt = mock_chat.call_args[0][0].lower()
+    assert "technical" in system_prompt or "precise" in system_prompt
+
+
+@pytest.mark.parametrize("style", ["formal", "informal", "friendly", "technical"])
+@patch("besser.generators.agents.agent_personalization.call_openai_chat")
+def test_supported_styles_pass_validation(mock_chat, style):
+    mock_chat.return_value = "1. rewritten"
+    # Should not raise, and should call the model exactly once.
+    result = style_text_batch(["original"], style, openai_api_key="k")
+
+    assert result == ["rewritten"]
+    assert mock_chat.call_count == 1
+
+
+@patch("besser.generators.agents.agent_personalization.call_openai_chat")
+def test_styles_select_distinct_prompts(mock_chat):
+    mock_chat.return_value = "1. x"
+    prompts = {}
+    for style in ("formal", "informal", "friendly", "technical"):
+        style_text_batch(["x"], style, openai_api_key="k")
+        prompts[style] = mock_chat.call_args[0][0]
+
+    # Every supported style must map to a different system prompt.
+    assert len(set(prompts.values())) == 4
+
+
+def test_unsupported_style_raises_value_error():
+    with pytest.raises(ValueError, match="style must be one of"):
+        style_text_batch(["hello"], "bogus", openai_api_key="k")
+
+
+def test_case_insensitive_style():
+    with patch(
+        "besser.generators.agents.agent_personalization.call_openai_chat",
+        return_value="1. ok",
+    ) as mock_chat:
+        result = style_text_batch(["hi"], "FRIENDLY", openai_api_key="k")
+
+    assert result == ["ok"]
+    assert mock_chat.call_count == 1

--- a/tests/generators/agents/test_baf_generator.py
+++ b/tests/generators/agents/test_baf_generator.py
@@ -1,8 +1,9 @@
 import os
 import pytest
 from besser.BUML.metamodel.state_machine.agent import (
-    Agent, Intent, WebSocketPlatform
+    Agent, Intent, LLMOpenAI, RAGReply, RAGTextSplitter, RAGVectorStore, WebSocketPlatform
 )
+from besser.BUML.metamodel.state_machine.state_machine import Body
 from besser.generators.agents.baf_generator import BAFGenerator, GenerationMode
 
 
@@ -116,3 +117,112 @@ def test_baf_generator_output_content(agent_model, tmpdir):
         code = f.read()
 
     assert "test_agent" in code, "Generated code should reference the agent name"
+
+
+def _make_rag(name: str) -> tuple[RAGVectorStore, RAGTextSplitter]:
+    vector_store = RAGVectorStore(
+        embedding_provider="openai",
+        embedding_parameters={"model": "text-embedding-3-small"},
+        persist_directory=f"vector_store/{name}",
+    )
+    splitter = RAGTextSplitter(splitter_type="recursive_character", chunk_size=1000, chunk_overlap=100)
+    return vector_store, splitter
+
+
+@pytest.fixture
+def multi_rag_agent_model():
+    """Create an agent with two RAG configs and distinct RAGReply targets."""
+    agent = Agent("multi_rag_agent")
+    agent.platforms.append(WebSocketPlatform())
+    LLMOpenAI(agent=agent, name="gpt-4o-mini", parameters={})
+
+    products_vs, products_splitter = _make_rag("products")
+    faq_vs, faq_splitter = _make_rag("faq")
+    agent.new_rag(
+        name="products_rag",
+        vector_store=products_vs,
+        splitter=products_splitter,
+        llm_name="gpt-4o-mini",
+        llm_prompt="Use only product catalog entries.",
+    )
+    agent.new_rag(name="faq_rag", vector_store=faq_vs, splitter=faq_splitter, llm_name="gpt-4o-mini")
+
+    products_state = agent.new_state(name="products", initial=True)
+    faq_state = agent.new_state(name="faq")
+
+    products_state.set_body(Body("products_body", actions=[RAGReply("products_rag", prompt="Products only")]))
+    faq_state.set_fallback_body(Body("faq_fallback", actions=[RAGReply("faq_rag")]))
+    return agent
+
+
+def test_baf_generator_uses_targeted_rag_instances(multi_rag_agent_model, tmp_path):
+    """RAGReply emits ``<rag_var>.run(...)`` for body and fallback-body actions."""
+    BAFGenerator(
+        model=multi_rag_agent_model,
+        output_dir=str(tmp_path),
+        generation_mode=GenerationMode.CODE_ONLY,
+    ).generate()
+
+    agent_file = os.path.join(str(tmp_path), f"{multi_rag_agent_model.name}.py")
+    with open(agent_file, "r", encoding="utf-8") as f:
+        code = f.read()
+
+    assert "rag_message = products_rag.run(session.event.message, llm_prompt='Products only')" in code
+    assert "rag_message = faq_rag.run(session.event.message)" in code
+    assert "rag_message = session.run_rag(session.event.message, llm_prompt='Products only')" not in code
+    assert "llm_prompt='Use only product catalog entries.'" in code
+
+
+def test_baf_generator_falls_back_to_session_rag_with_warning(tmp_path, caplog):
+    """Unknown RAG names keep backward compatibility via ``session.run_rag``."""
+    agent = Agent("rag_fallback_agent")
+    agent.platforms.append(WebSocketPlatform())
+    LLMOpenAI(agent=agent, name="gpt-4o-mini", parameters={})
+
+    known_vs, known_splitter = _make_rag("known")
+    agent.new_rag(name="known_rag", vector_store=known_vs, splitter=known_splitter, llm_name="gpt-4o-mini")
+
+    fallback_state = agent.new_state(name="fallback", initial=True)
+    fallback_state.set_body(Body("fallback_body", actions=[RAGReply("missing_rag", prompt="Use fallback")]))
+
+    with caplog.at_level("WARNING"):
+        BAFGenerator(
+            model=agent,
+            output_dir=str(tmp_path),
+            generation_mode=GenerationMode.CODE_ONLY,
+        ).generate()
+
+    agent_file = os.path.join(str(tmp_path), f"{agent.name}.py")
+    with open(agent_file, "r", encoding="utf-8") as f:
+        code = f.read()
+
+    assert "rag_message = session.run_rag(session.event.message, llm_prompt='Use fallback')" in code
+    assert "references unknown rag_db_name 'missing_rag'" in caplog.text
+
+
+def test_baf_generator_single_rag_still_uses_explicit_instance(tmp_path):
+    """When ``rag_db_name`` resolves unambiguously, always emit ``rag.run(...)``."""
+    agent = Agent("single_rag_agent")
+    agent.platforms.append(WebSocketPlatform())
+    LLMOpenAI(agent=agent, name="gpt-4o-mini", parameters={})
+
+    only_vs, only_splitter = _make_rag("only")
+    agent.new_rag(name="only_rag", vector_store=only_vs, splitter=only_splitter, llm_name="gpt-4o-mini")
+
+    only_state = agent.new_state(name="only", initial=True)
+    only_state.set_body(Body("only_body", actions=[RAGReply("only_rag")]))
+
+    BAFGenerator(
+        model=agent,
+        output_dir=str(tmp_path),
+        generation_mode=GenerationMode.CODE_ONLY,
+    ).generate()
+
+    agent_file = os.path.join(str(tmp_path), f"{agent.name}.py")
+    with open(agent_file, "r", encoding="utf-8") as f:
+        code = f.read()
+
+    assert "rag_message = only_rag.run(session.event.message)" in code
+    assert "rag_message = session.run_rag(session.event.message)" not in code
+
+

--- a/tests/generators/agents/test_baf_generator_reasoning.py
+++ b/tests/generators/agents/test_baf_generator_reasoning.py
@@ -2,15 +2,18 @@
 
 These tests build a fixture agent that uses every reasoning primitive
 (``Tool``, ``Skill``, ``Workspace``, ``ReasoningState``), run the
-generator, and assert that the produced ``<agent_name>.py`` file:
+generator, and assert that the produced output:
 
-    * exists and is non-empty;
-    * imports the BAF reasoning runtime symbols;
-    * registers each primitive via the canonical BAF builder calls;
-    * is syntactically valid Python (``ast.parse``).
+    * ``<agent_name>.py`` exists and is non-empty;
+    * ``<agent_name>.py`` imports the BAF reasoning runtime symbols;
+    * ``tools.py`` exists and contains each tool's function code;
+    * ``skills/<name>.md`` exists for each skill;
+    * ``<agent_name>.py`` calls ``load_tools``/``load_skills`` instead of
+      registering primitives inline;
+    * ``<agent_name>.py`` is syntactically valid Python (``ast.parse``).
 
 The tests deliberately avoid importing the BAF runtime — only the text
-of the generated file is inspected.
+of the generated files is inspected.
 """
 
 import ast
@@ -95,23 +98,32 @@ class TestBAFGeneratorReasoning:
         assert "from baf.library.state import new_reasoning_state" in code
 
     def test_emits_tool_registration(self, reasoning_agent_model, tmp_path):
-        path = _generate(reasoning_agent_model, str(tmp_path))
-        with open(path, "r", encoding="utf-8") as f:
-            code = f.read()
-        # The tool's source must be inlined and then registered.
-        assert "def ping" in code
-        assert "agent.new_tool(" in code
+        agent_path = _generate(reasoning_agent_model, str(tmp_path))
+        with open(agent_path, "r", encoding="utf-8") as f:
+            agent_code = f.read()
+        # Agent script delegates to load_tools, not inline new_tool calls.
+        assert "agent.load_tools(" in agent_code
+        assert "tools.py" in agent_code
+        # Tool source code lives in the separate tools.py module.
+        tools_path = os.path.join(str(tmp_path), "tools.py")
+        assert os.path.isfile(tools_path)
+        with open(tools_path, "r", encoding="utf-8") as f:
+            tools_code = f.read()
+        assert "def ping" in tools_code
 
     def test_emits_skill_registration(self, reasoning_agent_model, tmp_path):
-        path = _generate(reasoning_agent_model, str(tmp_path))
-        with open(path, "r", encoding="utf-8") as f:
-            code = f.read()
-        assert "agent.new_skill(" in code
-        assert "GreetByName" in code
-        # BAF's new_skill takes the skill text as the positional ``source``
-        # argument, not a ``content=`` kwarg (which would raise TypeError).
-        assert "content=" not in code
-        assert "Always greet the user by name when introduced." in code
+        agent_path = _generate(reasoning_agent_model, str(tmp_path))
+        with open(agent_path, "r", encoding="utf-8") as f:
+            agent_code = f.read()
+        # Agent script delegates to load_skills, not inline new_skill calls.
+        assert "agent.load_skills(" in agent_code
+        assert "skills" in agent_code
+        # Each skill is written to skills/<name>.md.
+        skill_file = os.path.join(str(tmp_path), "skills", "GreetByName.md")
+        assert os.path.isfile(skill_file)
+        with open(skill_file, "r", encoding="utf-8") as f:
+            skill_content = f.read()
+        assert "Always greet the user by name when introduced." in skill_content
 
     def test_emits_workspace_registration(self, reasoning_agent_model, tmp_path):
         path = _generate(reasoning_agent_model, str(tmp_path))
@@ -153,6 +165,6 @@ class TestBAFGeneratorReasoning:
             code = f.read()
 
         assert "from baf.library.state import new_reasoning_state" not in code
-        assert "agent.new_tool(" not in code
-        assert "agent.new_skill(" not in code
+        assert "agent.load_tools(" not in code
+        assert "agent.load_skills(" not in code
         assert "agent.new_workspace(" not in code

--- a/tests/generators/web_app/test_web_app_generator_multi_agent.py
+++ b/tests/generators/web_app/test_web_app_generator_multi_agent.py
@@ -91,7 +91,7 @@ def mock_baf_generator():
         instance = MagicMock()
         instance.generate.side_effect = lambda: _fake_generate(instance)
         # Captures the ctor args per call so we can inspect in assertions
-        def _side_effect(agent, output_dir=None, config=None):
+        def _side_effect(agent, output_dir=None, config=None, config_yaml=None):
             inst = MagicMock()
             inst.output_dir = output_dir
             inst.config = config

--- a/tests/utilities/web_modeling_editor/backend/services/converters/test_agent_converter_roundtrip.py
+++ b/tests/utilities/web_modeling_editor/backend/services/converters/test_agent_converter_roundtrip.py
@@ -7,7 +7,8 @@ per-reasoning-state LLM, tools/skills/workspaces) must survive the trip.
 """
 import os
 
-from besser.BUML.metamodel.state_machine.agent import Agent, ReasoningState
+from besser.BUML.metamodel.state_machine.agent import Agent, RAGReply, RAGTextSplitter, RAGVectorStore, ReasoningState
+from besser.BUML.metamodel.state_machine.state_machine import Body
 from besser.utilities.buml_code_builder.agent_model_builder import agent_model_to_code
 from besser.utilities.web_modeling_editor.backend.services.converters import (
     agent_buml_to_json,
@@ -25,7 +26,27 @@ def _build_reasoning_agent() -> Agent:
     agent.new_workspace(
         name="docs", path="/tmp/docs", description="doc store", writable=True, max_read_bytes=1000
     )
+    vector_store = RAGVectorStore(
+        embedding_provider="openai",
+        embedding_parameters={"api_key_property": "nlp.OPENAI_API_KEY"},
+        persist_directory="vector_store/docs",
+    )
+    splitter = RAGTextSplitter(
+        splitter_type="recursive_character",
+        chunk_size=1000,
+        chunk_overlap=100,
+    )
+    agent.new_rag(
+        name="docs_rag",
+        vector_store=vector_store,
+        splitter=splitter,
+        llm_name="fast",
+        llm_prompt="Answer only using the docs corpus.",
+        k=6,
+        num_previous_messages=3,
+    )
     initial = agent.new_state("initial", initial=True)
+    initial.set_body(Body("initial_body", actions=[RAGReply("docs_rag", prompt="Use only cited docs.")]))
     reason = agent.new_reasoning_state(name="reason", llm="fast", max_steps=5, system_prompt="Think.")
     initial.go_to(reason)
     return agent
@@ -60,3 +81,19 @@ def test_agent_roundtrip_preserves_multi_llm_and_reasoning(tmp_path):
     assert set(workspaces) == {"docs"}
     assert workspaces["docs"].path == "/tmp/docs"
     assert workspaces["docs"].writable is True
+
+    # RAG configuration survives with newly surfaced arguments.
+    rags = {r.name: r for r in restored.rags}
+    assert set(rags) == {"docs_rag"}
+    assert rags["docs_rag"].llm_name == "fast"
+    assert rags["docs_rag"].llm_prompt == "Answer only using the docs corpus."
+    assert rags["docs_rag"].k == 6
+    assert rags["docs_rag"].num_previous_messages == 3
+
+    # RAGReply action prompt survives the converters.
+    initial_state = next(s for s in restored.states if s.name == "initial")
+    rag_actions = [a for a in (initial_state.body.actions if initial_state.body else []) if isinstance(a, RAGReply)]
+    assert len(rag_actions) == 1
+    assert rag_actions[0].rag_db_name == "docs_rag"
+    assert rag_actions[0].prompt == "Use only cited docs."
+

--- a/tests/utilities/web_modeling_editor/backend/services/converters/test_agent_converter_roundtrip.py
+++ b/tests/utilities/web_modeling_editor/backend/services/converters/test_agent_converter_roundtrip.py
@@ -60,6 +60,17 @@ def test_agent_roundtrip_preserves_multi_llm_and_reasoning(tmp_path):
         content = handle.read()
 
     json_model = agent_buml_to_json(content)
+
+    # The reasoning state must be emitted in the canonical shape the editor can
+    # deserialize: an AgentState carrying stateType "reasoning". The legacy
+    # AgentReasoningState element type was removed from the editor registry, so
+    # emitting it would crash on import.
+    json_elements = list(json_model.get("elements", {}).values())
+    reasoning_elements = [el for el in json_elements if el.get("stateType") == "reasoning"]
+    assert len(reasoning_elements) == 1
+    assert reasoning_elements[0]["type"] == "AgentState"
+    assert all(el.get("type") != "AgentReasoningState" for el in json_elements)
+
     # process_agent_diagram consumes the frontend envelope: the apollon model
     # under "model" and the diagram config surfaced at the top level.
     restored = process_agent_diagram({"model": json_model, "config": json_model.get("config", {})})

--- a/tests/utilities/web_modeling_editor/backend/test_api_integration.py
+++ b/tests/utilities/web_modeling_editor/backend/test_api_integration.py
@@ -1589,7 +1589,8 @@ class TestStandaloneChatbotDeploy:
         # writer has somewhere to live.
         class _FakeBAFGenerator:
             def __init__(self, agent_model, output_dir, config=None,
-                         openai_api_key=None, generation_mode=None):
+                         config_yaml=None, openai_api_key=None,
+                         generation_mode=None):
                 self.output_dir = output_dir
 
             def generate(self):


### PR DESCRIPTION
## Summary
- New agent action types: `LLMChatReply`, `WebCrawlLLMReply`, and nine `WebSocketReply*` classes (#550).
- `RAG` gains `llm_prompt` / `k` / `num_previous_messages`; `BAFGenerator` gains `config_yaml` injection, `tools.py`, and per-skill `skills/*.md` (#550).
- Reasoning states handled via `stateType` on both converters; export now emits the canonical `AgentState`+`stateType` shape so reasoning states round-trip into the editor.
- **Headless SVG export pipeline**: backend `POST /besser_api/get-svg` (#554) → frontend `POST /api/svg` headless render route + one-click ELK auto-layout (WME #145/#146/#147).
- Frontend submodule bumped `2ce76709`→`ccc5c421`: agent editor expansion (WME #141) + follow-up fixes (WME #143) + auto-layout/SVG (WME #145–#147). Excludes the i18n/multilingual work (pending native-speaker review).

## Test plan
- [x] Backend CI green (lint, tests 3.11/3.12, CodeQL)
- [x] `test_agent_converter_roundtrip` green (reasoning emitted as `AgentState`+`stateType`)
- [x] `POST /besser_api/get-svg` returns SVG for a sample B-UML model
- [ ] Full docs build: `cd docs && make html` — v7.9.0 page renders
- [x] Paired frontend PR (develop→main) merged in lockstep