### PR TITLE
feat(agents): extend metamodel and generator for 10 new LLM provider families

### DIFF
--- a/besser/BUML/metamodel/state_machine/agent.py
+++ b/besser/BUML/metamodel/state_machine/agent.py
@@ -731,6 +731,429 @@ class LLMReplicate(LLMWrapper):
         self.num_previous_messages = num_previous_messages
 
 
+class LLMMistral(LLMWrapper):
+    """An LLM wrapper for Mistral AI models via Mistral's OpenAI-compatible API.
+
+    Args:
+        agent (Agent): the agent the LLM belongs to
+        name (str): the LLM name / model identifier (e.g. ``"mistral-small-latest"``)
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): for the chat functionality, the number of previous messages of the conversation
+            to add to the prompt context (must be > 0)
+        global_context (str): the global context to be provided to the LLM for each request
+
+    Attributes:
+        name (str): the LLM name
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): number of previous messages used in chat
+        _global_context (str): the global context to be provided to the LLM for each request
+        _user_context (dict): user specific context to be provided to the LLM for each request
+    """
+
+    def __init__(self, agent: 'Agent', name: str, parameters: dict, num_previous_messages: int = 1,
+                 global_context: str = None):
+        super().__init__(name, agent, parameters, global_context=global_context)
+        self.agent: 'Agent' = agent
+        self.num_previous_messages: int = num_previous_messages
+
+    def set_model(self, name: str) -> None:
+        """Set the LLM model name.
+
+        Args:
+            name (str): the new LLM name
+        """
+        self.name = name
+
+    def set_num_previous_messages(self, num_previous_messages: int) -> None:
+        """Set the number of previous messages to use in the chat functionality
+
+        Args:
+            num_previous_messages (int): the new number of previous messages
+        """
+        self.num_previous_messages = num_previous_messages
+
+
+class LLMDeepSeek(LLMWrapper):
+    """An LLM wrapper for DeepSeek models via DeepSeek's OpenAI-compatible API.
+
+    Args:
+        agent (Agent): the agent the LLM belongs to
+        name (str): the LLM name / model identifier (e.g. ``"deepseek-chat"``)
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): for the chat functionality, the number of previous messages of the conversation
+            to add to the prompt context (must be > 0)
+        global_context (str): the global context to be provided to the LLM for each request
+
+    Attributes:
+        name (str): the LLM name
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): number of previous messages used in chat
+        _global_context (str): the global context to be provided to the LLM for each request
+        _user_context (dict): user specific context to be provided to the LLM for each request
+    """
+
+    def __init__(self, agent: 'Agent', name: str, parameters: dict, num_previous_messages: int = 1,
+                 global_context: str = None):
+        super().__init__(name, agent, parameters, global_context=global_context)
+        self.agent: 'Agent' = agent
+        self.num_previous_messages: int = num_previous_messages
+
+    def set_model(self, name: str) -> None:
+        """Set the LLM model name.
+
+        Args:
+            name (str): the new LLM name
+        """
+        self.name = name
+
+    def set_num_previous_messages(self, num_previous_messages: int) -> None:
+        """Set the number of previous messages to use in the chat functionality
+
+        Args:
+            num_previous_messages (int): the new number of previous messages
+        """
+        self.num_previous_messages = num_previous_messages
+
+
+class LLMGoogle(LLMWrapper):
+    """An LLM wrapper for Google Gemini models via Google's OpenAI-compatible endpoint.
+
+    Args:
+        agent (Agent): the agent the LLM belongs to
+        name (str): the LLM name / model identifier (e.g. ``"gemini-2.5-flash"``)
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): for the chat functionality, the number of previous messages of the conversation
+            to add to the prompt context (must be > 0)
+        global_context (str): the global context to be provided to the LLM for each request
+
+    Attributes:
+        name (str): the LLM name
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): number of previous messages used in chat
+        _global_context (str): the global context to be provided to the LLM for each request
+        _user_context (dict): user specific context to be provided to the LLM for each request
+    """
+
+    def __init__(self, agent: 'Agent', name: str, parameters: dict, num_previous_messages: int = 1,
+                 global_context: str = None):
+        super().__init__(name, agent, parameters, global_context=global_context)
+        self.agent: 'Agent' = agent
+        self.num_previous_messages: int = num_previous_messages
+
+    def set_model(self, name: str) -> None:
+        """Set the LLM model name.
+
+        Args:
+            name (str): the new LLM name
+        """
+        self.name = name
+
+    def set_num_previous_messages(self, num_previous_messages: int) -> None:
+        """Set the number of previous messages to use in the chat functionality
+
+        Args:
+            num_previous_messages (int): the new number of previous messages
+        """
+        self.num_previous_messages = num_previous_messages
+
+
+class LLMMeta(LLMWrapper):
+    """An LLM wrapper for Meta Llama models via Meta's hosted OpenAI-compatible API.
+
+    Args:
+        agent (Agent): the agent the LLM belongs to
+        name (str): the LLM name / model identifier (e.g. ``"Llama-3.3-70B-Instruct"``)
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): for the chat functionality, the number of previous messages of the conversation
+            to add to the prompt context (must be > 0)
+        global_context (str): the global context to be provided to the LLM for each request
+
+    Attributes:
+        name (str): the LLM name
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): number of previous messages used in chat
+        _global_context (str): the global context to be provided to the LLM for each request
+        _user_context (dict): user specific context to be provided to the LLM for each request
+    """
+
+    def __init__(self, agent: 'Agent', name: str, parameters: dict, num_previous_messages: int = 1,
+                 global_context: str = None):
+        super().__init__(name, agent, parameters, global_context=global_context)
+        self.agent: 'Agent' = agent
+        self.num_previous_messages: int = num_previous_messages
+
+    def set_model(self, name: str) -> None:
+        """Set the LLM model name.
+
+        Args:
+            name (str): the new LLM name
+        """
+        self.name = name
+
+    def set_num_previous_messages(self, num_previous_messages: int) -> None:
+        """Set the number of previous messages to use in the chat functionality
+
+        Args:
+            num_previous_messages (int): the new number of previous messages
+        """
+        self.num_previous_messages = num_previous_messages
+
+
+class LLMAnthropic(LLMWrapper):
+    """An LLM wrapper for Anthropic Claude models using the native anthropic SDK.
+
+    Args:
+        agent (Agent): the agent the LLM belongs to
+        name (str): the LLM name / model identifier (e.g. ``"claude-opus-4-5"``)
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): for the chat functionality, the number of previous messages of the conversation
+            to add to the prompt context (must be > 0)
+        global_context (str): the global context to be provided to the LLM for each request
+
+    Attributes:
+        name (str): the LLM name
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): number of previous messages used in chat
+        _global_context (str): the global context to be provided to the LLM for each request
+        _user_context (dict): user specific context to be provided to the LLM for each request
+    """
+
+    def __init__(self, agent: 'Agent', name: str, parameters: dict, num_previous_messages: int = 1,
+                 global_context: str = None):
+        super().__init__(name, agent, parameters, global_context=global_context)
+        self.agent: 'Agent' = agent
+        self.num_previous_messages: int = num_previous_messages
+
+    def set_model(self, name: str) -> None:
+        """Set the LLM model name.
+
+        Args:
+            name (str): the new LLM name
+        """
+        self.name = name
+
+    def set_num_previous_messages(self, num_previous_messages: int) -> None:
+        """Set the number of previous messages to use in the chat functionality
+
+        Args:
+            num_previous_messages (int): the new number of previous messages
+        """
+        self.num_previous_messages = num_previous_messages
+
+
+class LLMQwen(LLMWrapper):
+    """An LLM wrapper for Alibaba Qwen models via DashScope's OpenAI-compatible endpoint.
+
+    Args:
+        agent (Agent): the agent the LLM belongs to
+        name (str): the LLM name / model identifier (e.g. ``"qwen-max"``)
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): for the chat functionality, the number of previous messages of the conversation
+            to add to the prompt context (must be > 0)
+        global_context (str): the global context to be provided to the LLM for each request
+
+    Attributes:
+        name (str): the LLM name
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): number of previous messages used in chat
+        _global_context (str): the global context to be provided to the LLM for each request
+        _user_context (dict): user specific context to be provided to the LLM for each request
+    """
+
+    def __init__(self, agent: 'Agent', name: str, parameters: dict, num_previous_messages: int = 1,
+                 global_context: str = None):
+        super().__init__(name, agent, parameters, global_context=global_context)
+        self.agent: 'Agent' = agent
+        self.num_previous_messages: int = num_previous_messages
+
+    def set_model(self, name: str) -> None:
+        """Set the LLM model name.
+
+        Args:
+            name (str): the new LLM name
+        """
+        self.name = name
+
+    def set_num_previous_messages(self, num_previous_messages: int) -> None:
+        """Set the number of previous messages to use in the chat functionality
+
+        Args:
+            num_previous_messages (int): the new number of previous messages
+        """
+        self.num_previous_messages = num_previous_messages
+
+
+class LLMxAI(LLMWrapper):
+    """An LLM wrapper for xAI Grok models via xAI's OpenAI-compatible API.
+
+    Args:
+        agent (Agent): the agent the LLM belongs to
+        name (str): the LLM name / model identifier (e.g. ``"grok-3-mini"``)
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): for the chat functionality, the number of previous messages of the conversation
+            to add to the prompt context (must be > 0)
+        global_context (str): the global context to be provided to the LLM for each request
+
+    Attributes:
+        name (str): the LLM name
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): number of previous messages used in chat
+        _global_context (str): the global context to be provided to the LLM for each request
+        _user_context (dict): user specific context to be provided to the LLM for each request
+    """
+
+    def __init__(self, agent: 'Agent', name: str, parameters: dict, num_previous_messages: int = 1,
+                 global_context: str = None):
+        super().__init__(name, agent, parameters, global_context=global_context)
+        self.agent: 'Agent' = agent
+        self.num_previous_messages: int = num_previous_messages
+
+    def set_model(self, name: str) -> None:
+        """Set the LLM model name.
+
+        Args:
+            name (str): the new LLM name
+        """
+        self.name = name
+
+    def set_num_previous_messages(self, num_previous_messages: int) -> None:
+        """Set the number of previous messages to use in the chat functionality
+
+        Args:
+            num_previous_messages (int): the new number of previous messages
+        """
+        self.num_previous_messages = num_previous_messages
+
+
+class LLMGroq(LLMWrapper):
+    """An LLM wrapper for Groq-hosted models via Groq's OpenAI-compatible API.
+
+    Args:
+        agent (Agent): the agent the LLM belongs to
+        name (str): the LLM name / model identifier (e.g. ``"llama-3.3-70b-versatile"``)
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): for the chat functionality, the number of previous messages of the conversation
+            to add to the prompt context (must be > 0)
+        global_context (str): the global context to be provided to the LLM for each request
+
+    Attributes:
+        name (str): the LLM name
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): number of previous messages used in chat
+        _global_context (str): the global context to be provided to the LLM for each request
+        _user_context (dict): user specific context to be provided to the LLM for each request
+    """
+
+    def __init__(self, agent: 'Agent', name: str, parameters: dict, num_previous_messages: int = 1,
+                 global_context: str = None):
+        super().__init__(name, agent, parameters, global_context=global_context)
+        self.agent: 'Agent' = agent
+        self.num_previous_messages: int = num_previous_messages
+
+    def set_model(self, name: str) -> None:
+        """Set the LLM model name.
+
+        Args:
+            name (str): the new LLM name
+        """
+        self.name = name
+
+    def set_num_previous_messages(self, num_previous_messages: int) -> None:
+        """Set the number of previous messages to use in the chat functionality
+
+        Args:
+            num_previous_messages (int): the new number of previous messages
+        """
+        self.num_previous_messages = num_previous_messages
+
+
+class LLMTogether(LLMWrapper):
+    """An LLM wrapper for Together AI-hosted models via Together's OpenAI-compatible API.
+
+    Args:
+        agent (Agent): the agent the LLM belongs to
+        name (str): the LLM name / model identifier (e.g. ``"meta-llama/Llama-3.3-70B-Instruct-Turbo"``)
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): for the chat functionality, the number of previous messages of the conversation
+            to add to the prompt context (must be > 0)
+        global_context (str): the global context to be provided to the LLM for each request
+
+    Attributes:
+        name (str): the LLM name
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): number of previous messages used in chat
+        _global_context (str): the global context to be provided to the LLM for each request
+        _user_context (dict): user specific context to be provided to the LLM for each request
+    """
+
+    def __init__(self, agent: 'Agent', name: str, parameters: dict, num_previous_messages: int = 1,
+                 global_context: str = None):
+        super().__init__(name, agent, parameters, global_context=global_context)
+        self.agent: 'Agent' = agent
+        self.num_previous_messages: int = num_previous_messages
+
+    def set_model(self, name: str) -> None:
+        """Set the LLM model name.
+
+        Args:
+            name (str): the new LLM name
+        """
+        self.name = name
+
+    def set_num_previous_messages(self, num_previous_messages: int) -> None:
+        """Set the number of previous messages to use in the chat functionality
+
+        Args:
+            num_previous_messages (int): the new number of previous messages
+        """
+        self.num_previous_messages = num_previous_messages
+
+
+class LLMOpenRouter(LLMWrapper):
+    """An LLM wrapper for models accessed via OpenRouter's OpenAI-compatible API.
+
+    OpenRouter provides a unified gateway to hundreds of models from many providers.
+
+    Args:
+        agent (Agent): the agent the LLM belongs to
+        name (str): the LLM name / model identifier in OpenRouter format
+            (e.g. ``"anthropic/claude-opus-4"``, ``"openai/gpt-4o"``)
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): for the chat functionality, the number of previous messages of the conversation
+            to add to the prompt context (must be > 0)
+        global_context (str): the global context to be provided to the LLM for each request
+
+    Attributes:
+        name (str): the LLM name
+        parameters (dict): the LLM parameters
+        num_previous_messages (int): number of previous messages used in chat
+        _global_context (str): the global context to be provided to the LLM for each request
+        _user_context (dict): user specific context to be provided to the LLM for each request
+    """
+
+    def __init__(self, agent: 'Agent', name: str, parameters: dict, num_previous_messages: int = 1,
+                 global_context: str = None):
+        super().__init__(name, agent, parameters, global_context=global_context)
+        self.agent: 'Agent' = agent
+        self.num_previous_messages: int = num_previous_messages
+
+    def set_model(self, name: str) -> None:
+        """Set the LLM model name.
+
+        Args:
+            name (str): the new LLM name
+        """
+        self.name = name
+
+    def set_num_previous_messages(self, num_previous_messages: int) -> None:
+        """Set the number of previous messages to use in the chat functionality
+
+        Args:
+            num_previous_messages (int): the new number of previous messages
+        """
+        self.num_previous_messages = num_previous_messages
+
+
 class RAGVectorStore:
     """Declarative description of a vector store used by a RAG pipeline.
 
@@ -2268,6 +2691,16 @@ Agent._LLM_PROVIDERS = {
     "huggingface": LLMHuggingFace,
     "huggingface_api": LLMHuggingFaceAPI,
     "replicate": LLMReplicate,
+    "mistral": LLMMistral,
+    "deepseek": LLMDeepSeek,
+    "google": LLMGoogle,
+    "meta": LLMMeta,
+    "anthropic": LLMAnthropic,
+    "qwen": LLMQwen,
+    "xai": LLMxAI,
+    "groq": LLMGroq,
+    "together": LLMTogether,
+    "openrouter": LLMOpenRouter,
 }
 
 

--- a/besser/BUML/metamodel/state_machine/agent.py
+++ b/besser/BUML/metamodel/state_machine/agent.py
@@ -2372,13 +2372,12 @@ class Agent(StateMachine):
     ) -> 'LLMWrapper':
         """Register an LLM on the agent and return the :class:`LLMWrapper` instance.
 
