### PR TITLE
fix(buml-builder): export all object models in multi-object projects

### DIFF
--- a/besser/utilities/buml_code_builder/domain_model_builder.py
+++ b/besser/utilities/buml_code_builder/domain_model_builder.py
@@ -561,91 +561,150 @@ def domain_model_to_code(
 
         # Generate object model code if provided
         if objectmodel:
-            f.write("\n################\n")
-            f.write("# OBJECT MODEL #\n")
-            f.write("################\n")
-
-            # Write object instances using fluent API
-            for obj in sorted(objectmodel.objects, key=lambda x: x.name_):
-                obj_var_name = f"{obj.name_.lower()}_obj"
-                classifier_var_name = safe_class_name(obj.classifier.name)
-
-                # Start the fluent API call using the proper syntax: Class("name")
-                f.write(f"{obj_var_name} = {classifier_var_name}(\"{_escape_python_string(obj.name_)}\")")
-
-                # Add attributes if the object has slots
-                if obj.slots:
-                    attributes_dict = {}
-                    for slot in obj.slots:
-                        attr_name = slot.attribute.name
-
-                        # Format the value based on type
-                        if isinstance(slot.value.value, str):
-                            value_str = f'"{_escape_python_string(slot.value.value)}"'
-                        elif hasattr(slot.value.value, 'isoformat'):  # datetime objects
-                            value_str = f'datetime.datetime.fromisoformat("{slot.value.value.isoformat()}")'
-                        elif hasattr(slot.value.value, 'owner') and hasattr(slot.value.value.owner, 'name'):
-                            # This is an enumeration literal - generate the proper reference
-                            enum_name = slot.value.value.owner.name
-                            literal_name = slot.value.value.name
-                            value_str = f"{enum_name}.{literal_name}"
-                        else:
-                            value_str = str(slot.value.value)
-
-                        attributes_dict[attr_name] = value_str
-
-                    # Add attributes to the fluent API call
-                    if attributes_dict:
-                        attr_pairs = [f"{k}={v}" for k, v in attributes_dict.items()]
-                        f.write(f".attributes({', '.join(attr_pairs)})")
-
-                # Complete the fluent API call
-                f.write(".build()\n")
-
-            f.write("\n")
-
-            # Add links after objects are created (avoiding forward reference issues)
-            if hasattr(objectmodel, 'links') and objectmodel.links:
-
-                # Group links by (source_obj_var, end_name)
-                grouped_links = {}
-                for link in objectmodel.links:
-                    if len(link.connections) == 2:
-                        end1, end2 = link.connections
-                        obj1_var = f"{end1.object.name_.lower()}_obj"
-                        obj2_var = f"{end2.object.name_.lower()}_obj"
-                        end2_name = end2.association_end.name
-
-                        key = (obj1_var, end2_name)
-                        grouped_links.setdefault(key, set()).add(obj2_var)
-
-                # Write assignments for each group
-                for (obj_var, end_name), targets in grouped_links.items():
-                    if len(targets) == 1:
-                        [single_target] = targets
-                        f.write(f"{obj_var}.{end_name} = {single_target}\n")
-                    else:
-                        target_str = ", ".join(sorted(targets))  # sorted for consistency
-                        f.write(f"{obj_var}.{end_name} = {{{target_str}}}\n")
-
-                f.write("\n")
-
-            # Create the object model instance
-            f.write("# Object Model instance\n")
-            objects_str = ", ".join([f"{obj.name_.lower()}_obj" for obj in sorted(objectmodel.objects, key=lambda x: x.name_)])
-            f.write(f"{object_model_var_name}: ObjectModel = ObjectModel(\n")
-            f.write(f"    name=\"{_escape_python_string(objectmodel.name)}\",\n")
-            f.write(f"    objects={{{objects_str}}}")
-
-            # Add metadata if it exists
-            if hasattr(objectmodel, 'metadata') and objectmodel.metadata:
-                if objectmodel.metadata.description:
-                    f.write(",\n")
-                    f.write(f'    metadata=Metadata(description="{_escape_python_string(objectmodel.metadata.description)}")\n')
-                else:
-                    f.write("\n")
-            else:
-                f.write("\n")
-            f.write(")\n")
+            _write_object_model_section(f, objectmodel, object_model_var_name)
 
     print(f"BUML model saved to {file_path}")
+
+
+def _write_object_model_section(f, objectmodel: ObjectModel, object_model_var_name: str = "object_model"):
+    """Write the object-model portion of the builder output to an open file handle.
+
+    Emits the ``# OBJECT MODEL #`` banner, the object instances (via the fluent
+    API), the links between objects, and the final ``ObjectModel(...)`` binding.
+    This section assumes the referenced domain classes and enumerations are
+    already defined earlier in the same (concatenated) file.
+
+    Parameters:
+        f: An already-open, writable file handle.
+        objectmodel (ObjectModel): The B-UML object model to serialize.
+        object_model_var_name (str): Name of the ObjectModel variable to bind.
+    """
+    object_model_var_name = object_model_var_name or "object_model"
+
+    f.write("\n################\n")
+    f.write("# OBJECT MODEL #\n")
+    f.write("################\n")
+
+    # Write object instances using fluent API
+    for obj in sorted(objectmodel.objects, key=lambda x: x.name_):
+        obj_var_name = f"{obj.name_.lower()}_obj"
+        classifier_var_name = safe_class_name(obj.classifier.name)
+
+        # Start the fluent API call using the proper syntax: Class("name")
+        f.write(f"{obj_var_name} = {classifier_var_name}(\"{_escape_python_string(obj.name_)}\")")
+
+        # Add attributes if the object has slots
+        if obj.slots:
+            attributes_dict = {}
+            for slot in obj.slots:
+                attr_name = slot.attribute.name
+
+                # Format the value based on type
+                if isinstance(slot.value.value, str):
+                    value_str = f'"{_escape_python_string(slot.value.value)}"'
+                elif hasattr(slot.value.value, 'isoformat'):  # datetime objects
+                    value_str = f'datetime.datetime.fromisoformat("{slot.value.value.isoformat()}")'
+                elif hasattr(slot.value.value, 'owner') and hasattr(slot.value.value.owner, 'name'):
+                    # This is an enumeration literal - generate the proper reference
+                    enum_name = slot.value.value.owner.name
+                    literal_name = slot.value.value.name
+                    value_str = f"{enum_name}.{literal_name}"
+                else:
+                    value_str = str(slot.value.value)
+
+                attributes_dict[attr_name] = value_str
+
+            # Add attributes to the fluent API call
+            if attributes_dict:
+                attr_pairs = [f"{k}={v}" for k, v in attributes_dict.items()]
+                f.write(f".attributes({', '.join(attr_pairs)})")
+
+        # Complete the fluent API call
+        f.write(".build()\n")
+
+    f.write("\n")
+
+    # Add links after objects are created (avoiding forward reference issues)
+    if hasattr(objectmodel, 'links') and objectmodel.links:
+
+        # Group links by (source_obj_var, end_name)
+        grouped_links = {}
+        for link in objectmodel.links:
+            if len(link.connections) == 2:
+                end1, end2 = link.connections
+                obj1_var = f"{end1.object.name_.lower()}_obj"
+                obj2_var = f"{end2.object.name_.lower()}_obj"
+                end2_name = end2.association_end.name
+
+                key = (obj1_var, end2_name)
+                grouped_links.setdefault(key, set()).add(obj2_var)
+
+        # Write assignments for each group
+        for (obj_var, end_name), targets in grouped_links.items():
+            if len(targets) == 1:
+                [single_target] = targets
+                f.write(f"{obj_var}.{end_name} = {single_target}\n")
+            else:
+                target_str = ", ".join(sorted(targets))  # sorted for consistency
+                f.write(f"{obj_var}.{end_name} = {{{target_str}}}\n")
+
+        f.write("\n")
+
+    # Create the object model instance
+    f.write("# Object Model instance\n")
+    objects_str = ", ".join([f"{obj.name_.lower()}_obj" for obj in sorted(objectmodel.objects, key=lambda x: x.name_)])
+    f.write(f"{object_model_var_name}: ObjectModel = ObjectModel(\n")
+    f.write(f"    name=\"{_escape_python_string(objectmodel.name)}\",\n")
+    f.write(f"    objects={{{objects_str}}}")
+
+    # Add metadata if it exists
+    if hasattr(objectmodel, 'metadata') and objectmodel.metadata:
+        if objectmodel.metadata.description:
+            f.write(",\n")
+            f.write(f'    metadata=Metadata(description="{_escape_python_string(objectmodel.metadata.description)}")\n')
+        else:
+            f.write("\n")
+    else:
+        f.write("\n")
+    f.write(")\n")
+
+
+def object_model_to_code(
+    objectmodel: ObjectModel,
+    file_path: str,
+    object_model_var_name: str = "object_model",
+):
+    """Generate Python code for a standalone B-UML object model.
+
+    The generated file is self-contained apart from the domain classes and
+    enumerations it references: it only imports ``ObjectModel`` and ``datetime``
+    and then emits the object-model section. It is meant to be concatenated
+    *after* the corresponding domain model (whose classes/enums it references)
+    so the combined file executes cleanly.
+
+    Parameters:
+        objectmodel (ObjectModel): The B-UML object model to serialize.
+        file_path (str): The path where the generated code will be saved.
+        object_model_var_name (str): Name of the ObjectModel variable in the
+            generated code. Defaults to "object_model".
+
+    Outputs:
+        - A Python file containing the object-model instances and their links.
+    """
+    output_dir = os.path.dirname(file_path)
+    if output_dir and not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    if not file_path.endswith('.py'):
+        file_path += '.py'
+
+    object_model_var_name = object_model_var_name or "object_model"
+
+    with open(file_path, 'w', encoding='utf-8') as f:
+        # Object-model imports. The domain classes/enums are assumed to be
+        # defined earlier in the concatenated output.
+        f.write("from besser.BUML.metamodel.object import ObjectModel\n")
+        f.write("import datetime\n")
+
+        _write_object_model_section(f, objectmodel, object_model_var_name)
+
+    print(f"BUML object model saved to {file_path}")

--- a/besser/utilities/buml_code_builder/project_builder.py
+++ b/besser/utilities/buml_code_builder/project_builder.py
@@ -16,6 +16,7 @@ from besser.BUML.metamodel.state_machine.state_machine import StateMachine
 from besser.utilities.buml_code_builder.common import _comment_safe, _escape_python_string
 from besser.utilities.buml_code_builder.domain_model_builder import (
     domain_model_to_code,
+    object_model_to_code,
     contains_user_class,
     is_user_object_model,
 )
@@ -222,28 +223,28 @@ def project_to_code(project: Project, file_path: str, sm: str = ""):
                     _write_temp_to_output(tmp_path, f, section_header=section)
                     model_vars.append(var_name)
 
-            # Standalone object models (when not paired 1:1 with domain models)
+            # Standalone object models (when not paired 1:1 with domain models).
+            # The domain model these objects reference is already written above
+            # (in the domain_pairs loop). Since the whole project is concatenated
+            # into ONE file, each object-only section can reference the class and
+            # enum variables defined earlier, so we emit just the object portion.
             if not (len(domain_models) == 1 and len(object_models) == 1):
                 n_standalone_obj = len(object_models)
                 for idx, om in enumerate(object_models, start=1):
                     obj_var_name = _suffixed_name("object_model", idx, n_standalone_obj)
-                    # Object models need a domain_model to reference; pass None and
-                    # generate just the object portion via domain_model_to_code.
-                    # For standalone objects without a paired domain model we find
-                    # the domain_model attribute on the ObjectModel itself.
-                    paired_dm = getattr(om, "domain_model", None)
-                    if paired_dm:
-                        dm_var = _suffixed_name("object_domain_model", idx, n_standalone_obj)
-                        tmp_path = os.path.join(temp_dir, f"object_model_{idx}.py")
-                        domain_model_to_code(
-                            model=paired_dm,
-                            file_path=tmp_path,
-                            objectmodel=om,
-                            model_var_name=dm_var,
-                            object_model_var_name=obj_var_name,
-                        )
-                        _write_temp_to_output(tmp_path, f)
-                        model_vars.append(obj_var_name)
+
+                    section = ""
+                    if n_standalone_obj > 1:
+                        section = f"# OBJECT MODEL {idx} #\n\n"
+
+                    tmp_path = os.path.join(temp_dir, f"object_model_{idx}.py")
+                    object_model_to_code(
+                        objectmodel=om,
+                        file_path=tmp_path,
+                        object_model_var_name=obj_var_name,
+                    )
+                    _write_temp_to_output(tmp_path, f, section_header=section)
+                    model_vars.append(obj_var_name)
 
             # ---------------------------------------------------------- #
             # USER DOMAIN MODELS                                         #

--- a/tests/utilities/buml_code_builder/test_builders.py
+++ b/tests/utilities/buml_code_builder/test_builders.py
@@ -1018,6 +1018,9 @@ class TestGUIModelBuilder:
 # project_builder.py
 # ---------------------------------------------------------------------------
 from besser.BUML.metamodel.project import Project
+from besser.BUML.metamodel.object import (
+    Object, AttributeLink, DataValue, ObjectModel,
+)
 from besser.utilities.buml_code_builder.project_builder import project_to_code
 
 
@@ -1199,6 +1202,74 @@ class TestProjectBuilder:
             code = f.read()
 
         assert "Test project" in code
+
+    def test_project_multiple_object_models_are_exported(self, tmp_path):
+        """Regression for WME #161.
+
+        A project with ONE domain model and MULTIPLE object models must export
+        every object model to the generated BUML Python file. Previously the
+        "standalone object models" loop gated on a non-existent
+        ``ObjectModel.domain_model`` attribute, so all object models were
+        silently dropped (JSON export was fine; only the .py export lost them).
+        """
+        # --- Domain model: Library + Book -------------------------------
+        title = Property(name="title", type=StringType)
+        pages = Property(name="pages", type=IntegerType)
+        book = Class(name="Book", attributes={title, pages})
+        lib_name = Property(name="name", type=StringType)
+        library = Class(name="Library", attributes={lib_name})
+        dm = DomainModel(name="LibraryModel", types={library, book}, associations=set())
+
+        # --- Two distinct object models over that same domain -----------
+        book_one = Object(
+            name="BookOne",
+            classifier=book,
+            slots=[
+                AttributeLink(attribute=title, value=DataValue(classifier=StringType, value="Book One")),
+                AttributeLink(attribute=pages, value=DataValue(classifier=IntegerType, value=100)),
+            ],
+        )
+        om1 = ObjectModel(name="ObjectModelOne", objects={book_one})
+
+        book_two = Object(
+            name="BookTwo",
+            classifier=book,
+            slots=[
+                AttributeLink(attribute=title, value=DataValue(classifier=StringType, value="Book Two")),
+                AttributeLink(attribute=pages, value=DataValue(classifier=IntegerType, value=200)),
+            ],
+        )
+        om2 = ObjectModel(name="ObjectModelTwo", objects={book_two})
+
+        meta = Metadata(description="Multi object-model project")
+        project = Project(
+            name="MultiObjectProject",
+            models=[dm, om1, om2],
+            owner="tester",
+            metadata=meta,
+        )
+
+        file_path = str(tmp_path / "multi_object.py")
+        project_to_code(project, file_path)
+
+        with open(file_path, "r", encoding="utf-8") as f:
+            code = f.read()
+
+        # Both object models must be emitted as ObjectModel(...) definitions...
+        assert code.count("ObjectModel(") == 2
+        # ...and both must be referenced in the final Project(models=[...]) list.
+        assert "object_model_1" in code
+        assert "object_model_2" in code
+
+        # The generated file must be valid, runnable Python that reconstructs a
+        # project holding BOTH object models (i.e. nothing was dropped).
+        compile(code, file_path, "exec")
+        namespace: dict = {}
+        exec(code, namespace)
+        recreated = namespace["project"]
+        assert isinstance(recreated, Project)
+        object_models = [m for m in recreated.models if isinstance(m, ObjectModel)]
+        assert len(object_models) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why
Fixes **BESSER-Web-Modeling-Editor#161**: exporting a project with a class model + **multiple object models** to a B-UML `.py` file dropped every object model (JSON export was unaffected).

## Root cause
`project_builder.py`'s standalone-object loop only wrote a model when `getattr(om, "domain_model", None)` was truthy — but `ObjectModel` has no `domain_model` attribute, so the branch never ran and the models were never added to `Project(models=[...])` either. Single object model worked only via a separate 1:1 special case.

## Fix
- Extract the object-writing block from `domain_model_to_code` into a reusable `object_model_to_code()` (`domain_model_to_code` output is byte-identical).
- Emit **every** standalone object model (object-only, referencing the domain classes already written above in the concatenated file).

## Tests
- New `test_project_multiple_object_models_are_exported`: 1 domain + 2 object models → asserts both survive export and the generated file `exec()`s back to 2 ObjectModels. Fails without the fix (`0 == 2`), passes with it.
- Broader sweep (builder + object metamodel + converter roundtrip): **236 passed**, no regressions.