### PR TITLE
chore(tooling): add Pyrefly type-check config and bump version to 7.11.2

### DIFF
--- a/docs/source/contributor_guide.rst
+++ b/docs/source/contributor_guide.rst
@@ -217,6 +217,31 @@ We use **Ruff** for linting (run automatically in CI):
 
 Fix lint warnings before opening a PR. CI will fail on lint errors.
 
+Type checking
+~~~~~~~~~~~~~
+
+We use **Pyrefly** for static type checking (it also powers the inline
+diagnostics in editors such as VS Code):
+
+.. code-block:: bash
+
+   pip install pyrefly
+   pyrefly check
+
+Because the repository directory is itself named ``besser`` **and** contains
+the ``besser`` package, Pyrefly would otherwise mis-infer the import root and
+fail to resolve ``besser.*`` imports. The repo root is pinned as a search path
+in ``pyproject.toml`` so imports resolve against the live source regardless of
+how the package is installed:
+
+.. code-block:: toml
+
+   [tool.pyrefly]
+   search-path = ["."]
+
+Keep this section in ``pyproject.toml``; without it the editor reports spurious
+``Cannot find module besser...`` errors on otherwise-valid code.
+
 Working in core packages
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/contributor_guide.rst
+++ b/docs/source/contributor_guide.rst
@@ -217,8 +217,10 @@ We use **Ruff** for linting (run automatically in CI):
 
 Fix lint warnings before opening a PR. CI will fail on lint errors.
 
-Type checking
+Type checking (Optional)
 ~~~~~~~~~~~~~
+
+Note: This is optional for now (as of version 7.11.x) since there are many unresolved type checking warnings and errors (could be true or false positives).
 
 We use **Pyrefly** for static type checking (it also powers the inline
 diagnostics in editors such as VS Code):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ addopts = "--import-mode=importlib"
 
 [tool.pylint.'FORMAT']
 max-line-length = 120
+
+[tool.pyrefly]
+search-path = ["."]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = besser
-version = 7.11.1
+version = 7.11.2
 author = Luxembourg Institute of Science and Technology
 description = BESSER
 long_description = file: README.md


### PR DESCRIPTION
## What & why

The repository directory is itself named `besser` **and** contains the `besser` package. Because of this layout, Pyrefly (static type checker) mis-infers the import root as the repo's parent and reports spurious `Cannot find module besser...` errors on otherwise-valid code (e.g. new subpackages like the in-progress activity metamodel). This is a false positive — `python`/`pytest` resolve the imports fine via CWD; only the static analyzer is misled.

## Changes

- **`pyproject.toml`** — add `[tool.pyrefly] search-path = ["."]` so `besser.*` imports resolve against the live source regardless of how (or whether) the package is installed into the venv.
- **`docs/source/contributor_guide.rst`** — document Pyrefly for type checking alongside the existing Ruff linting section, and explain why the `pyproject.toml` search-path entry must stay. Note that this project has many "type errors" linted by Pyrefly, some could be false positive, some are actually possible bugs/mismatch (i.e. the type signature of a function said "return string" but it actually returns a string and None (nullable return)).
- **`setup.cfg`** — bump `version` to `7.11.2` for the next release (previous release tag: `v7.11.1`).

## Follow-up (separate PRs — not in scope here)
Actually eliminate type errors and note false positives.

Modernize the Python toolchain incrementally:
- Adopt **uv** for environment and dependency management.
- Promote **Pyrefly** type checking to a CI gate.
- Consolidate `setup.cfg` + `requirements.txt` into `pyproject.toml` (retire the legacy files).

(Ruff is already used for linting in CI; this note is about the remaining pieces.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)