### PR TITLE
fix(structural): honest multiplicity max types and idiomatic empty lists

### DIFF
--- a/besser/BUML/metamodel/structural/structural.py
+++ b/besser/BUML/metamodel/structural/structural.py
@@ -505,14 +505,14 @@ class Multiplicity(Element):
 
     Attributes:
         min (int): The minimum multiplicity.
-        max (int | Literal["*"]): The maximum multiplicity. Use "*" for unlimited.
+        max (int): The maximum multiplicity.
         is_derived (bool): Indicates whether the element is derived (False as default).
     """
 
     def __init__(self, min_multiplicity: int, max_multiplicity: int | Literal["*"], is_derived: bool = False, uncertainty: float = 0.0):
         super().__init__(is_derived=is_derived, uncertainty=uncertainty)
         self.min: int = min_multiplicity
-        self.max: int | Literal["*"] = max_multiplicity
+        self.max: int = max_multiplicity
 
     @property
     def min(self) -> int:
@@ -532,14 +532,14 @@ class Multiplicity(Element):
         self.__min = min_multiplicity
 
     @property
-    def max(self) -> int | Literal["*"]:
-        """int | Literal["*"]: Get the maximum multiplicity."""
+    def max(self) -> int:
+        """int: Get the maximum multiplicity."""
         return self.__max
 
     @max.setter
     def max(self, max_multiplicity: int | Literal["*"]):
         """
-        int | Literal["*"]: Set the maximum multiplicity.
+        int: Set the maximum multiplicity.
 
         Raises:
             ValueError: (Invalid max multiplicity) if the maximum multiplicity is less than 0 or

--- a/besser/BUML/metamodel/structural/structural.py
+++ b/besser/BUML/metamodel/structural/structural.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Union, List, TYPE_CHECKING
+from typing import Any, Union, List, TYPE_CHECKING, Literal
 import keyword
 import logging
 import time
@@ -500,19 +500,19 @@ class Multiplicity(Element):
 
     Args:
         min_multiplicity (int): The minimum multiplicity.
-        max_multiplicity (int): The maximum multiplicity. Use "*" for unlimited.
+        max_multiplicity (int | Literal["*"]): The maximum multiplicity. Use "*" for unlimited.
         is_derived (bool): Indicates whether the element is derived (False as default).
 
     Attributes:
         min (int): The minimum multiplicity.
-        max (int): The maximum multiplicity. Use "*" for unlimited.
+        max (int | Literal["*"]): The maximum multiplicity. Use "*" for unlimited.
         is_derived (bool): Indicates whether the element is derived (False as default).
     """
 
-    def __init__(self, min_multiplicity: int, max_multiplicity: int, is_derived: bool = False, uncertainty: float = 0.0):
+    def __init__(self, min_multiplicity: int, max_multiplicity: int | Literal["*"], is_derived: bool = False, uncertainty: float = 0.0):
         super().__init__(is_derived=is_derived, uncertainty=uncertainty)
         self.min: int = min_multiplicity
-        self.max: int = max_multiplicity
+        self.max: int | Literal["*"] = max_multiplicity
 
     @property
     def min(self) -> int:
@@ -532,14 +532,14 @@ class Multiplicity(Element):
         self.__min = min_multiplicity
 
     @property
-    def max(self) -> int:
-        """int: Get the maximum multiplicity."""
+    def max(self) -> int | Literal["*"]:
+        """int | Literal["*"]: Get the maximum multiplicity."""
         return self.__max
 
     @max.setter
-    def max(self, max_multiplicity: int):
+    def max(self, max_multiplicity: int | Literal["*"]):
         """
-        int: Set the maximum multiplicity.
+        int | Literal["*"]: Set the maximum multiplicity.
 
         Raises:
             ValueError: (Invalid max multiplicity) if the maximum multiplicity is less than 0 or
@@ -848,7 +848,7 @@ class Method(TypedElement):
                  pre: list["Constraint"] = None, post: list["Constraint"] = None):
         super().__init__(name, type, timestamp, metadata, visibility, is_derived, uncertainty)
         self.is_abstract: bool = is_abstract
-        self.parameters: list[Parameter] = parameters if parameters is not None else list()
+        self.parameters: list[Parameter] = parameters if parameters is not None else []
         self.owner: Type = owner
         self.code: str = code
         self.state_machine: "StateMachine" = state_machine
@@ -905,7 +905,7 @@ class Method(TypedElement):
 
             self.__parameters = parameters
         else:
-            self.__parameters = list()
+            self.__parameters = []
 
     def add_parameter(self, parameter: Parameter):
         """
@@ -933,7 +933,7 @@ class Method(TypedElement):
             ValueError: if two preconditions have the same name.
         """
         if pre is None:
-            self.__pre = list()
+            self.__pre = []
             return
         names_seen = set()
         duplicates = set()
@@ -959,7 +959,7 @@ class Method(TypedElement):
             ValueError: if two postconditions have the same name.
         """
         if post is None:
-            self.__post = list()
+            self.__post = []
             return
         names_seen = set()
         duplicates = set()


### PR DESCRIPTION
## What

Small quality fixes in `besser/BUML/metamodel/structural/structural.py`:

- Make the `Multiplicity.max` typing honest. The **setter** and `__init__` parameter accept `int | Literal["*"]` (the setter already normalises `"*"` to `UNLIMITED_MAX_MULTIPLICITY` at runtime), while the **stored attribute and getter stay `int`**, since that is what is always returned after normalisation. Docstrings updated to match.
- Replace `list()` with the literal `[]` in `Method` (parameters / pre / post initialisation) per SonarQube rule [python:S7498](https://next.sonarqube.com/sonarqube/coding_rules?open=python%3AS7498&rule_key=python%3AS7498).

No behavioural change — this only aligns the declared types with existing runtime behaviour and applies an idiomatic-literal lint fix.

## Why

The `max` setter has always converted `"*"` to the unlimited sentinel, but the input signatures claimed plain `int`, which is misleading to callers and static type checkers. Conversely the getter never returns `"*"`, so it is correctly typed as `int`. The `list()` -> `[]` change satisfies the SonarQube quality rule flagged on this file.

## How

Input types (`__init__` param + `max` setter param) widened to `int | Literal["*"]`; stored attribute and getter kept as `int`; docstrings updated; `from typing import ... Literal` added. Three `list()` -> `[]` replacements in `Method`.

## Testing

- `ruff check besser/BUML/metamodel/structural/structural.py` -> passes.
- `python -m pytest tests/BUML/metamodel/structural` -> 61 passed.

## Checklist

- [x] Targeted `development` (not `master`)
- [ ] Tests added or updated (no behavioural change; existing suite covers it)
- [ ] Docs updated (no user-facing behaviour change)
- [x] Lint passes (`ruff check .`)
- [ ] Frontend submodule pointer updated (not a cross-repo change)

## Note

I also suggest we need a better evaluation logic for this value.