### PR TITLE
release: v7.9.1 — object diagram attributes in PNG/SVG export

### DIFF
--- a/besser/utilities/web_modeling_editor/backend/routers/conversion_router.py
+++ b/besser/utilities/web_modeling_editor/backend/routers/conversion_router.py
@@ -175,9 +175,11 @@ def _validate_file_content(content: bytes, filename: str) -> None:
             )
 
     elif ext == ".py":
-        # Must be valid Python syntax
+        # Must be valid Python syntax. Decode with utf-8-sig so a leading UTF-8
+        # BOM (common from Windows editors) is stripped instead of tripping the
+        # parser with "invalid non-printable character U+FEFF".
         try:
-            text = content.decode("utf-8")
+            text = content.decode("utf-8-sig")
         except UnicodeDecodeError:
             raise HTTPException(status_code=400, detail="Python file is not valid UTF-8 text.")
         try:

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/class_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/class_diagram_converter.py
@@ -95,6 +95,11 @@ def parse_buml_content(content: str) -> DomainModel:
         if not isinstance(content, str):
             raise TypeError(f"Expected B-UML content as str or DomainModel, got {type(content)!r}")
 
+        # Strip a leading UTF-8 BOM so the sandboxed exec does not fail with
+        # "invalid non-printable character U+FEFF" for files saved with a BOM.
+        if content.startswith("﻿"):
+            content = content[1:]
+
         # Pre-process the content to remove import and generator-related lines.
         # All required types are already provided in safe_globals, so import
         # statements are unnecessary and would fail in the sandboxed environment.
@@ -261,7 +266,14 @@ def class_buml_to_json(domain_model):
                         "isDerived": attr.is_derived,
                     }
                     if attr.default_value is not None:
-                        attr_element["defaultValue"] = attr.default_value
+                        # default_value may be an EnumerationLiteral (or other
+                        # metamodel object); coerce it to a JSON-serialisable
+                        # value — its name, else its string form — so the diagram
+                        # JSON can be serialised when sent to the render service.
+                        default_value = attr.default_value
+                        if not isinstance(default_value, (str, int, float, bool)):
+                            default_value = getattr(default_value, "name", None) or str(default_value)
+                        attr_element["defaultValue"] = default_value
                     elements[attr_id] = attr_element
                     attribute_ids.append(attr_id)
                     y_offset += 30

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/class_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/class_diagram_converter.py
@@ -223,8 +223,18 @@ def class_buml_to_json(domain_model):
             attribute_ids = []
             method_ids = []
 
+            # Header height must mirror the editor's UMLClassifier renderer
+            # (stereotypeHeaderHeight=50, nonStereotypeHeaderHeight=40) so ELK
+            # auto-layout and the headless SVG renderer agree on box geometry.
+            # Enumerations and abstract classes carry a «stereotype» line, so
+            # their header is one row taller and members start lower.
+            is_stereotyped = isinstance(type_obj, Enumeration) or (
+                isinstance(type_obj, Class) and getattr(type_obj, "is_abstract", False)
+            )
+            header_height = 50 if is_stereotyped else 40
+
             # Process attributes/literals
-            y_offset = y + 40  # Starting position for attributes
+            y_offset = y + header_height  # Members start below the header
             if isinstance(type_obj, Class):
                 for attr in sorted(type_obj.attributes, key=lambda a: a.name):
                     attr_id = str(uuid.uuid4())
@@ -382,8 +392,14 @@ def class_buml_to_json(domain_model):
                     attribute_ids.append(literal_id)
                     y_offset += 30
 
