### PR TITLE
release: v7.11.1 — honest Multiplicity.max typing + idiomatic empty lists

### DIFF
--- a/besser/BUML/metamodel/structural/structural.py
+++ b/besser/BUML/metamodel/structural/structural.py
@@ -505,14 +505,14 @@ class Multiplicity(Element):
 
     Attributes:
         min (int): The minimum multiplicity.
-        max (int | Literal["*"]): The maximum multiplicity. Use "*" for unlimited.
+        max (int): The maximum multiplicity.
         is_derived (bool): Indicates whether the element is derived (False as default).
     """
 
     def __init__(self, min_multiplicity: int, max_multiplicity: int | Literal["*"], is_derived: bool = False, uncertainty: float = 0.0):
         super().__init__(is_derived=is_derived, uncertainty=uncertainty)
         self.min: int = min_multiplicity
-        self.max: int | Literal["*"] = max_multiplicity
+        self.max: int = max_multiplicity
 
     @property
     def min(self) -> int:
@@ -532,14 +532,14 @@ class Multiplicity(Element):
         self.__min = min_multiplicity
 
     @property
-    def max(self) -> int | Literal["*"]:
-        """int | Literal["*"]: Get the maximum multiplicity."""
+    def max(self) -> int:
+        """int: Get the maximum multiplicity."""
         return self.__max
 
     @max.setter
     def max(self, max_multiplicity: int | Literal["*"]):
         """
-        int | Literal["*"]: Set the maximum multiplicity.
+        int: Set the maximum multiplicity.
 
         Raises:
             ValueError: (Invalid max multiplicity) if the maximum multiplicity is less than 0 or

--- a/besser/BUML/metamodel/structural/structural.py
+++ b/besser/BUML/metamodel/structural/structural.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Union, List, TYPE_CHECKING
+from typing import Any, Union, List, TYPE_CHECKING, Literal
 import keyword
 import logging
 import time
@@ -500,19 +500,19 @@ class Multiplicity(Element):
 
     Args:
         min_multiplicity (int): The minimum multiplicity.
-        max_multiplicity (int): The maximum multiplicity. Use "*" for unlimited.
+        max_multiplicity (int | Literal["*"]): The maximum multiplicity. Use "*" for unlimited.
         is_derived (bool): Indicates whether the element is derived (False as default).
 
     Attributes:
         min (int): The minimum multiplicity.
-        max (int): The maximum multiplicity. Use "*" for unlimited.
+        max (int | Literal["*"]): The maximum multiplicity. Use "*" for unlimited.
         is_derived (bool): Indicates whether the element is derived (False as default).
     """
 
-    def __init__(self, min_multiplicity: int, max_multiplicity: int, is_derived: bool = False, uncertainty: float = 0.0):
+    def __init__(self, min_multiplicity: int, max_multiplicity: int | Literal["*"], is_derived: bool = False, uncertainty: float = 0.0):
         super().__init__(is_derived=is_derived, uncertainty=uncertainty)
         self.min: int = min_multiplicity
-        self.max: int = max_multiplicity
+        self.max: int | Literal["*"] = max_multiplicity
 
     @property
     def min(self) -> int:
@@ -532,14 +532,14 @@ class Multiplicity(Element):
         self.__min = min_multiplicity
 
     @property
-    def max(self) -> int:
-        """int: Get the maximum multiplicity."""
+    def max(self) -> int | Literal["*"]:
+        """int | Literal["*"]: Get the maximum multiplicity."""
         return self.__max
 
     @max.setter
-    def max(self, max_multiplicity: int):
+    def max(self, max_multiplicity: int | Literal["*"]):
         """
-        int: Set the maximum multiplicity.
+        int | Literal["*"]: Set the maximum multiplicity.
 
         Raises:
             ValueError: (Invalid max multiplicity) if the maximum multiplicity is less than 0 or
