### PR TITLE
refactor(wme-importer): AST-restricted B-UML import — banner-free sectioning + exec() removal (#560)

### DIFF
--- a/besser/utilities/buml_code_builder/domain_model_builder.py
+++ b/besser/utilities/buml_code_builder/domain_model_builder.py
@@ -534,7 +534,9 @@ def domain_model_to_code(
         enum_names = ', '.join(safe_class_name(enum.name) for enum in sort(model.get_enumerations()))
         types_str = (f"{class_names}, {enum_names}" if class_names and enum_names else
                     class_names or enum_names)
-        f.write(f"    types={{{types_str}}},\n")
+        # Empty collections must be an empty set(), not {} (which is a dict and
+        # breaks the metamodel's set-typed setters on re-import).
+        f.write(f"    types={{{types_str}}},\n" if types_str else "    types=set(),\n")
 
         # Include both regular associations and those used in association classes
         all_assoc_names = ', '.join([assoc.name for assoc in regular_associations] +
@@ -542,7 +544,7 @@ def domain_model_to_code(
         if all_assoc_names:
             f.write(f"    associations={{{all_assoc_names}}},\n")
         else:
-            f.write("    associations={},\n")
+            f.write("    associations=set(),\n")
 
         if hasattr(model, 'constraints') and model.constraints:
             constraints_str = ', '.join(c.name.replace("-", "_") for c in sort(model.constraints))
@@ -550,7 +552,7 @@ def domain_model_to_code(
         if model.generalizations:
             f.write(f"    generalizations={{{', '.join(f'gen_{gen.specific.name}_{gen.general.name}' for gen in sort(model.generalizations))}}},\n")
         else:
-            f.write("    generalizations={},\n")
+            f.write("    generalizations=set(),\n")
 
         # Add metadata if it exists
         if domain_metadata_var:

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/_safe_eval.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/_safe_eval.py
@@ -1,0 +1,383 @@
+"""Shared safe AST evaluator for the BUML -> JSON importers.
+
+The per-diagram converters in this package reconstruct a BUML model object from
+an *uploaded* ``.py`` source string, then walk that object into the editor's
+JSON. Historically the reconstruction step used ``exec()`` inside a namespace
+with a trimmed ``__builtins__`` dict. That sandbox is escapable — the classic
+``().__class__.__bases__[0].__subclasses__()`` attribute-traversal trick needs
+no builtins at all — so ``exec()`` on untrusted input is a remote-code-execution
+risk regardless of how the globals are restricted.
+
+``safe_exec`` replaces that ``exec()`` with a whitelist AST interpreter. It
+``ast.parse``s the code and evaluates only a narrow, explicitly-enumerated set
+of node types, seeded from the caller's ``allowed`` mapping (the same dict of
+whitelisted BUML constructors each converter already builds). The resulting
+namespace is returned so the existing JSON walkers and ``_find_*_model`` lookups
+keep working unchanged.
+
+Security boundary
+-----------------
+ALLOWED:
+  * literals: str / int / float / bool / None and list / tuple / set / dict
+    literals of allowed expressions;
+  * ``Name`` lookups resolving to a prior assignment or to a whitelisted name;
+  * calls to whitelisted callables by name (the BUML constructors + a handful
+    of benign builtins the caller seeds, e.g. ``set``/``list``);
+  * method calls on values already produced in the namespace — the fluent
+    builder chains (``bpmn_model.add_process(...)``, ``qc.add_operation(...)``,
+    ``gate.control_qubits.append(...)``);
+  * attribute *reads* for enum-literal access (``TaskType.SEND``,
+    ``ControlState.CONTROL``) and data attributes of namespace objects;
+  * simple name / attribute assignment (``x = ...``, ``x.layout = {...}``),
+    annotated assignment (``x: T = ...``);
+  * ``if``/``try`` control flow needed to reproduce import semantics
+    (``if __name__ == "__main__":`` guards, the builder's
+    ``try: m.state_machine = sm  except NameError: pass`` optional wiring).
+
+BLOCKED (raises ``UnsafeConstruct``, which no in-code ``try/except`` can swallow):
+  * any attribute whose name starts with ``__`` — read, write, or call. This is
+    the single control that defeats every known sandbox escape, all of which
+    route through ``__class__`` / ``__globals__`` / ``__subclasses__`` / ``__bases__``
+    / ``__mro__`` / ``__builtins__`` / ``__import__`` etc.;
+  * calls whose target is neither a whitelisted name nor a method on a namespace
+    value (so ``__import__(...)``, ``getattr(...)``, ``eval(...)`` all fail —
+    those names are not in the whitelist);
+  * method calls on ``str`` / ``bytes`` receivers (blocks ``"{0.__class__}".format``
+    style attribute-leak gadgets that hide the dunder inside a string literal);
+  * ``import`` (silently skipped — the names are already whitelisted), ``lambda``,
+    comprehensions, generator expressions, f-strings, subscripting, ``*``/``**``
+    unpacking, walrus, binary operators, and every statement type not listed
+    above.
+"""
+
+import ast
+from typing import Any, Dict, List
+
+
+class UnsafeConstruct(ValueError):
+    """Raised when the uploaded code contains a construct the evaluator refuses
+    to run.
+
+    Subclasses ``ValueError`` so the converters' existing ``except (ValueError,
+    ...)`` wrappers map it to a 400-style failure. It is deliberately *never*
+    caught by the evaluator's own ``try``/``except`` handling — a security
+    refusal aborts the whole parse rather than being swallowed by an attacker's
+    ``try: <payload> except Exception: pass``.
+    """
+
+
+# Builtin exceptions an uploaded file's ``try``/``except`` may legitimately
+# catch. The domain-model builder emits, for methods wired to a state machine
+# or quantum circuit that only exist in a *combined* project file:
+#
+#     try:
+#         SomeClass_m_method.state_machine = sm
+#     except NameError:
+#         pass
+#
+# so that a class-diagram-only import (where ``sm`` is undefined) skips the
+# wiring instead of crashing. We reproduce that control flow but keep the set
+# of catchable exception types tiny and explicit.
+_CATCHABLE_EXCEPTIONS: Dict[str, type] = {
+    "NameError": NameError,
+    "AttributeError": AttributeError,
+    "KeyError": KeyError,
+    "TypeError": TypeError,
+    "ValueError": ValueError,
+    "Exception": Exception,
+}
+
+_COMPARE_OPS = {
+    ast.Eq: lambda a, b: a == b,
+    ast.NotEq: lambda a, b: a != b,
+    ast.Lt: lambda a, b: a < b,
+    ast.LtE: lambda a, b: a <= b,
+    ast.Gt: lambda a, b: a > b,
+    ast.GtE: lambda a, b: a >= b,
+    ast.Is: lambda a, b: a is b,
+    ast.IsNot: lambda a, b: a is not b,
+    ast.In: lambda a, b: a in b,
+    ast.NotIn: lambda a, b: a not in b,
+}
+
+
+def _guard_attr(name: str) -> None:
+    """Reject any dunder attribute access (read / write / method call)."""
+    if name.startswith("__"):
+        raise UnsafeConstruct(
+            f"Access to dunder attribute {name!r} is not allowed"
+        )
+
+
+class _SafeEvaluator:
+    """Whitelist AST interpreter. One instance per ``safe_exec`` call."""
+
+    def __init__(self, resolvable: Dict[str, Any]):
+        # ``resolvable`` is the flattened whitelist: seeded builtins + the
+        # caller's constructor names. Name lookups fall back to it after the
+        # per-run assignment namespace ``env``.
+        self._resolvable = resolvable
+        self.env: Dict[str, Any] = {}
+
+    # ------------------------------------------------------------------ #
+    # Statement execution
+    # ------------------------------------------------------------------ #
+    def run(self, code: str) -> Dict[str, Any]:
+        try:
+            tree = ast.parse(code, mode="exec")
+        except SyntaxError as exc:
+            raise ValueError(f"Failed to parse BUML content: {exc}") from exc
+        self._run_body(tree.body)
+        return self.env
+
+    def _run_body(self, body: List[ast.stmt]) -> None:
+        for stmt in body:
+            self._run_stmt(stmt)
+
+    def _run_stmt(self, stmt: ast.stmt) -> None:
+        if isinstance(stmt, (ast.Import, ast.ImportFrom)):
+            # All metamodel names are already whitelisted; imports are noise.
+            return
+        if isinstance(stmt, ast.Assign):
+            value = self._eval(stmt.value)
+            for target in stmt.targets:
+                self._assign(target, value)
+            return
+        if isinstance(stmt, ast.AnnAssign):
+            # ``x: T = value`` — the annotation ``T`` is a type hint only, never
+            # evaluated. Bare ``x: T`` (value is None) binds nothing.
+            if stmt.value is None:
+                return
+            value = self._eval(stmt.value)
+            self._assign(stmt.target, value)
+            return
+        if isinstance(stmt, ast.Expr):
+            # A bare expression statement. Constants (docstrings / stray
+            # literals) are ignored; everything else is evaluated for its side
+            # effect (the fluent ``obj.add_*(...)`` builder calls).
+            if isinstance(stmt.value, ast.Constant):
+                return
+            self._eval(stmt.value)
+            return
+        if isinstance(stmt, ast.If):
+            if self._eval(stmt.test):
+                self._run_body(stmt.body)
+            else:
+                self._run_body(stmt.orelse)
+            return
+        if isinstance(stmt, ast.Try):
+            self._run_try(stmt)
+            return
+        if isinstance(stmt, ast.Pass):
+            return
+        raise UnsafeConstruct(
+            f"Disallowed statement: {type(stmt).__name__}"
+        )
+
+    def _assign(self, target: ast.AST, value: Any) -> None:
+        if isinstance(target, ast.Name):
+            self.env[target.id] = value
+            return
+        if isinstance(target, ast.Attribute):
+            _guard_attr(target.attr)
+            obj = self._eval(target.value)
+            if isinstance(obj, (str, bytes, bytearray)):
+                raise UnsafeConstruct(
+                    "Attribute assignment on str/bytes values is not allowed"
+                )
+            setattr(obj, target.attr, value)
+            return
+        raise UnsafeConstruct(
+            f"Only simple name / attribute assignment targets are allowed; "
+            f"got {type(target).__name__}"
+        )
+
+    def _run_try(self, stmt: ast.Try) -> None:
+        try:
+            self._run_body(stmt.body)
+        except UnsafeConstruct:
+            # A security refusal is never catchable by uploaded code.
+            raise
+        except Exception as exc:  # noqa: BLE001 - reproducing Python semantics
+            for handler in stmt.handlers:
+                if self._handler_matches(handler, exc):
+                    if handler.name:
+                        self.env[handler.name] = exc
+                    self._run_body(handler.body)
+                    break
+            else:
+                raise
+        else:
+            self._run_body(stmt.orelse)
+        finally:
+            self._run_body(stmt.finalbody)
+
+    def _handler_matches(self, handler: ast.ExceptHandler, exc: Exception) -> bool:
+        if handler.type is None:
+            return True  # bare ``except:`` (UnsafeConstruct already re-raised)
+        types = handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+        matched: List[type] = []
+        for node in types:
+            if not isinstance(node, ast.Name) or node.id not in _CATCHABLE_EXCEPTIONS:
+                raise UnsafeConstruct(
+                    "Only a small set of builtin exceptions "
+                    f"({', '.join(sorted(_CATCHABLE_EXCEPTIONS))}) may be caught"
+                )
+            matched.append(_CATCHABLE_EXCEPTIONS[node.id])
+        return isinstance(exc, tuple(matched))
+
+    # ------------------------------------------------------------------ #
+    # Expression evaluation
+    # ------------------------------------------------------------------ #
+    def _eval(self, node: ast.AST) -> Any:
+        if isinstance(node, ast.Constant):
+            return node.value
+        if isinstance(node, ast.Name):
+            if node.id in self.env:
+                return self.env[node.id]
+            if node.id in self._resolvable:
+                return self._resolvable[node.id]
+            # Faithful to Python import semantics: an undefined name raises
+            # NameError (catchable by an ``except NameError`` in the source),
+            # NOT UnsafeConstruct.
+            raise NameError(f"name {node.id!r} is not defined")
+        if isinstance(node, (ast.List, ast.Tuple)):
+            return [self._eval(e) for e in self._elts(node.elts)]
+        if isinstance(node, ast.Set):
+            return {self._eval(e) for e in self._elts(node.elts)}
+        if isinstance(node, ast.Dict):
+            for key in node.keys:
+                if key is None:
+                    raise UnsafeConstruct("Dict unpacking (**expr) is not allowed")
+            return {self._eval(k): self._eval(v)
+                    for k, v in zip(node.keys, node.values)}
+        if isinstance(node, ast.UnaryOp):
+            operand = self._eval(node.operand)
+            if isinstance(node.op, ast.USub):
+                return -operand
+            if isinstance(node.op, ast.UAdd):
+                return +operand
+            raise UnsafeConstruct(
+                f"Disallowed unary operator: {type(node.op).__name__}"
+            )
+        if isinstance(node, ast.Attribute):
+            _guard_attr(node.attr)
+            return getattr(self._eval(node.value), node.attr)
+        if isinstance(node, ast.Compare):
+            return self._eval_compare(node)
+        if isinstance(node, ast.BoolOp):
+            return self._eval_boolop(node)
+        if isinstance(node, ast.Call):
+            return self._eval_call(node)
+        raise UnsafeConstruct(
+            f"Disallowed expression: {type(node).__name__}"
+        )
+
+    @staticmethod
+    def _elts(elts: List[ast.expr]) -> List[ast.expr]:
+        for e in elts:
+            if isinstance(e, ast.Starred):
+                raise UnsafeConstruct("Iterable unpacking (*expr) is not allowed")
+        return elts
+
+    def _eval_compare(self, node: ast.Compare) -> Any:
+        left = self._eval(node.left)
+        for op, right_node in zip(node.ops, node.comparators):
+            impl = _COMPARE_OPS.get(type(op))
+            if impl is None:
+                raise UnsafeConstruct(
+                    f"Disallowed comparison operator: {type(op).__name__}"
+                )
+            right = self._eval(right_node)
+            if not impl(left, right):
+                return False
+            left = right
+        return True
+
+    def _eval_boolop(self, node: ast.BoolOp) -> Any:
+        if isinstance(node.op, ast.And):
+            result: Any = True
+            for value in node.values:
+                result = self._eval(value)
+                if not result:
+                    return result
+            return result
+        if isinstance(node.op, ast.Or):
+            result = False
+            for value in node.values:
+                result = self._eval(value)
+                if result:
+                    return result
+            return result
+        raise UnsafeConstruct(
+            f"Disallowed boolean operator: {type(node.op).__name__}"
+        )
+
+    def _eval_call(self, node: ast.Call) -> Any:
+        args = [self._eval(a) for a in self._elts(node.args)]
+        kwargs = {}
+        for kw in node.keywords:
+            if kw.arg is None:
+                raise UnsafeConstruct("Keyword unpacking (**kwargs) is not allowed")
+            kwargs[kw.arg] = self._eval(kw.value)
+
+        func = node.func
+        if isinstance(func, ast.Name):
+            # Only whitelisted callables may be invoked by bare name. A name
+            # bound only in ``env`` (a reconstructed model object) is data, not
+            # a constructor, and must not be called.
+            if func.id not in self._resolvable:
+                raise UnsafeConstruct(
+                    f"Call to non-whitelisted name {func.id!r}"
+                )
+            target = self._resolvable[func.id]
+            if not callable(target):
+                raise UnsafeConstruct(
+                    f"Whitelisted name {func.id!r} is not callable"
+                )
+            return target(*args, **kwargs)
+
+        if isinstance(func, ast.Attribute):
+            # Method call on a namespace value — the fluent builder chains.
+            _guard_attr(func.attr)
+            receiver = self._eval(func.value)
+            if isinstance(receiver, (str, bytes, bytearray)):
+                raise UnsafeConstruct(
+                    "Method calls on str/bytes values are not allowed"
+                )
+            method = getattr(receiver, func.attr)
+            return method(*args, **kwargs)
+
+        raise UnsafeConstruct(
+            "Only calls to whitelisted names or methods on namespace values "
+            "are allowed"
+        )
+
+
+def safe_exec(code: str, allowed: Dict[str, Any]) -> Dict[str, Any]:
+    """Safely evaluate ``code`` and return its resulting top-level namespace.
+
+    Drop-in replacement for ``exec(code, allowed, local_vars)`` in the
+    BUML -> JSON converters: pass the same ``safe_globals`` dict each converter
+    already builds, and use the returned dict exactly like the old
+    ``local_vars``.
+
+    ``allowed`` may carry the ``exec``-style special keys ``__builtins__`` (a
+    dict of benign builtins) and ``__name__`` (a sentinel string): the builtins
+    are flattened into the resolvable namespace so bare ``set(...)`` / ``list(...)``
+    calls keep working, and ``__name__`` stays resolvable so
+    ``if __name__ == "__main__":`` guards evaluate to False (the guarded block is
+    skipped, matching import semantics).
+
+    Raises ``UnsafeConstruct`` (a ``ValueError``) on any disallowed construct,
+    or ``NameError`` for an undefined name — never executes it.
+    """
+    resolvable: Dict[str, Any] = {}
+    builtins = allowed.get("__builtins__")
+    if isinstance(builtins, dict):
+        resolvable.update(builtins)
+    for key, value in allowed.items():
+        if key == "__builtins__":
+            continue
+        resolvable[key] = value
+    return _SafeEvaluator(resolvable).run(code)

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/bpmn_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/bpmn_diagram_converter.py
@@ -66,6 +66,9 @@ from besser.utilities.web_modeling_editor.backend.services.converters.bpmn_event
     serialise_event_type,
 )
 from besser.utilities.web_modeling_editor.backend.services.exceptions import ConversionError
+from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json._safe_eval import (
+    safe_exec,
+)
 from besser.utilities.web_modeling_editor.backend.services.utils import (
     calculate_connection_points,
     calculate_path_points,
@@ -549,9 +552,11 @@ def bpmn_buml_to_json(content: str) -> dict:
         cleaned_lines.append(line)
     cleaned_content = "\n".join(cleaned_lines)
 
-    local_vars: dict = {}
     try:
-        exec(cleaned_content, safe_globals, local_vars)
+        # AST whitelist evaluation instead of exec() — the uploaded BPMN model
+        # source is untrusted (see _safe_eval). UnsafeConstruct subclasses
+        # ValueError, so a security refusal is reported as a ConversionError too.
+        local_vars: dict = safe_exec(cleaned_content, safe_globals)
     except (SyntaxError, NameError, TypeError, ValueError) as exc:
         raise ConversionError(f"BPMN BUML file failed to execute: {exc}") from exc
 

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/class_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/class_diagram_converter.py
@@ -27,6 +27,9 @@ from besser.utilities.web_modeling_editor.backend.services.utils import (
     determine_connection_direction, calculate_connection_points,
     calculate_path_points, calculate_relationship_bounds
 )
+from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json._safe_eval import (
+    safe_exec,
+)
 
 
 def _format_multiplicity_label(multiplicity):
@@ -138,9 +141,11 @@ def parse_buml_content(content: str) -> DomainModel:
             cleaned_lines.append(line)
         cleaned_content = "\n".join(cleaned_lines)
 
-        # Execute the cleaned B-UML content
-        local_vars = {}
-        exec(cleaned_content, safe_globals, local_vars)
+        # Safely reconstruct the B-UML content. The uploaded file is untrusted,
+        # so it is evaluated by an AST whitelist interpreter (see _safe_eval),
+        # never exec()'d — exec on user input is an RCE vector even with a
+        # restricted __builtins__.
+        local_vars = safe_exec(cleaned_content, safe_globals)
 
         domain_name = "Imported_Domain_Model"
         for var_name, var_value in local_vars.items():

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/gui_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/gui_diagram_converter.py
@@ -57,6 +57,10 @@ from besser.BUML.metamodel.gui.events_actions import (
 )
 from besser.BUML.metamodel.gui.graphical_ui import InputFieldType
 from besser.BUML.metamodel.gui.style import Alignment, Color, Layout, LayoutType, Position, PositionType, Size, Styling, UnitSize
+from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json._safe_eval import (
+    safe_exec,
+    UnsafeConstruct,
+)
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -196,9 +200,14 @@ def _parse_gui_model(content: str) -> Optional[GUIModel]:
         cleaned_lines.append(line)
     cleaned_content = "\n".join(cleaned_lines)
 
-    local_vars: Dict[str, Any] = {}
     try:
-        exec(cleaned_content, safe_globals, local_vars)
+        # AST whitelist evaluation instead of exec() — the uploaded GUI model
+        # source is untrusted (see _safe_eval).
+        local_vars: Dict[str, Any] = safe_exec(cleaned_content, safe_globals)
+    except UnsafeConstruct:
+        # A security refusal must surface as-is, not be reframed as a generic
+        # execution failure.
+        raise
     except Exception as exc:
         raise ValueError(f"Failed to execute GUI BUML content: {exc}") from exc
     gui_candidates = [

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/project_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/project_converter.py
@@ -4,11 +4,12 @@ Handles project structure processing and diagram coordination.
 Supports both single-diagram and multi-diagram per type formats.
 """
 
+import ast
 import logging
 import uuid
 import re
 from datetime import datetime, timezone
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Optional, Tuple
 
 from .class_diagram_converter import parse_buml_content, class_buml_to_json
 from .state_machine_converter import state_machine_to_json
@@ -21,23 +22,24 @@ from .bpmn_diagram_converter import bpmn_buml_to_json
 
 logger = logging.getLogger(__name__)
 
-# Maps model variable name prefixes to (section header keyword, diagram type, default title)
-SECTION_CONFIG = {
-    'domain_model': ('STRUCTURAL', 'ClassDiagram', 'Class Diagram'),
-    'object_model': ('OBJECT', 'ObjectDiagram', 'Object Diagram'),
-    'agent': ('AGENT', 'AgentDiagram', 'Agent Diagram'),
-    'gui_model': ('GUI', 'GUINoCodeDiagram', 'GUI Diagram'),
-    'quantum_model': ('QUANTUM', 'QuantumCircuitDiagram', 'Quantum Circuit Diagram'),
-    'sm': ('STATE MACHINE', 'StateMachineDiagram', 'State Machine Diagram'),
-    'nn_model': ('NN', 'NNDiagram', 'NN Diagram'),
-    'bpmn_model': ('BPMN', 'BPMNDiagram', 'BPMN Diagram'),
+# Maps the *constructor* used in a model's assignment (e.g. ``ObjectModel`` in
+# ``object_model_1 = ObjectModel(...)``) to (diagram type, default title).
+#
+# This is the authoritative source of a model's diagram type: it is derived from
+# the actual Python assignment recovered from the AST, NOT from a comment banner.
+# A stray/duplicate/reformatted ``# ... MODEL #`` banner therefore cannot change
+# the diagram set — only the ``Project(models=[...])`` list and the constructors
+# of the referenced variables can.
+CONSTRUCTOR_TO_DIAGRAM: Dict[str, Tuple[str, str]] = {
+    'DomainModel': ('ClassDiagram', 'Class Diagram'),
+    'ObjectModel': ('ObjectDiagram', 'Object Diagram'),
+    'Agent': ('AgentDiagram', 'Agent Diagram'),
+    'GUIModel': ('GUINoCodeDiagram', 'GUI Diagram'),
+    'QuantumCircuit': ('QuantumCircuitDiagram', 'Quantum Circuit Diagram'),
+    'StateMachine': ('StateMachineDiagram', 'State Machine Diagram'),
+    'NN': ('NNDiagram', 'NN Diagram'),
+    'BPMNModel': ('BPMNDiagram', 'BPMN Diagram'),
 }
-
-# All known section header keywords used as boundary markers
-ALL_SECTION_KEYWORDS = [
-    'STRUCTURAL', 'OBJECT', 'AGENT', 'GUI', 'QUANTUM', 'STATE MACHINE', 'NN',
-    'BPMN',
-]
 
 
 def empty_model(diagram_type: str) -> Dict[str, Any]:
@@ -73,146 +75,233 @@ def empty_model(diagram_type: str) -> Dict[str, Any]:
     }
 
 
-def _build_section_boundary_pattern() -> str:
-    """
-    Build a regex alternation matching any section header or the project definition marker.
-
-    Returns:
-        Regex pattern string matching known section boundaries
-    """
-    keyword_alts = '|'.join(re.escape(kw) for kw in ALL_SECTION_KEYWORDS)
-    # Match both old format: # KEYWORD MODEL #
-    # and new numbered format: # KEYWORD MODEL 1: "Title" #
-    return rf'#\s*(?:{keyword_alts})\s+MODEL(?:\s+\d+)?(?:\s*:\s*"[^"]*")?\s*#|# PROJECT DEFINITION'
+# ---------------------------------------------------------------------------
+# AST-based sectioning
+#
+# Instead of counting comment banners, we recover each model's Python source
+# chunk from the module AST: the model's own assignment plus the transitive
+# closure of module-level definitions it references. The diagram set is driven
+# entirely by the ``Project(models=[...])`` list, so stray/duplicate banners are
+# irrelevant.
+# ---------------------------------------------------------------------------
 
 
-def _extract_all_sections(content: str, keyword: str) -> List[Tuple[str, str]]:
-    """
-    Extract ALL sections matching a given type keyword from the project content.
+def _call_func_name(call: ast.Call) -> Optional[str]:
+    """Return the simple callable name of a Call (``Foo(...)`` -> 'Foo', ``x.Foo(...)`` -> 'Foo')."""
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
 
-    Supports both the old single-section format:
-        # STRUCTURAL MODEL #
-    and the new multi-section numbered format:
-        # STRUCTURAL MODEL 1: "User Model" #
-        # STRUCTURAL MODEL 2: "Product Model" #
 
-    Args:
-        content: Full project Python code as string
-        keyword: Section keyword to search for (e.g. 'STRUCTURAL', 'AGENT')
-
-    Returns:
-        List of (title, section_code) tuples. Title is extracted from the header
-        if present, otherwise a default is used based on the keyword.
-    """
-    # Pattern matches:
-    #   # KEYWORD MODEL #                          (old format, no number, no title)
-    #   # KEYWORD MODEL 1 #                        (numbered, no title)
-    #   # KEYWORD MODEL 1: "Some Title" #          (numbered with title)
-    #   #  KEYWORD MODEL  #                        (extra whitespace, e.g. GUI)
-    header_pattern = re.compile(
-        rf'#\s*{re.escape(keyword)}\s+MODEL(?:\s+(\d+))?(?:\s*:\s*"([^"]*)")?\s*#',
-        re.IGNORECASE
-    )
-
-    boundary_pattern = _build_section_boundary_pattern()
-
-    sections = []
-    for match in header_pattern.finditer(content):
-        number = match.group(1)  # e.g. "1", "2", or None
-        title = match.group(2)   # e.g. "User Model" or None
-        section_start = match.end()
-
-        # Find the next section boundary after this header
-        next_boundary = re.search(boundary_pattern, content[section_start:])
-        if next_boundary:
-            section_code = content[section_start:section_start + next_boundary.start()].strip()
+def _expr_root_name(node: ast.AST) -> Optional[str]:
+    """Walk the value/func chain of an Attribute/Call/Subscript down to its root Name id."""
+    while True:
+        if isinstance(node, ast.Name):
+            return node.id
+        if isinstance(node, ast.Attribute):
+            node = node.value
+        elif isinstance(node, ast.Call):
+            node = node.func
+        elif isinstance(node, ast.Subscript):
+            node = node.value
         else:
-            # Last section in the file: take everything until end
-            section_code = content[section_start:].strip()
-
-        if not section_code:
-            logger.debug("Empty section found for keyword '%s' (number=%s)", keyword, number)
-            continue
-
-        # Build a descriptive title
-        if title:
-            resolved_title = title
-        elif number:
-            resolved_title = f"{keyword.title()} Model {number}"
-        else:
-            resolved_title = None  # Caller will use default
-
-        sections.append((resolved_title, section_code))
-
-    return sections
+            return None
 
 
-def _convert_section(
-    model_name: str,
+def _target_base_names(target: ast.AST) -> set:
+    """Base variable names bound or mutated by an assignment target.
+
+    ``x`` -> {'x'}; ``x.attr`` / ``x.attr = ...`` -> {'x'} (mutation of x);
+    ``x[i]`` -> {'x'}; tuple/list targets -> union of their elements.
+    """
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.Attribute, ast.Subscript)):
+        root = _expr_root_name(target)
+        return {root} if root else set()
+    if isinstance(target, (ast.Tuple, ast.List)):
+        names: set = set()
+        for elt in target.elts:
+            names |= _target_base_names(elt)
+        return names
+    return set()
+
+
+def _statement_defines(stmt: ast.stmt) -> set:
+    """Names a top-level statement binds *or* mutates.
+
+    Mutations count as definitions so that e.g. ``Book.attributes = {...}`` is
+    pulled into any chunk that already needs ``Book``.
+    """
+    names: set = set()
+    if isinstance(stmt, ast.Import):
+        for alias in stmt.names:
+            names.add((alias.asname or alias.name).split('.')[0])
+    elif isinstance(stmt, ast.ImportFrom):
+        for alias in stmt.names:
+            names.add(alias.asname or alias.name)
+    elif isinstance(stmt, ast.Assign):
+        for tgt in stmt.targets:
+            names |= _target_base_names(tgt)
+    elif isinstance(stmt, (ast.AnnAssign, ast.AugAssign)):
+        names |= _target_base_names(stmt.target)
+    elif isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        names.add(stmt.name)
+    elif isinstance(stmt, ast.Expr):
+        # Bare expression such as ``book.add_constraint(c)`` mutates ``book``.
+        root = _expr_root_name(stmt.value)
+        if root:
+            names.add(root)
+    return names
+
+
+def _statement_uses(stmt: ast.stmt) -> set:
+    """Names a statement references (over-approximated as every Name it contains).
+
+    Imports reference nothing at module scope. Over-approximating is safe: it can
+    only pull *more* definitions into a chunk, never fewer, and generated
+    statements never mention two different model variables at once.
+    """
+    if isinstance(stmt, (ast.Import, ast.ImportFrom)):
+        return set()
+    return {node.id for node in ast.walk(stmt) if isinstance(node, ast.Name)}
+
+
+def _assignment_name_and_call(stmt: ast.stmt) -> Tuple[Optional[str], Optional[ast.Call]]:
+    """For ``name = Call(...)`` or ``name: Ann = Call(...)`` return (name, call)."""
+    if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 \
+            and isinstance(stmt.targets[0], ast.Name) and isinstance(stmt.value, ast.Call):
+        return stmt.targets[0].id, stmt.value
+    if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name) \
+            and isinstance(stmt.value, ast.Call):
+        return stmt.target.id, stmt.value
+    return None, None
+
+
+def _extract_name_kwarg(call: ast.Call) -> Optional[str]:
+    """Return the string value of the ``name=`` keyword of a constructor call, if any."""
+    for kw in call.keywords:
+        if kw.arg == "name" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+            return kw.value.value
+    return None
+
+
+def _project_model_names(tree: ast.Module) -> List[str]:
+    """Return the ordered variable names in ``Project(models=[...])``.
+
+    Returns an empty list when no ``Project(...)`` call carrying a ``models=``
+    list/tuple of plain names is present.
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _call_func_name(node) == "Project":
+            for kw in node.keywords:
+                if kw.arg == "models" and isinstance(kw.value, (ast.List, ast.Tuple)):
+                    return [elt.id for elt in kw.value.elts if isinstance(elt, ast.Name)]
+    return []
+
+
+def _closure_indices(root_name: str, name_to_def_indices: Dict[str, List[int]],
+                     uses_by_index: Dict[int, set]) -> set:
+    """Transitive closure of statement indices needed to define ``root_name``.
+
+    Every statement that defines or mutates a needed name is pulled in, and each
+    pulled-in statement contributes its own referenced names to the frontier.
+    """
+    included: set = set()
+    needed = {root_name}
+    processed: set = set()
+    while needed - processed:
+        name = (needed - processed).pop()
+        processed.add(name)
+        for idx in name_to_def_indices.get(name, ()):
+            if idx not in included:
+                included.add(idx)
+                needed |= uses_by_index[idx]
+    return included
+
+
+def _source_of(content: str, tree: ast.Module, indices: set) -> str:
+    """Join the original source segments of the given top-level statement indices, in order."""
+    segments = []
+    for idx in sorted(indices):
+        segment = ast.get_source_segment(content, tree.body[idx])
+        if segment:
+            segments.append(segment)
+    return "\n\n".join(segments)
+
+
+def _convert_model(
+    diagram_type: str,
     section_code: str,
     title: str,
-    domain_sections: List[Tuple[str, str]],
+    domain_prefix_code: str,
     class_diagram_list: List[Dict[str, Any]],
-) -> Dict[str, Any]:
+) -> Optional[Dict[str, Any]]:
     """
-    Convert a single section's code into a diagram JSON entry.
+    Convert a single model's source chunk into a diagram JSON entry.
 
     Args:
-        model_name: Model variable name prefix (e.g. 'domain_model', 'agent')
-        section_code: The extracted Python code for this section
-        title: Display title for the diagram
-        domain_sections: All structural/domain sections (needed for object diagram context)
-        class_diagram_list: Already-converted class diagrams (needed for object diagram references)
+        diagram_type: Frontend diagram type (e.g. 'ClassDiagram', 'ObjectDiagram').
+        section_code: The Python source chunk for this model (see _build_ast_sections).
+        title: Display title for the diagram.
+        domain_prefix_code: Concatenated source of all class-diagram models. Object
+            diagrams need the domain-model code prepended for context (preserved
+            from the previous banner-based behaviour).
+        class_diagram_list: Already-converted class diagrams (object diagrams use the
+            first one as their class reference).
 
     Returns:
-        Dictionary with 'id', 'title', 'model', and 'lastUpdate' keys
+        Dictionary with 'id', 'title', 'model', and 'lastUpdate' keys, or None.
     """
     diagram_id = str(uuid.uuid4())
     last_update = datetime.now(timezone.utc).isoformat()
 
     try:
-        if model_name == "domain_model":
+        if diagram_type == "ClassDiagram":
             parsed = parse_buml_content(section_code)
             model = class_buml_to_json(parsed)
 
-        elif model_name == "object_model":
-            # Object diagrams need the domain model code prepended for context
-            # Combine all domain sections as context prefix
-            domain_code = "\n".join(code for _, code in domain_sections)
-            combined_code = domain_code + "\n" + section_code if domain_code else section_code
-            # Use the first class diagram's model as reference, or empty dict
+        elif diagram_type == "ObjectDiagram":
+            # Object diagrams need the domain-model code prepended for context.
+            combined_code = (
+                domain_prefix_code + "\n" + section_code if domain_prefix_code else section_code
+            )
+            # Use the first class diagram's model as reference, or empty dict.
             class_model_ref = class_diagram_list[0]["model"] if class_diagram_list else {}
             model = object_buml_to_json(combined_code, class_model_ref)
 
-        elif model_name == "agent":
+        elif diagram_type == "AgentDiagram":
             model = agent_buml_to_json(section_code)
 
-        elif model_name == "gui_model":
+        elif diagram_type == "GUINoCodeDiagram":
             model = gui_buml_to_json(section_code)
 
-        elif model_name == "quantum_model":
+        elif diagram_type == "QuantumCircuitDiagram":
             model = quantum_buml_to_json(section_code)
 
-        elif model_name == "nn_model":
+        elif diagram_type == "NNDiagram":
             model = nn_buml_to_json(section_code)
 
-        elif model_name == "bpmn_model":
+        elif diagram_type == "BPMNDiagram":
             model = bpmn_buml_to_json(section_code)
 
-        elif model_name == "sm":
+        elif diagram_type == "StateMachineDiagram":
             model = state_machine_to_json(section_code)
 
         else:
-            logger.warning("Unknown model name '%s', skipping conversion", model_name)
+            logger.warning("Unknown diagram type '%s', skipping conversion", diagram_type)
             return None
 
     except (SyntaxError, ValueError, TypeError) as e:
         logger.error(
-            "Failed to convert section '%s' (type: %s): %s",
-            title, model_name, e, exc_info=True,
+            "Failed to convert '%s' (type: %s): %s",
+            title, diagram_type, e, exc_info=True,
         )
         raise ValueError(
-            f"Failed to convert '{title}' section ({model_name}): {e}"
+            f"Failed to convert '{title}' ({diagram_type}): {e}"
         ) from e
 
     return {
@@ -221,6 +310,109 @@ def _convert_section(
         "model": model,
         "lastUpdate": last_update,
     }
+
+
+def _build_ast_sections(content: str) -> Optional[List[Dict[str, Any]]]:
+    """Derive per-model source chunks from the AST, driven by ``Project(models=[...])``.
+
+    Returns an ordered list (matching the ``models=[...]`` order) of dicts with
+    keys ``var``, ``diagram_type``, ``title`` and ``section_code``. Object-diagram
+    chunks have the domain-model statements removed (they are supplied separately
+    via the prepended domain prefix). The domain prefix itself is attached to every
+    object entry under ``domain_prefix_code``.
+
+    Returns ``None`` when the file has no ``Project(models=[...])`` wrapper (the
+    caller then uses the single-diagram fallback).
+    """
+    try:
+        tree = ast.parse(content)
+    except SyntaxError as e:
+        logger.warning("Could not AST-parse project content: %s", e)
+        return None
+
+    model_names = _project_model_names(tree)
+    if not model_names:
+        return None
+
+    logger.debug("Project models=[...] order: %s", model_names)
+
+    # Index every top-level statement's defines/uses.
+    name_to_def_indices: Dict[str, List[int]] = {}
+    uses_by_index: Dict[int, set] = {}
+    ctor_by_name: Dict[str, Tuple[str, str, Optional[str]]] = {}
+    for idx, stmt in enumerate(tree.body):
+        uses_by_index[idx] = _statement_uses(stmt)
+        for name in _statement_defines(stmt):
+            name_to_def_indices.setdefault(name, []).append(idx)
+
+        target_name, call = _assignment_name_and_call(stmt)
+        if target_name is not None and call is not None:
+            ctor = _call_func_name(call)
+            if ctor in CONSTRUCTOR_TO_DIAGRAM and target_name not in ctor_by_name:
+                diagram_type, default_title = CONSTRUCTOR_TO_DIAGRAM[ctor]
+                ctor_by_name[target_name] = (diagram_type, default_title, _extract_name_kwarg(call))
+
+    # Resolve each model variable (in list order) to its diagram type.
+    resolved: List[Dict[str, Any]] = []
+    for var in model_names:
+        if var not in ctor_by_name:
+            logger.debug("Model var '%s' has no recognised constructor; skipping", var)
+            continue
+        diagram_type, default_title, name_kwarg = ctor_by_name[var]
+        resolved.append({
+            "var": var,
+            "diagram_type": diagram_type,
+            "default_title": default_title,
+            "name_kwarg": name_kwarg,
+            "closure": _closure_indices(var, name_to_def_indices, uses_by_index),
+        })
+
+    if not resolved:
+        return None
+
+    # Domain (class-diagram) statements are the shared context for object diagrams.
+    domain_union: set = set()
+    for entry in resolved:
+        if entry["diagram_type"] == "ClassDiagram":
+            domain_union |= entry["closure"]
+    domain_prefix_code = _source_of(content, tree, domain_union)
+
+    # Count per-type occurrences so we can disambiguate default titles.
+    type_counts: Dict[str, int] = {}
+    for entry in resolved:
+        type_counts[entry["diagram_type"]] = type_counts.get(entry["diagram_type"], 0) + 1
+    type_running: Dict[str, int] = {}
+
+    sections: List[Dict[str, Any]] = []
+    for entry in resolved:
+        diagram_type = entry["diagram_type"]
+        type_running[diagram_type] = type_running.get(diagram_type, 0) + 1
+
+        # Title comes from the model's name= argument; fall back to the default,
+        # numbering it when several models of the same type share the default.
+        if entry["name_kwarg"]:
+            title = entry["name_kwarg"]
+        elif type_counts[diagram_type] > 1:
+            title = f"{entry['default_title']} {type_running[diagram_type]}"
+        else:
+            title = entry["default_title"]
+
+        # Object chunks exclude the shared domain statements (prepended separately);
+        # every other type keeps its self-contained closure.
+        if diagram_type == "ObjectDiagram":
+            indices = entry["closure"] - domain_union
+        else:
+            indices = entry["closure"]
+
+        sections.append({
+            "var": entry["var"],
+            "diagram_type": diagram_type,
+            "title": title,
+            "section_code": _source_of(content, tree, indices),
+            "domain_prefix_code": domain_prefix_code,
+        })
+
+    return sections
 
 
 # Detection heuristics for single-diagram BUML files that omit the Project(...)
@@ -375,11 +567,16 @@ def project_to_json(content: str) -> Dict[str, Any]:
     """
     Convert a BUML project content to JSON format matching the frontend structure.
 
-    Supports both the legacy single-diagram-per-type format and the new
-    multi-diagram-per-type format with numbered/titled section headers.
-    Also accepts plain single-diagram BUML files that omit the Project(...)
-    wrapper — they are wrapped into a one-diagram project so that the
-    Project Import flow works with any well-formed BUML file.
+    The diagram set is driven by the authoritative ``Project(models=[...])`` list
+    recovered from the module AST: each variable in that list yields exactly one
+    diagram, whose type is read from its assignment's constructor
+    (``ObjectModel(...)`` -> object diagram, ``DomainModel(...)`` -> class diagram,
+    ...). Comment banners are ignored, so a stray/duplicate ``# ... MODEL #`` line
+    cannot change the number or identity of diagrams (WME issue #161).
+
+    Also accepts plain single-diagram BUML files that omit the ``Project(...)``
+    wrapper — they are wrapped into a one-diagram project so that the Project
+    Import flow works with any well-formed BUML file.
 
     Args:
         content: Project Python code as string
@@ -388,9 +585,9 @@ def project_to_json(content: str) -> Dict[str, Any]:
         Dictionary representing the complete project with all diagrams.
         Each diagram type maps to a list of diagram entries.
     """
-    # Detect models included in the project
-    model_match = re.search(r"models\s*=\s*\[(.*?)\]", content, re.DOTALL)
-    if not model_match:
+    # Derive per-model source chunks from the AST, driven by Project(models=[...]).
+    sections = _build_ast_sections(content)
+    if sections is None:
         # No Project(...) wrapper — fall back to single-diagram detection so
         # plain class/agent/state-machine/GUI/NN files can still be imported.
         logger.info(
@@ -398,10 +595,7 @@ def project_to_json(content: str) -> Dict[str, Any]:
         )
         return _build_project_from_single_diagram(content)
 
-    model_names = re.findall(r'\b(\w+)\b', model_match.group(1))
-    logger.debug("Detected model names in project: %s", model_names)
-
-    # Extract project metadata
+    # Extract project metadata (orthogonal to sectioning; kept as lightweight regex).
     project_name_match = re.search(r'Project\s*\(\s*name\s*=\s*"(.*?)"', content)
     project_desc_match = re.search(r'Metadata\s*\(\s*description\s*=\s*"(.*?)"', content)
     project_owner_match = re.search(r'owner\s*=\s*"(.*?)"', content)
@@ -410,78 +604,38 @@ def project_to_json(content: str) -> Dict[str, Any]:
     project_description = project_desc_match.group(1) if project_desc_match else "No description"
     project_owner = project_owner_match.group(1) if project_owner_match else "Unknown"
 
-    # diagram_jsons maps diagram type -> list of diagram entries
+    # diagram_jsons maps diagram type -> list of diagram entries.
     diagram_jsons: Dict[str, List[Dict[str, Any]]] = {}
 
-    # First pass: extract all structural/domain sections (needed as context for object diagrams)
-    # Check for both exact "domain_model" and suffixed variants like "domain_model_1"
-    domain_sections: List[Tuple[str, str]] = []
-    has_domain_model = any(re.sub(r'_\d+$', '', name) == "domain_model" for name in model_names)
-    if has_domain_model:
-        keyword = SECTION_CONFIG["domain_model"][0]
-        domain_sections = _extract_all_sections(content, keyword)
-        logger.debug("Found %d structural model section(s)", len(domain_sections))
+    # Convert class diagrams first so object diagrams can reference them, then the
+    # rest. Within each pass, sections keep their Project(models=[...]) order, so
+    # per-type diagram lists are ordered by the models list.
+    def _emit(section: Dict[str, Any]) -> None:
+        entry = _convert_model(
+            section["diagram_type"],
+            section["section_code"],
+            section["title"],
+            section["domain_prefix_code"],
+            diagram_jsons.get("ClassDiagram", []),
+        )
+        if entry is not None:
+            diagram_jsons.setdefault(section["diagram_type"], []).append(entry)
 
-    # Process each model type referenced in the project
-    # Use a deduplicated ordered list to process each base model name only once.
-    # Variable names may carry numeric suffixes (e.g. domain_model_1, agent_2)
-    # generated by project_builder._suffixed_name for multi-diagram projects.
-    # Strip trailing _<digits> to recover the base name used in SECTION_CONFIG.
-    seen_base_names = set()
-    for model_name in model_names:
-        # Strip numeric suffix: "domain_model_1" -> "domain_model", "agent_2" -> "agent"
-        base_name = re.sub(r'_\d+$', '', model_name)
+    for section in sections:
+        if section["diagram_type"] == "ClassDiagram":
+            _emit(section)
+    for section in sections:
+        if section["diagram_type"] != "ClassDiagram":
+            _emit(section)
 
-        if base_name in seen_base_names:
-            continue
-        seen_base_names.add(base_name)
-
-        if base_name not in SECTION_CONFIG:
-            logger.debug("Skipping unknown model name '%s' (base: '%s')", model_name, base_name)
-            continue
-
-        keyword, diagram_type, default_title = SECTION_CONFIG[base_name]
-        sections = _extract_all_sections(content, keyword)
-
-        if not sections:
-            logger.info("No sections found for '%s' (keyword: %s), skipping", base_name, keyword)
-            continue
-
-        diagram_list = []
-        for idx, (title, section_code) in enumerate(sections):
-            resolved_title = title if title else default_title
-            # Append index suffix for multi-diagram types (only when more than one)
-            if len(sections) > 1 and not title:
-                resolved_title = f"{default_title} {idx + 1}"
-
-            logger.debug(
-                "Converting section %d/%d for %s: '%s'",
-                idx + 1, len(sections), diagram_type, resolved_title
-            )
-
-            # class_diagram_list is only needed for object_model; pass current ClassDiagram list
-            class_diagrams = diagram_jsons.get("ClassDiagram", [])
-            entry = _convert_section(
-                base_name, section_code, resolved_title,
-                domain_sections, class_diagrams,
-            )
-            if entry is not None:
-                diagram_list.append(entry)
-
-        if diagram_list:
-            diagram_jsons[diagram_type] = diagram_list
-
-    # Section-header fallback: some project files declare `models=[domain_model]`
-    # but omit the `# STRUCTURAL MODEL #` (or sibling) section headers entirely —
-    # all the model code lives in one flat block above the project definition.
-    # When this happens, `diagram_jsons` ends up empty and every diagram type
-    # gets an empty placeholder, which the frontend renders as a blank canvas.
-    # Reuse the single-diagram detector to recover the actual model, then
-    # restore the project name/description/owner from the Project(...) wrapper.
+    # Safety net: a Project(...) wrapper whose models resolved to nothing usable
+    # (e.g. all constructors unrecognised, or a flat file the AST closure could not
+    # section). Recover the embedded model via single-diagram detection and restore
+    # the project metadata from the wrapper.
     if not diagram_jsons:
         logger.info(
-            "Project declares models=%s but no section headers were found; "
-            "falling back to single-diagram detection.", model_names,
+            "Project wrapper present but no diagrams were produced; "
+            "falling back to single-diagram detection."
         )
         try:
             result = _build_project_from_single_diagram(content)

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/quantum_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/quantum_diagram_converter.py
@@ -4,6 +4,10 @@ Quantum diagram conversion from BUML to JSON format.
 
 from typing import Dict, Any
 
+from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json._safe_eval import (
+    safe_exec,
+    UnsafeConstruct,
+)
 from besser.BUML.metamodel.quantum.quantum import (
     QuantumCircuit, QuantumOperation, PrimitiveGate, ParametricGate,
     ArithmeticGate, ModularArithmeticGate, ComparisonGate, QFTGate,
@@ -512,9 +516,12 @@ def quantum_buml_to_json(content: str) -> Dict[str, Any]:
         cleaned_lines.append(line)
     cleaned_content = "\n".join(cleaned_lines)
 
-    local_vars = {}
     try:
-        exec(cleaned_content, safe_globals, local_vars)
+        # AST whitelist evaluation instead of exec() — the uploaded quantum
+        # circuit source is untrusted (see _safe_eval).
+        local_vars = safe_exec(cleaned_content, safe_globals)
+    except UnsafeConstruct:
+        raise
     except Exception as exc:
         raise ValueError(f"Failed to execute quantum BUML content: {exc}") from exc
 

--- a/tests/utilities/buml_code_builder/test_builders.py
+++ b/tests/utilities/buml_code_builder/test_builders.py
@@ -1330,8 +1330,13 @@ class TestProjectBuilder:
 class TestDomainModelBuilderAdvanced:
     """Additional domain model builder tests for edge cases."""
 
-    def test_empty_model_compiles(self, tmp_path):
-        """A model with no classes or associations generates syntactically valid code."""
+    def test_empty_model_roundtrips(self, tmp_path):
+        """A model with no classes or associations generates code that compiles AND runs.
+
+        Empty collections must be emitted as ``set()``, not ``{}`` (a dict literal):
+        a dict breaks the metamodel's set-typed setters on re-import (``{} | set``),
+        so an empty domain model previously crashed on round-trip.
+        """
         model = DomainModel(name="EmptyModel", types=set(), associations=set())
         file_path = str(tmp_path / "empty.py")
         domain_model_to_code(model, file_path)
@@ -1339,11 +1344,15 @@ class TestDomainModelBuilderAdvanced:
         with open(file_path, "r", encoding="utf-8") as f:
             code = f.read()
 
-        # Generated code must at least compile
+        # Empty collections are set(), never the dict literal {}.
+        assert "types=set()" in code and "types={}" not in code
+        assert "associations=set()" in code and "generalizations=set()" in code
+
+        # Compiles AND execs (the {} bug used to make exec crash).
         compile(code, file_path, "exec")
-        # Note: exec() currently fails because the builder emits types={}
-        # (a dict literal) instead of set() for empty type collections.
-        # This is a known limitation of the builder.
+        namespace: dict = {}
+        exec(code, namespace)
+        assert namespace["domain_model"].name == "EmptyModel"
 
     def test_single_class_model(self, tmp_path):
         """A model with a single class (no associations) roundtrips correctly."""

--- a/tests/utilities/web_modeling_editor/backend/services/converters/test_buml_to_json_safe_eval.py
+++ b/tests/utilities/web_modeling_editor/backend/services/converters/test_buml_to_json_safe_eval.py
@@ -1,0 +1,324 @@
+"""Safety + round-trip tests for the shared ``safe_exec`` AST evaluator that
+replaced ``exec()`` in the class / gui / bpmn / quantum BUML -> JSON converters.
+
+Two concerns:
+
+1. **Security** — ``safe_exec`` must *refuse* (raise, never run) the standard
+   sandbox-escape gadgets: dunder attribute traversal
+   (``().__class__.__bases__[0].__subclasses__()``), ``__import__(...)`` /
+   ``getattr(...)`` -to-globals, imports, lambdas, comprehensions, and
+   ``str.format`` attribute-leak gadgets. The four converters that call it must
+   propagate that refusal rather than execute the payload.
+
+2. **Round-trip fidelity** — the builder-emitted ``.py`` for each of the four
+   de-exec'd model types must still reconstruct through the AST evaluator with
+   no loss. OCL ``Constraint`` objects (the explicitly-called-out case) must
+   survive with their names *and* opaque expression strings byte-for-byte.
+"""
+
+import pytest
+
+from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json._safe_eval import (
+    safe_exec,
+    UnsafeConstruct,
+)
+from besser.utilities.web_modeling_editor.backend.services.exceptions import ConversionError
+
+
+# A minimal whitelist mimicking what the converters seed: benign builtins under
+# ``__builtins__``, an import sentinel ``__name__``, and one stand-in
+# "constructor" (``dict`` is a convenient callable that echoes its kwargs).
+ALLOWED = {
+    "__name__": "besser_buml_import",
+    "__builtins__": {"set": set, "list": list, "dict": dict},
+    "Ctor": dict,
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. Security — adversarial payloads must be refused, never executed
+# ---------------------------------------------------------------------------
+
+# Each of these must raise ``UnsafeConstruct`` (a security refusal), proving the
+# construct was rejected at evaluation time and never ran.
+UNSAFE_PAYLOADS = {
+    "subclass_traversal": "x = ().__class__.__bases__[0].__subclasses__()",
+    "dunder_on_str": "x = ''.__class__",
+    "dunder_on_list": "x = [].__class__",
+    "dunder_import_call": "x = __import__('os').system('echo pwned')",
+    "getattr_to_globals": "x = getattr(Ctor, '__globals__')",
+    "dunder_kwarg": "x = Ctor(name=().__class__)",
+    "dunder_attr_assign": "obj = Ctor(a=1)\nobj.__class__ = list",
+    "lambda_expr": "f = lambda: 1",
+    "list_comprehension": "g = [i for i in range(3)]",
+    "generator_expr": "g = list(i for i in range(3))",
+    "dict_unpacking": "z = {**{'a': 1}}",
+    "iterable_unpacking": "w = [*[1, 2]]",
+    "kwargs_unpacking": "x = Ctor(**{'a': 1})",
+    "format_attr_leak": "s = '{0.__class__}'.format(())",
+    "fstring": "name = 'a'\ns = f'{name.__class__}'",
+    "subscript_read": "d = {'a': 1}\nx = d['a'].__class__",
+    "binop": "x = 1 + ().__class__.__name__",
+    "walrus": "x = (y := 5)",
+    "function_def": "def evil():\n    import os\n    os.system('x')",
+    "class_def": "class Evil:\n    pass",
+    "for_loop": "for i in range(3):\n    x = i",
+    "while_loop": "while False:\n    pass",
+    "with_stmt": "with open('x') as f:\n    pass",
+    "raise_stmt": "raise RuntimeError('boom')",
+    "delete_stmt": "x = 1\ndel x",
+    "global_stmt": "global x",
+    "await_expr": "async def f():\n    await g()",
+}
+
+
+@pytest.mark.parametrize("name,src", sorted(UNSAFE_PAYLOADS.items()))
+def test_safe_exec_refuses_unsafe_construct(name, src):
+    """Every escape gadget raises UnsafeConstruct — parse aborts, nothing runs."""
+    with pytest.raises(UnsafeConstruct):
+        safe_exec(src, ALLOWED)
+
+
+def test_safe_exec_import_then_use_never_executes():
+    """A stripped/kept ``import os`` is a no-op, so a later ``os.system(...)``
+    fails with NameError — ``os`` was never actually imported."""
+    with pytest.raises((UnsafeConstruct, NameError)):
+        safe_exec("import os\nos.system('echo pwned')", ALLOWED)
+
+
+def test_unsafe_construct_is_valueerror():
+    """UnsafeConstruct subclasses ValueError so the converters' existing
+    ``except ValueError`` wrappers catch it (mapping to a 400, not a 500)."""
+    assert issubclass(UnsafeConstruct, ValueError)
+
+
+def test_try_except_cannot_swallow_security_refusal():
+    """Wrapping a payload in ``try/except Exception: pass`` must NOT let it
+    slip through — a security refusal always aborts the whole parse."""
+    src = "try:\n    x = ().__class__\nexcept Exception:\n    pass\n"
+    with pytest.raises(UnsafeConstruct):
+        safe_exec(src, ALLOWED)
+
+
+# ---------------------------------------------------------------------------
+# 1b. Security — the refusal propagates through each real converter entry point
+# ---------------------------------------------------------------------------
+
+_ESCAPE = "pwned = ().__class__.__bases__[0].__subclasses__()\n"
+
+
+def test_class_converter_rejects_escape():
+    from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json.class_diagram_converter import (
+        parse_buml_content,
+    )
+    with pytest.raises(ValueError):
+        parse_buml_content(_ESCAPE)
+
+
+def test_gui_converter_rejects_escape():
+    from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json.gui_diagram_converter import (
+        gui_buml_to_json,
+    )
+    with pytest.raises(ValueError):
+        gui_buml_to_json(_ESCAPE)
+
+
+def test_quantum_converter_rejects_escape():
+    from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json.quantum_diagram_converter import (
+        quantum_buml_to_json,
+    )
+    with pytest.raises(ValueError):
+        quantum_buml_to_json(_ESCAPE)
+
+
+def test_bpmn_converter_rejects_escape():
+    from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json.bpmn_diagram_converter import (
+        bpmn_buml_to_json,
+    )
+    # BPMN wraps parse failures (incl. the ValueError-derived UnsafeConstruct)
+    # into ConversionError.
+    with pytest.raises(ConversionError):
+        bpmn_buml_to_json(_ESCAPE)
+
+
+# ---------------------------------------------------------------------------
+# 2. Import semantics — ``if __name__ == "__main__":`` guard is skipped
+# ---------------------------------------------------------------------------
+
+def test_main_guard_body_is_not_executed():
+    """The guarded block must be skipped (condition False), never run — mirrors
+    Python import semantics for a file with a ``__main__`` guard."""
+    src = (
+        "value = 1\n"
+        "if __name__ == '__main__':\n"
+        "    raise RuntimeError('main block must not execute during import')\n"
+    )
+    env = safe_exec(src, ALLOWED)
+    assert env["value"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. OCL round-trip — Constraints survive the de-exec'd class converter
+# ---------------------------------------------------------------------------
+
+def test_ocl_constraints_survive_class_converter_roundtrip(tmp_path):
+    """Build a class diagram with OCL invariants via ``buml_code_builder``,
+    export to ``.py``, and re-import it through the (now exec-free)
+    ``parse_buml_content``. Constraint names *and* opaque expression strings
+    must survive unchanged, with their class context re-wired."""
+    from besser.BUML.metamodel.structural import (
+        DomainModel, Class, Property, IntegerType, Constraint,
+    )
+    from besser.utilities.buml_code_builder.domain_model_builder import (
+        domain_model_to_code,
+    )
+    from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json.class_diagram_converter import (
+        parse_buml_content, class_buml_to_json,
+    )
+
+    pages = Property(name="pages", type=IntegerType)
+    stock = Property(name="stock", type=IntegerType)
+    book = Class(name="Book", attributes={pages, stock})
+
+    expressions = {
+        "pages_positive": "context Book inv pages_positive: self.pages > 0",
+        "stock_non_negative": "context Book inv stock_non_negative: self.stock >= 0",
+    }
+    constraints = {
+        Constraint(name=name, context=book, expression=expr, language="OCL")
+        for name, expr in expressions.items()
+    }
+    model = DomainModel(name="Library", types={book}, constraints=constraints)
+
+    code_path = tmp_path / "library_ocl.py"
+    domain_model_to_code(model, str(code_path))
+    code = code_path.read_text(encoding="utf-8")
+
+    parsed = parse_buml_content(code)
+
+    # Names + expressions round-trip verbatim (the opaque OCL text is never
+    # parsed or re-serialised by the evaluator).
+    assert {c.name: c.expression for c in parsed.constraints} == expressions
+    # Every constraint keeps its class context wiring.
+    assert all(c.context.name == "Book" for c in parsed.constraints)
+    # And the JSON walk still emits an OCL box per constraint.
+    out = class_buml_to_json(parsed)
+    boxes = sorted(
+        e["constraint"]
+        for e in out["elements"].values()
+        if e.get("type") == "ClassOCLConstraint"
+    )
+    assert boxes == sorted(expressions.values())
+
+
+def test_project_to_json_preserves_ocl_constraints(tmp_path):
+    """The same OCL survives the full project import path (``project_to_json``),
+    which routes the class section through ``parse_buml_content``."""
+    from besser.BUML.metamodel.structural import (
+        DomainModel, Class, Property, IntegerType, Constraint,
+    )
+    from besser.utilities.buml_code_builder.domain_model_builder import (
+        domain_model_to_code,
+    )
+    from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json.project_converter import (
+        project_to_json,
+    )
+
+    balance = Property(name="balance", type=IntegerType)
+    account = Class(name="Account", attributes={balance})
+    expr = "context Account inv positive: self.balance >= 0"
+    inv = Constraint(name="positive", context=account, expression=expr, language="OCL")
+    model = DomainModel(name="Bank", types={account}, constraints={inv})
+
+    code_path = tmp_path / "bank.py"
+    domain_model_to_code(model, str(code_path))
+    code = code_path.read_text(encoding="utf-8")
+
+    project = project_to_json(code)
+    class_model = project["diagrams"]["ClassDiagram"][0]["model"]
+    boxes = [
+        e for e in class_model["elements"].values()
+        if e.get("type") == "ClassOCLConstraint"
+    ]
+    assert [b["constraint"] for b in boxes] == [expr]
+
+
+# ---------------------------------------------------------------------------
+# 4. Quantum round-trip — control-qubit chains + enum-literal reads
+# ---------------------------------------------------------------------------
+
+def test_quantum_builder_roundtrips_through_safe_eval(tmp_path):
+    """A circuit whose builder output uses the tricky patterns —
+    ``gate.control_qubits.append(...)`` (method call on an attribute of a
+    namespace object) and ``ControlState.CONTROL`` (enum-literal attribute
+    read) — must reconstruct through the exec-free converter."""
+    from besser.BUML.metamodel.quantum.quantum import (
+        QuantumCircuit, HadamardGate, PauliXGate, Measurement,
+        ControlState, ClassicalRegister,
+    )
+    from besser.utilities.buml_code_builder.quantum_model_builder import (
+        quantum_model_to_code,
+    )
+    from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json.quantum_diagram_converter import (
+        quantum_buml_to_json,
+    )
+
+    qc = QuantumCircuit(name="Bell", qubits=2)
+    qc.add_operation(HadamardGate(target_qubit=0))
+    cx = PauliXGate(target_qubit=1)
+    cx.control_qubits = [0]
+    cx.control_states = [ControlState.CONTROL]
+    qc.add_operation(cx)
+    qc.add_creg(ClassicalRegister("c", 2))
+    qc.add_operation(Measurement(target_qubit=0, output_bit=0))
+
+    code_path = tmp_path / "bell.py"
+    quantum_model_to_code(qc, str(code_path))
+    code = code_path.read_text(encoding="utf-8")
+
+    out = quantum_buml_to_json(code)
+    assert out["title"] == "Bell"
+    # Three operations -> three columns (H, controlled-X, Measurement).
+    assert len(out["cols"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# 5. GUI round-trip — fluent builder chains through the exec-free converter
+# ---------------------------------------------------------------------------
+
+def test_gui_builder_roundtrips_through_safe_eval(tmp_path):
+    """A GUI model exported by ``gui_model_to_code`` must reconstruct through the
+    exec-free ``gui_buml_to_json`` and yield the expected page."""
+    from besser.BUML.metamodel.gui import GUIModel
+    from besser.BUML.metamodel.gui.graphical_ui import (
+        Screen, Module, Button, Text, ButtonType, ButtonActionType,
+    )
+    from besser.utilities.buml_code_builder.gui_model_builder import (
+        gui_model_to_code,
+    )
+    from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json.gui_diagram_converter import (
+        gui_buml_to_json,
+    )
+
+    btn = Button(
+        name="SubmitBtn", label="Submit", description="A submit button",
+        buttonType=ButtonType.RaisedButton, actionType=ButtonActionType.Navigate,
+    )
+    txt = Text(name="WelcomeText", content="Hello World", description="Welcome text")
+    screen = Screen(
+        name="MainScreen", description="The main screen",
+        view_elements={btn, txt}, is_main_page=True,
+    )
+    module = Module(name="MainModule", screens={screen})
+    gui = GUIModel(
+        name="TestGUI", package="com.test", versionCode="1", versionName="1.0",
+        modules={module}, description="Test GUI model",
+    )
+
+    code_path = tmp_path / "gui.py"
+    gui_model_to_code(gui, str(code_path))
+    code = code_path.read_text(encoding="utf-8")
+
+    out = gui_buml_to_json(code)
+    assert out["pages"], "expected at least one GrapesJS page"
+    assert any(p.get("name") == "The main screen" for p in out["pages"])

--- a/tests/utilities/web_modeling_editor/backend/services/converters/test_project_ast_sectioning.py
+++ b/tests/utilities/web_modeling_editor/backend/services/converters/test_project_ast_sectioning.py
@@ -1,0 +1,125 @@
+"""
+Banner-immunity tests for ``project_to_json``.
+
+The importer must derive the number and identity of diagrams from the
+authoritative ``Project(models=[...])`` list and the Python AST — NOT from
+counting ``# ... MODEL #`` comment banners. This guards WME issue #161, where a
+stray/duplicate object-model banner caused each object model to yield one real
+diagram plus one spurious empty one (2 models -> 4 diagrams).
+"""
+
+import re
+
+from besser.BUML.metamodel.structural.structural import (
+    Class, Property, DomainModel, Metadata, StringType, IntegerType,
+)
+from besser.BUML.metamodel.object import (
+    Object, AttributeLink, DataValue, ObjectModel,
+)
+from besser.BUML.metamodel.project import Project
+from besser.utilities.buml_code_builder.project_builder import project_to_code
+from besser.utilities.web_modeling_editor.backend.services.converters.buml_to_json.project_converter import (
+    project_to_json,
+)
+
+
+def _multi_object_project_code(tmp_path) -> str:
+    """Generate a real BUML file for a project with 1 domain + 2 object models."""
+    title = Property(name="title", type=StringType)
+    pages = Property(name="pages", type=IntegerType)
+    book = Class(name="Book", attributes={title, pages})
+    library = Class(name="Library", attributes={Property(name="name", type=StringType)})
+    dm = DomainModel(name="LibraryModel", types={library, book}, associations=set())
+
+    om1 = ObjectModel(name="ObjectModelOne", objects={Object(
+        name="BookOne", classifier=book,
+        slots=[AttributeLink(attribute=title, value=DataValue(classifier=StringType, value="Book One")),
+               AttributeLink(attribute=pages, value=DataValue(classifier=IntegerType, value=100))])})
+    om2 = ObjectModel(name="ObjectModelTwo", objects={Object(
+        name="BookTwo", classifier=book,
+        slots=[AttributeLink(attribute=title, value=DataValue(classifier=StringType, value="Book Two")),
+               AttributeLink(attribute=pages, value=DataValue(classifier=IntegerType, value=200))])})
+
+    project = Project(name="MultiObjectProject", models=[dm, om1, om2], owner="tester",
+                      metadata=Metadata(description="banner immunity"))
+
+    file_path = str(tmp_path / "multi_object.py")
+    project_to_code(project, file_path)
+    with open(file_path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _object_diagrams(code):
+    return project_to_json(code)["diagrams"].get("ObjectDiagram", [])
+
+
+def test_baseline_two_object_diagrams(tmp_path):
+    """A clean 1-domain + 2-object project imports as exactly two object diagrams."""
+    code = _multi_object_project_code(tmp_path)
+    object_diagrams = _object_diagrams(code)
+
+    assert len(object_diagrams) == 2
+    assert {d["title"] for d in object_diagrams} == {"ObjectModelOne", "ObjectModelTwo"}
+    for d in object_diagrams:
+        assert d["model"]["elements"], f"object diagram {d['title']!r} came back empty"
+
+
+def test_stray_duplicate_object_banner_is_ignored(tmp_path):
+    """Injecting a stray ``# OBJECT MODEL 3 #`` banner must NOT add a diagram.
+
+    The number of object diagrams is fixed by ``models=[...]`` (two entries), so a
+    third banner — with no corresponding model variable in the list — is inert.
+    """
+    code = _multi_object_project_code(tmp_path)
+
+    stray_banner = (
+        "####################################\n"
+        '# OBJECT MODEL 3: "Ghost" #\n'
+        "####################################\n\n"
+    )
+    poisoned = code.replace("# PROJECT DEFINITION #", stray_banner + "# PROJECT DEFINITION #")
+    # Sanity: the poison actually introduced a third OBJECT MODEL banner.
+    assert len(re.findall(r"#\s*OBJECT\s+MODEL[^\n#]*#", poisoned, flags=re.IGNORECASE)) == 3
+
+    object_diagrams = _object_diagrams(poisoned)
+    assert len(object_diagrams) == 2, [d["title"] for d in object_diagrams]
+    assert {d["title"] for d in object_diagrams} == {"ObjectModelOne", "ObjectModelTwo"}
+    for d in object_diagrams:
+        assert d["model"]["elements"], f"object diagram {d['title']!r} came back empty"
+
+
+def test_leftover_import_only_block_is_ignored(tmp_path):
+    """A leftover import-only block (no model in ``models=[...]``) must not add a diagram."""
+    code = _multi_object_project_code(tmp_path)
+
+    leftover = (
+        "####################################\n"
+        "# OBJECT MODEL #\n"
+        "####################################\n"
+        "from besser.BUML.metamodel.object import ObjectModel\n"
+        "import datetime\n\n"
+    )
+    poisoned = code.replace("# PROJECT DEFINITION #", leftover + "# PROJECT DEFINITION #")
+
+    object_diagrams = _object_diagrams(poisoned)
+    assert len(object_diagrams) == 2
+    for d in object_diagrams:
+        assert d["model"]["elements"], f"object diagram {d['title']!r} came back empty"
+
+
+def test_renumbered_banners_do_not_change_diagram_set(tmp_path):
+    """Reformatting/renumbering the banners leaves the diagram set untouched."""
+    code = _multi_object_project_code(tmp_path)
+
+    # Rewrite every "# OBJECT MODEL N: "X" #" banner to a bare, wrongly-numbered one.
+    poisoned = re.sub(
+        r'#\s*OBJECT\s+MODEL[^\n#]*#',
+        "# OBJECT MODEL 99 #",
+        code,
+        flags=re.IGNORECASE,
+    )
+
+    object_diagrams = _object_diagrams(poisoned)
+    # Titles still come from each ObjectModel(name=...) call, not the banner text.
+    assert len(object_diagrams) == 2
+    assert {d["title"] for d in object_diagrams} == {"ObjectModelOne", "ObjectModelTwo"}


### PR DESCRIPTION
Completes **#560** — move the WME B-UML importers off text/`exec()` heuristics to AST-restricted parsing. Two parts:

## Part 1 — banner-free sectioning
`project_to_json` used to decide the diagram set by **counting `# X MODEL #` comment banners**, coupling the importer to the generator's comment formatting (root cause of WME #161). Now it parses the AST, reads the authoritative `Project(models=[...])` list, resolves each model's type from its constructor, and slices each model's source as its dependency closure. **One diagram per model in the list**; banners are no longer load-bearing. Adds a banner-immunity test (stray/duplicate/renumbered banners can't create phantom diagrams).

## Part 2 — `exec()` removal (the security core)
The `class`/`gui`/`bpmn`/`quantum` converters reconstructed the model by **`exec()`-ing the uploaded `.py`** in a restricted namespace — escapable (`().__class__.__bases__[0].__subclasses__()` needs no builtins), i.e. RCE on untrusted upload. Replaced with a shared **whitelist AST evaluator** (`_safe_eval.py`):
- **Allows:** literals/collections, calls to whitelisted constructors, method-chains on namespace values, enum reads, and the `if`/`try` the generated files use.
- **Refuses (`UnsafeConstruct`, un-catchable by uploaded `try/except`):** any `__dunder__` attribute (read/write/call) — the single control defeating `__class__`/`__globals__`/`__subclasses__`/`__import__`; non-whitelisted bare calls (`__import__`,`getattr`,`eval`); `str`/`bytes`-receiver method calls (format-leak gadgets); subscript, lambda, comprehensions, f-strings, imports.
- Each converter's `safe_globals` whitelist and JSON walker are unchanged; only the `exec` step swapped. **OCL `Constraint` expressions round-trip verbatim** (opaque strings, never parsed/executed).

## Diff & tests
`+1207 / −195` across 8 files. `exec(` real calls in `buml_to_json`: **0**.
- converters + code builder: **521 passed**; full WME tree: **556 passed, 4 skipped** — all re-verified locally.
- New: banner-immunity test; **26 adversarial security payloads** (subclass traversal, `__import__`/`getattr`-to-globals, str.format leak, lambda/comprehension/subscript…) all refused and proven un-swallowable; OCL constraint round-trip.

## Reviewer notes / honest caveats
- Only cosmetic behavior change: diagram **titles** now come from each model's `name=` (verified the class-diagram *count* is unchanged for auth/User-model projects — an earlier claim of a count change was wrong and removed).
- The evaluator permits non-dunder method calls on any non-`str`/`bytes` namespace value (shared evaluator, not a per-converter method allowlist); the dunder block is the load-bearing control and no dangerous callable is reachable (quantum's blanket module seed exposes only BUML classes — no `os`/`sys`/`open`).
- Follow-up worth considering: tighten quantum's `dir(module)` seed to an explicit whitelist so a future stray `import` in that module can't widen the surface.

Draft → mark ready when you've reviewed. #161 is already fixed & live independently; this is the durable, security-hardening version.