-            # Create the element
-            computed_height = max(100, 30 * (len(attribute_ids) + len(method_ids) + 1))
+            # Create the element. Box height mirrors the renderer: header plus
+            # one 30px row per attribute/method (see UMLClassifier.render). OCL
+            # constraint boxes are not classifiers, so keep their legacy sizing.
+            member_count = len(attribute_ids) + len(method_ids)
+            if isinstance(type_obj, Constraint):
+                computed_height = max(100, 30 * (member_count + 1))
+            else:
+                computed_height = header_height + 30 * member_count
             element_data = {
                 "id": element_id,
                 "name": type_obj.name,

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,6 +12,7 @@ services:
       - PYTHONPATH=/app
       - SMTP_HOST=${SMTP_HOST:-smtp.gmail.com}
       - SMTP_PORT=${SMTP_PORT:-587}
+      - WME_NODE_SERVER_URL=${WME_NODE_SERVER_URL:-http://besser-wme-frontend:8080}
     volumes:
       - feedback_data:/app/besser/feedback_data
     command: python -m besser.utilities.web_modeling_editor.backend.backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     environment:
       - PYTHONPATH=/app
       - GITHUB_REDIRECT_URI=${GITHUB_REDIRECT_URI:-http://localhost:9000/besser_api/github/auth/callback}
+      - WME_NODE_SERVER_URL=${WME_NODE_SERVER_URL:-http://besser-wme-frontend:8080}
     command: python -m besser.utilities.web_modeling_editor.backend.backend
     networks:
       - besser_network

--- a/docs/source/releases/v7.rst
+++ b/docs/source/releases/v7.rst
@@ -4,6 +4,7 @@ Version 7
 .. toctree::
    :maxdepth: 1
 
+   v7/v7.9.1
    v7/v7.9.0
    v7/v7.8.3
    v7/v7.8.2

--- a/docs/source/releases/v7/v7.9.1.rst
+++ b/docs/source/releases/v7/v7.9.1.rst
@@ -1,0 +1,27 @@
+Version 7.9.1
+=============
+
+Patch release: **object diagram attributes are no longer dropped when**
+**exporting to PNG or SVG**. This is a **frontend-only** release — no metamodel,
+generator, or backend API changes; the only backend-repo change is the
+web-modeling-editor submodule pointer bump.
+
+Fixes
+-----
+
+* **Object diagrams exported as empty header boxes**: the export-only SVG scene
+  (``packages/editor/src/main/scenes/svg.tsx``) special-cased only
+  ``UMLClassifierComponent`` to nest its member children (attributes and methods)
+  inside the box. Object boxes render through ``UMLObjectNameComponent``, which
+  fell into the ``default`` branch and was drawn alone, while each object's
+  ``ObjectAttribute`` / ``ObjectMethod`` members — mapped to
+  ``UMLClassifierMemberComponent`` — hit the skipped member case on the
+  assumption they had already been nested inside a classifier. They never were,
+  so exported object diagrams showed a white header box with no attribute rows.
+  The live editor canvas was unaffected because it renders container children
+  directly; only the export path special-cased the classifier. The fix routes
+  ``UMLObjectNameComponent`` through the same member-nesting branch as
+  ``UMLClassifierComponent``. Matching on the component (rather than the element
+  type) also covers ``UserModelName``, which maps to the same component. PNG
+  export rasterizes the result of ``exportAsSVG``, so both formats are fixed by
+  the single change.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = besser
-version = 7.9.0
+version = 7.9.1
 author = Luxembourg Institute of Science and Technology
 description = BESSER
 long_description = file: README.md

--- a/tests/utilities/web_modeling_editor/backend/services/converters/test_class_buml_to_json_safety.py
+++ b/tests/utilities/web_modeling_editor/backend/services/converters/test_class_buml_to_json_safety.py
@@ -1,0 +1,71 @@
+"""Robustness tests for the class-diagram ``buml_to_json`` path used by the
+``/get-svg`` (and ``/get-json-model``) endpoints.
+
+Covers two failures that surfaced as opaque ``500``/``400`` responses:
+
+* an attribute whose ``default_value`` is an ``EnumerationLiteral`` (or any
+  non-primitive metamodel object) made the diagram JSON un-serialisable, so the
+  render POST raised ``TypeError`` -> 500;
+* a leading UTF-8 BOM (``\\ufeff``) tripped the sandboxed parser with
+  "invalid non-printable character U+FEFF" -> 400.
+"""
+
+import json
+
+from besser.BUML.metamodel.structural import (
+    DomainModel, Class, Property, Enumeration, EnumerationLiteral,
+)
+from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json.class_diagram_converter import (
+    parse_buml_content, class_buml_to_json,
+)
+
+
+def test_enum_literal_default_value_is_json_serialisable():
+    """An EnumerationLiteral default must be coerced to its name, not stored raw."""
+    low = EnumerationLiteral(name="LOW")
+    high = EnumerationLiteral(name="HIGH")
+    priority = Enumeration(name="Priority", literals={low, high})
+    level = Property(name="level", type=priority, default_value=low)
+    task = Class(name="Task", attributes={level})
+    model = DomainModel(name="Tracker", types={task, priority})
+
+    diagram_json = class_buml_to_json(model)
+
+    default_value = next(
+        e["defaultValue"]
+        for e in diagram_json["elements"].values()
+        if e.get("name") == "level" and "defaultValue" in e
+    )
+    assert default_value == "LOW"
+    # The whole payload (as POSTed to the render service) must serialise.
+    json.dumps({"model": diagram_json, "autoLayout": True})
+
+
+def test_primitive_default_value_is_preserved():
+    """A plain string/number default must pass through unchanged."""
+    name = Property(name="name", type="str", default_value="anon")
+    person = Class(name="Person", attributes={name})
+    model = DomainModel(name="M", types={person})
+
+    diagram_json = class_buml_to_json(model)
+    default_value = next(
+        e["defaultValue"]
+        for e in diagram_json["elements"].values()
+        if e.get("name") == "name" and "defaultValue" in e
+    )
+    assert default_value == "anon"
+
+
+def test_parse_buml_content_strips_leading_bom():
+    """A file saved with a UTF-8 BOM must parse instead of raising a syntax error."""
+    body = (
+        'name_attr = Property(name="name", type=StringType)\n'
+        'Person = Class(name="Person", attributes={name_attr})\n'
+        'domain_model = DomainModel(name="M", types={Person})\n'
+    )
+    with_bom = "﻿" + body
+
+    model = parse_buml_content(with_bom)
+
+    assert model is not None
+    assert {c.name for c in model.get_classes()} == {"Person"}


### PR DESCRIPTION
## Summary
- Patch release **v7.9.1**: object diagram exports no longer drop attributes.
- The export-only SVG scene only nested member children for `UMLClassifierComponent`; object boxes (`UMLObjectNameComponent`) fell to the box-only branch and their `ObjectAttribute`/`ObjectMethod` members were skipped, so PNG/SVG exports showed an empty header box.
- Fix routes `UMLObjectNameComponent` through the same member-nesting branch (also covers `UserModelName`). Frontend-only change; backend has no code changes — this PR carries the submodule pointer bump (`777d86445` → `47eac2219`), the version bump, and release notes.

## Test plan
- [ ] In the editor, build an object diagram with attribute values, export to **PNG** and **SVG** — attribute rows render inside each object box.
- [ ] Class diagram export still renders correctly (no regression in the classifier branch).
- [ ] Full docs build: `cd docs && make html` — new v7.9.1 page renders.