@@ -848,7 +848,7 @@ class Method(TypedElement):
                  pre: list["Constraint"] = None, post: list["Constraint"] = None):
         super().__init__(name, type, timestamp, metadata, visibility, is_derived, uncertainty)
         self.is_abstract: bool = is_abstract
-        self.parameters: list[Parameter] = parameters if parameters is not None else list()
+        self.parameters: list[Parameter] = parameters if parameters is not None else []
         self.owner: Type = owner
         self.code: str = code
         self.state_machine: "StateMachine" = state_machine
@@ -905,7 +905,7 @@ class Method(TypedElement):
 
             self.__parameters = parameters
         else:
-            self.__parameters = list()
+            self.__parameters = []
 
     def add_parameter(self, parameter: Parameter):
         """
@@ -933,7 +933,7 @@ class Method(TypedElement):
             ValueError: if two preconditions have the same name.
         """
         if pre is None:
-            self.__pre = list()
+            self.__pre = []
             return
         names_seen = set()
         duplicates = set()
@@ -959,7 +959,7 @@ class Method(TypedElement):
             ValueError: if two postconditions have the same name.
         """
         if post is None:
-            self.__post = list()
+            self.__post = []
             return
         names_seen = set()
         duplicates = set()

--- a/docs/source/releases/v7.rst
+++ b/docs/source/releases/v7.rst
@@ -4,6 +4,7 @@ Version 7
 .. toctree::
    :maxdepth: 1
 
+   v7/v7.11.1
    v7/v7.11.0
    v7/v7.10.0
    v7/v7.9.1

--- a/docs/source/releases/v7/v7.11.1.rst
+++ b/docs/source/releases/v7/v7.11.1.rst
@@ -1,0 +1,25 @@
+Version 7.11.1
+===============
+
+Patch release: **honest** ``Multiplicity.max`` **typing and idiomatic empty-list
+literals**. A metamodel type-hint and lint cleanup with no behavioural change —
+it only aligns the declared types with existing runtime behaviour.
+
+Highlights
+----------
+
+- **Honest** ``Multiplicity.max`` **input typing**: the ``Multiplicity``
+  constructor and ``max`` setter now declare ``int | Literal["*"]`` instead of
+  plain ``int``. ``"*"`` has always been accepted and normalised to
+  ``UNLIMITED_MAX_MULTIPLICITY`` at runtime, but the old signature claimed
+  ``int``, so callers — and static type checkers — passing ``"*"`` saw a false
+  type error. The getter stays ``int``, since a normalised value is always
+  returned. Docstrings were updated to match.
+- **Idiomatic empty lists**: ``Method`` parameter / precondition / postcondition
+  initialisation uses the ``[]`` literal instead of ``list()`` (SonarQube rule
+  ``python:S7498``).
+
+No runtime behaviour changes, and no metamodel or API contract changes.
+
+Thanks to `@ichxorya <https://github.com/ichxorya>`_ for the contribution
+(`#564 <https://github.com/BESSER-PEARL/BESSER/pull/564>`_).

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = besser
-version = 7.11.0
+version = 7.11.1
 author = Luxembourg Institute of Science and Technology
 description = BESSER
 long_description = file: README.md


### PR DESCRIPTION
## Summary
- **`Multiplicity.max` honest typing** (#564): the constructor and `max` setter now declare `int | Literal["*"]` (the setter already normalizes `"*"` → `UNLIMITED_MAX_MULTIPLICITY`); the getter stays `int`. Fixes a false type error for callers/checkers passing `"*"`.
- **`list()` → `[]`** in `Method` parameter/pre/post init (SonarQube `python:S7498`).
- No runtime behaviour change; no metamodel/API contract change. Thanks @ichxorya (first contribution).

## Test plan
- [x] `structural.py` imports on 3.11 (`int | Literal["*"]` is import-time-evaluated; PEP 604, safe 3.10–3.12)
- [x] `Multiplicity(1, "*").max` → `9999`; `Method()` → empty `[]` lists
- [x] Structural metamodel suite (61) + new label/SVG tests (10) pass
- [x] Docs build: v7.11.1 page renders