-        ``provider`` selects the concrete subclass: ``openai`` →
-        :class:`LLMOpenAI`, ``huggingface`` → :class:`LLMHuggingFace`,
-        ``huggingface_api`` → :class:`LLMHuggingFaceAPI`,
-        ``replicate`` → :class:`LLMReplicate`,
-        ``ollama`` → :class:`LLMOllama`. Names must be unique on the
-        agent so other elements (reasoning states, RAG, replies, intent
-        classifiers) can reference the LLM by ``llm_name``.
+        ``provider`` selects the concrete :class:`LLMWrapper` subclass via
+        :attr:`Agent._LLM_PROVIDERS`; ``sorted(Agent._LLM_PROVIDERS)`` is the
+        authoritative list of accepted keys (the :class:`ValueError` raised below
+        reports it). Names must be unique on the agent so other elements
+        (reasoning states, RAG, replies, intent classifiers) can reference the
+        LLM by ``llm_name``.
         """
         if any(existing.name == name for existing in self.llms):
             raise ValueError(

--- a/besser/generators/agents/templates/baf_agent_template.py.j2
+++ b/besser/generators/agents/templates/baf_agent_template.py.j2
@@ -13,6 +13,16 @@ from baf.nlp.llm.llm_huggingface import LLMHuggingFace
 from baf.nlp.llm.llm_huggingface_api import LLMHuggingFaceAPI
 from baf.nlp.llm.llm_openai_api import LLMOpenAI
 from baf.nlp.llm.llm_replicate_api import LLMReplicate
+from baf.nlp.llm.llm_mistral import LLMMistral
+from baf.nlp.llm.llm_deepseek import LLMDeepSeek
+from baf.nlp.llm.llm_google import LLMGoogle
+from baf.nlp.llm.llm_meta import LLMMeta
+from baf.nlp.llm.llm_anthropic import LLMAnthropic
+from baf.nlp.llm.llm_qwen import LLMQwen
+from baf.nlp.llm.llm_xai import LLMxAI
+from baf.nlp.llm.llm_groq import LLMGroq
+from baf.nlp.llm.llm_together import LLMTogether
+from baf.nlp.llm.llm_openrouter import LLMOpenRouter
 from baf.core.session import Session
 from baf.nlp.intent_classifier.intent_classifier_configuration import LLMIntentClassifierConfiguration, SimpleIntentClassifierConfiguration
 from baf.nlp.speech2text.openai_speech2text import OpenAISpeech2Text

--- a/besser/generators/agents/templates/baf_config_template.py.j2
+++ b/besser/generators/agents/templates/baf_config_template.py.j2
@@ -13,6 +13,26 @@ nlp:
     api_key: YOUR-API-KEY
   replicate:
     api_key: YOUR-API-KEY
+  mistral:
+    api_key: YOUR-API-KEY
+  deepseek:
+    api_key: YOUR-API-KEY
+  google:
+    api_key: YOUR-API-KEY
+  meta:
+    api_key: YOUR-API-KEY
+  anthropic:
+    api_key: YOUR-API-KEY
+  qwen:
+    api_key: YOUR-API-KEY
+  xai:
+    api_key: YOUR-API-KEY
+  groq:
+    api_key: YOUR-API-KEY
+  together:
+    api_key: YOUR-API-KEY
+  openrouter:
+    api_key: YOUR-API-KEY
 
 platforms:
   websocket:

--- a/besser/utilities/buml_code_builder/agent_model_builder.py
+++ b/besser/utilities/buml_code_builder/agent_model_builder.py
@@ -58,6 +58,8 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
             "WebSocketReplyOptions, WebSocketReplyLocation, "
             "WebSocketReplyFile, WebSocketReplyImage, WebSocketReplyDataframe, WebSocketReplyPlotly, "
             "LLMOpenAI, LLMHuggingFace, LLMHuggingFaceAPI, LLMReplicate, "
+            "LLMMistral, LLMDeepSeek, LLMGoogle, LLMMeta, LLMAnthropic, "
+            "LLMQwen, LLMxAI, LLMGroq, LLMTogether, LLMOpenRouter, "
             "RAGVectorStore, RAGTextSplitter, "
             "Tool, Skill, Workspace, ReasoningState, "
             "ReceiveTextEvent, ReceiveFileEvent, ReceiveJSONEvent, "

--- a/besser/utilities/web_modeling_editor/backend/routers/generation_router.py
+++ b/besser/utilities/web_modeling_editor/backend/routers/generation_router.py
@@ -179,10 +179,14 @@ async def recommend_agent_config_llm(
     profile_document = _generate_user_profile_document(user_profile_model)
     default_config = load_default_agent_recommendation_config()
 
+    # Provider choice and every per-provider model list are excluded: this prompt
+    # flow does not recommend the LLM provider, so shipping the model catalogues
+    # would only add noise. Matching on the "Models" suffix keeps this correct as
+    # new providers are added, instead of a hand-maintained key list.
     allowed_values_payload = {
         key: value
         for key, value in RECOMMENDATION_ALLOWED_VALUES.items()
-        if key not in {"llmProvider", "openaiModels"}
+        if key != "llmProvider" and not key.endswith("Models")
     }
 
     system_prompt = (

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
@@ -870,6 +870,16 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
             "LLMHuggingFace": "huggingface",
             "LLMHuggingFaceAPI": "huggingface_api",
             "LLMReplicate": "replicate",
+            "LLMMistral": "mistral",
+            "LLMDeepSeek": "deepseek",
+            "LLMGoogle": "google",
+            "LLMMeta": "meta",
+            "LLMAnthropic": "anthropic",
+            "LLMQwen": "qwen",
+            "LLMxAI": "xai",
+            "LLMGroq": "groq",
+            "LLMTogether": "together",
+            "LLMOpenRouter": "openrouter",
         }
 
         def _collect_llm_kwargs(call: ast.Call) -> Dict[str, Any]:

--- a/besser/utilities/web_modeling_editor/backend/services/utils/agent_config_recommendation_utils.py
+++ b/besser/utilities/web_modeling_editor/backend/services/utils/agent_config_recommendation_utils.py
@@ -30,8 +30,22 @@ RECOMMENDATION_ALLOWED_VALUES = {
     "responseTiming": ["instant", "delayed"],
     "agentPlatform": ["websocket", "streamlit", "telegram"],
     "intentRecognitionTechnology": ["classical", "llm-based"],
-    "llmProvider": ["openai", "huggingface", "huggingfaceapi", "replicate"],
+    "llmProvider": [
+        "openai", "huggingface", "huggingface_api", "replicate",
+        "mistral", "deepseek", "google", "meta", "anthropic",
+        "qwen", "xai", "groq", "together", "openrouter",
+    ],
     "openaiModels": ["gpt-5.5", "gpt-5", "gpt-5-mini", "gpt-5-nano"],
+    "mistralModels": ["mistral-small-latest", "mistral-large-latest", "open-mistral-nemo"],
+    "deepseekModels": ["deepseek-chat", "deepseek-reasoner"],
+    "googleModels": ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"],
+    "metaModels": ["Llama-3.3-70B-Instruct", "Llama-4-Scout-17B-16E-Instruct-FP8"],
+    "anthropicModels": ["claude-opus-4-5", "claude-sonnet-4-5", "claude-haiku-4-5-20251001"],
+    "qwenModels": ["qwen-max", "qwen-plus", "qwen-turbo"],
+    "xaiModels": ["grok-3", "grok-3-mini", "grok-2-latest"],
+    "groqModels": ["llama-3.3-70b-versatile", "gemma2-9b-it", "mixtral-8x7b-32768"],
+    "togetherModels": ["meta-llama/Llama-3.3-70B-Instruct-Turbo", "Qwen/Qwen2.5-72B-Instruct-Turbo"],
+    "openrouterModels": ["anthropic/claude-opus-4", "google/gemini-2.5-pro", "openai/gpt-4o"],
 }
 
 

--- a/besser/utilities/web_modeling_editor/backend/services/utils/agent_config_recommendation_utils.py
+++ b/besser/utilities/web_modeling_editor/backend/services/utils/agent_config_recommendation_utils.py
@@ -30,6 +30,9 @@ RECOMMENDATION_ALLOWED_VALUES = {
     "responseTiming": ["instant", "delayed"],
     "agentPlatform": ["websocket", "streamlit", "telegram"],
     "intentRecognitionTechnology": ["classical", "llm-based"],
+    # "huggingfaceapi" (no underscore) is the legacy spelling still emitted by saved
+    # frontend configs; it is kept alongside the canonical "huggingface_api" so that
+    # normalize_recommended_agent_config() does not silently drop an existing provider.
     "llmProvider": [
         "openai", "huggingface", "huggingface_api", "huggingfaceapi", "replicate", "ollama",
         "mistral", "deepseek", "google", "meta", "anthropic",

--- a/docs/source/generators/agent_personalization.rst
+++ b/docs/source/generators/agent_personalization.rst
@@ -86,8 +86,20 @@ The full list of allowed values is defined in
 - ``responseTiming``: ``instant``, ``delayed``
 - ``agentPlatform``: ``websocket``, ``streamlit``, ``telegram``
 - ``intentRecognitionTechnology``: ``classical``, ``llm-based``
-- ``llmProvider``: ``openai``, ``huggingface``, ``huggingfaceapi``, ``replicate``
+- ``llmProvider``: ``openai``, ``huggingface``, ``huggingface_api``, ``replicate``,
+  ``mistral``, ``deepseek``, ``google``, ``meta``, ``anthropic``,
+  ``qwen``, ``xai``, ``groq``, ``together``, ``openrouter``
 - ``openaiModels``: ``gpt-5``, ``gpt-5-mini``, ``gpt-5-nano``
+- ``mistralModels``: ``mistral-small-latest``, ``mistral-large-latest``, ``open-mistral-nemo``
+- ``deepseekModels``: ``deepseek-chat``, ``deepseek-reasoner``
+- ``googleModels``: ``gemini-2.5-pro``, ``gemini-2.5-flash``, ``gemini-2.0-flash``
+- ``metaModels``: ``Llama-3.3-70B-Instruct``, ``Llama-4-Scout-17B-16E-Instruct-FP8``
+- ``anthropicModels``: ``claude-opus-4-5``, ``claude-sonnet-4-5``, ``claude-haiku-4-5-20251001``
+- ``qwenModels``: ``qwen-max``, ``qwen-plus``, ``qwen-turbo``
+- ``xaiModels``: ``grok-3``, ``grok-3-mini``, ``grok-2-latest``
+- ``groqModels``: ``llama-3.3-70b-versatile``, ``gemma2-9b-it``, ``mixtral-8x7b-32768``
+- ``togetherModels``: ``meta-llama/Llama-3.3-70B-Instruct-Turbo``, ``Qwen/Qwen2.5-72B-Instruct-Turbo``
+- ``openrouterModels``: ``anthropic/claude-opus-4``, ``google/gemini-2.5-pro``, ``openai/gpt-4o``
 
 .. note::
 

--- a/tests/utilities/web_modeling_editor/backend/services/converters/test_agent_converter_roundtrip.py
+++ b/tests/utilities/web_modeling_editor/backend/services/converters/test_agent_converter_roundtrip.py
@@ -1,11 +1,13 @@
 """Round-trip tests for the agent converters covering the multi-LLM and
