### PR TITLE
ci: prune dangling images after WME deploy

### DIFF
--- a/.github/workflows/deploy-wme.yml
+++ b/.github/workflows/deploy-wme.yml
@@ -75,6 +75,8 @@ jobs:
             docker compose pull $SERVICES
             echo "Restarting services..."
             docker compose up -d $SERVICES
+            echo "Pruning dangling images..."
+            docker image prune -f
             echo "Running containers:"
             docker compose ps
           EOF

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Welcome to BESSER's Documentation
    Checkout the latest repository: `BESSER-Dataset <https://github.com/BESSER-PEARL/BESSER-Dataset>`_
    The B-UML Dataset is a large-scale dataset containing 5,000+ B-UML models for research in modeling languages and AI-assisted modeling.
 
-**BESSER** is a `low-modeling <https://modeling-languages.com/welcome-to-the-low-modeling-revolution/>`_
+**BESSER** (*BEtter Smart Software fastER*) is a `low-modeling <https://modeling-languages.com/welcome-to-the-low-modeling-revolution/>`_
 `low-code <https://modeling-languages.com/low-code-vs-model-driven/>`_ open-source platform built on top
 of our Python-based personal interpretation of a "Universal Modeling Language" (yes, heavily inspired and
 a simplified version of the better known UML, the Unified Modeling Language).


### PR DESCRIPTION
## What
Adds a `docker image prune -f` step to the EC2 deploy job, right after `docker compose up -d`.

## Why
Each deploy runs `docker compose pull` for the `:latest` backend/frontend images; the previously-tagged layers become dangling and are never cleaned up. Over ~16 weeks this grew `/var/lib/docker` to 29 GB and tripped the weekly host-health disk alarm (**besser-ops#2**, `/` at 88%).

Pruning dangling images after each deploy drops exactly the layers that deploy just superseded. (Watchtower already runs with `--cleanup`, so this closes the remaining gap: the CI deploy-pull path.)

## Note
The manual `scripts/deploy.sh` path got the same one-liner locally, but `scripts/` is git-ignored so it isn't part of this PR.

## Verification
Ran the equivalent prune on the host during incident cleanup: reclaimed 6.83 GB, disk 88% → 64%, no downtime.