-reasoning-extension surface added in 7.8.0.
+reasoning-extension surface, plus the ten new provider families added in 7.9.0.
 
 Direction exercised: Agent (B-UML) -> generated B-UML code -> JSON (buml_to_json)
 -> Agent (json_to_buml). The new fields (multiple LLMs + designated default,
 per-reasoning-state LLM, tools/skills/workspaces) must survive the trip.
 """
 import os
+
+import pytest
 
 from besser.BUML.metamodel.state_machine.agent import Agent, RAGReply, RAGTextSplitter, RAGVectorStore, ReasoningState
 from besser.BUML.metamodel.state_machine.state_machine import Body
@@ -107,4 +109,94 @@ def test_agent_roundtrip_preserves_multi_llm_and_reasoning(tmp_path):
     assert len(rag_actions) == 1
     assert rag_actions[0].rag_db_name == "docs_rag"
     assert rag_actions[0].prompt == "Use only cited docs."
+
+
+# ---------------------------------------------------------------------------
+# New LLM provider round-trip — parametrized over all 10 new families
+# ---------------------------------------------------------------------------
+
+_NEW_PROVIDERS = [
+    "mistral",
+    "deepseek",
+    "google",
+    "meta",
+    "anthropic",
+    "qwen",
+    "xai",
+    "groq",
+    "together",
+    "openrouter",
+]
+
+# Representative model names per provider (used as the 'model' parameter so the
+# generated code is realistic, not just a bare empty-parameters instantiation).
+_PROVIDER_MODEL = {
+    "mistral": "mistral-small-latest",
+    "deepseek": "deepseek-chat",
+    "google": "gemini-2.5-flash",
+    "meta": "Llama-3.3-70B-Instruct",
+    "anthropic": "claude-sonnet-4-5",
+    "qwen": "qwen-plus",
+    "xai": "grok-3-mini",
+    "groq": "llama-3.3-70b-versatile",
+    "together": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    "openrouter": "openai/gpt-4o",
+}
+
+# Exact class names as they appear in generated imports (non-trivial capitalisation).
+_PROVIDER_CLASS = {
+    "mistral": "LLMMistral",
+    "deepseek": "LLMDeepSeek",
+    "google": "LLMGoogle",
+    "meta": "LLMMeta",
+    "anthropic": "LLMAnthropic",
+    "qwen": "LLMQwen",
+    "xai": "LLMxAI",
+    "groq": "LLMGroq",
+    "together": "LLMTogether",
+    "openrouter": "LLMOpenRouter",
+}
+
+
+@pytest.mark.parametrize("provider", _NEW_PROVIDERS)
+def test_new_provider_roundtrip_preserves_provider_key(provider, tmp_path):
+    """Agent (B-UML) → code → JSON → Agent: provider key and model survive intact.
+
+    This catches missing or misnamed entries in _LLM_PROVIDERS, _direct_llm_class_to_provider,
+    and the generator import block — all of which would break the round-trip silently.
+    """
+    model = _PROVIDER_MODEL[provider]
+    agent = Agent(f"agent_{provider}")
+    agent.new_llm(name="main_llm", provider=provider, parameters={"model": model})
+
+    code_path = os.path.join(str(tmp_path), "agent.py")
+    from besser.utilities.buml_code_builder.agent_model_builder import agent_model_to_code
+    from besser.utilities.web_modeling_editor.backend.services.converters import (
+        agent_buml_to_json,
+        process_agent_diagram,
+    )
+
+    agent_model_to_code(agent, code_path)
+    with open(code_path, encoding="utf-8") as fh:
+        code = fh.read()
+
+    # The generated code must import the correct provider class.
+    expected_class = _PROVIDER_CLASS[provider]
+    assert expected_class in code, (
+        f"Generated agent.py for provider '{provider}' missing import of '{expected_class}'"
+    )
+
+    json_model = agent_buml_to_json(code)
+    restored = process_agent_diagram({"model": json_model, "config": json_model.get("config", {})})
+
+    # Exactly one LLM must survive with its original name.
+    assert len(list(restored.llms)) == 1
+    llm = next(iter(restored.llms))
+    assert llm.name == "main_llm"
+
+    # The model parameter must be preserved through the round-trip.
+    assert llm.parameters.get("model") == model, (
+        f"model parameter lost for provider '{provider}': "
+        f"expected {model!r}, got {llm.parameters.get('model')!r}"
+    )
 

--- a/tests/utilities/web_modeling_editor/backend/services/converters/test_agent_converter_roundtrip.py
+++ b/tests/utilities/web_modeling_editor/backend/services/converters/test_agent_converter_roundtrip.py
@@ -194,6 +194,13 @@ def test_new_provider_roundtrip_preserves_provider_key(provider, tmp_path):
     llm = next(iter(restored.llms))
     assert llm.name == "main_llm"
 
+    # The restored object must be the *correct* LLMWrapper subclass. Without this,
+    # a wrong entry in _direct_llm_class_to_provider (e.g. LLMMistral -> "deepseek")
+    # would still satisfy the name/parameter assertions below and pass silently.
+    assert type(llm).__name__ == expected_class, (
+        f"provider '{provider}' round-tripped to {type(llm).__name__}, expected {expected_class}"
+    )
+
     # The model parameter must be preserved through the round-trip.
     assert llm.parameters.get("model") == model, (
         f"model parameter lost for provider '{provider}': "

--- a/tests/utilities/web_modeling_editor/backend/services/utils/test_agent_config_recommendation_utils.py
+++ b/tests/utilities/web_modeling_editor/backend/services/utils/test_agent_config_recommendation_utils.py
@@ -240,3 +240,39 @@ def test_normalize_llm_block_keeps_known_provider():
     raw = {"system": {"llm": {"provider": "openai", "model": "gpt-5-mini"}}}
     out = normalize_recommended_agent_config(raw, None)
     assert out["system"]["llm"] == {"provider": "openai", "model": "gpt-5-mini"}
+
+
+# ---------------------------------------------------------------------------
+# New provider families — all 10 must be accepted by the allow-list
+# ---------------------------------------------------------------------------
+
+_NEW_PROVIDERS_AND_MODELS = [
+    ("mistral", "mistral-small-latest"),
+    ("deepseek", "deepseek-chat"),
+    ("google", "gemini-2.5-flash"),
+    ("meta", "Llama-3.3-70B-Instruct"),
+    ("anthropic", "claude-sonnet-4-5"),
+    ("qwen", "qwen-plus"),
+    ("xai", "grok-3-mini"),
+    ("groq", "llama-3.3-70b-versatile"),
+    ("together", "meta-llama/Llama-3.3-70B-Instruct-Turbo"),
+    ("openrouter", "openai/gpt-4o"),
+]
+
+
+@pytest.mark.parametrize("provider,model", _NEW_PROVIDERS_AND_MODELS)
+def test_normalize_llm_block_keeps_new_providers(provider, model):
+    """New provider keys must not be coerced to {} by normalize_recommended_agent_config."""
+    raw = {"system": {"llm": {"provider": provider, "model": model}}}
+    out = normalize_recommended_agent_config(raw, None)
+    assert out["system"]["llm"] == {"provider": provider, "model": model}, (
+        f"provider '{provider}' was rejected — add it to RECOMMENDATION_ALLOWED_VALUES['llmProvider']"
+    )
+
+
+@pytest.mark.parametrize("provider,_model", _NEW_PROVIDERS_AND_MODELS)
+def test_new_providers_in_recommendation_allowed_values(provider, _model):
+    """Every new provider key must appear in the RECOMMENDATION_ALLOWED_VALUES allow-list."""
+    assert provider in RECOMMENDATION_ALLOWED_VALUES["llmProvider"], (
+        f"'{provider}' missing from RECOMMENDATION_ALLOWED_VALUES['llmProvider']"
+    )


### PR DESCRIPTION
## Summary
- Adds 10 `LLMWrapper` subclasses to the agent metamodel
  (`LLMMistral`, `LLMDeepSeek`, `LLMGoogle`, `LLMMeta`, `LLMAnthropic`, `LLMQwen`,
  `LLMxAI`, `LLMGroq`, `LLMTogether`, `LLMOpenRouter`) — class names match the BAF
  runtime class names exactly, as required by the Jinja template.
- Extends `Agent._LLM_PROVIDERS` from 4 to 14 entries; `new_llm()` and
  `llm_provider_key()` work for all new families automatically.
- Updates `baf_agent_template.py.j2` with import lines for all new provider classes.
- Updates `baf_config_template.py.j2` with `api_key: YOUR-API-KEY` stanzas for each
  new provider under the `nlp:` block.
- Extends `agent_model_builder.py` import string and `agent_diagram_converter.py`
  `_direct_llm_class_to_provider` reverse map for round-trip consistency.
- Extends `agent_config_recommendation_utils.py` provider allow-list with model name
  suggestions per new family.
  

## Related PRs:
- BAF PR: [195](https://github.com/BESSER-PEARL/BESSER-Agentic-Framework/pull/195)
- WME PR: [162](https://github.com/BESSER-PEARL/BESSER-Web-Modeling-Editor/pull/162)