### PR TITLE
refactor(gui-personalization): extract endpoint to a module + fix model defaults

### DIFF
--- a/besser/generators/agents/agent_personalization.py
+++ b/besser/generators/agents/agent_personalization.py
@@ -9,6 +9,9 @@ logger = logging.getLogger(__name__)
 
 OPENAI_API_KEY_ENV_VAR = "OPENAI_API_KEY"
 
+# Single default model for all OpenAI-backed personalization helpers.
+DEFAULT_OPENAI_MODEL = "gpt-5"
+
 
 def _resolve_openai_api_key(config: dict = None, openai_api_key: str = None) -> str | None:
     if isinstance(openai_api_key, str) and openai_api_key.strip():
@@ -80,7 +83,7 @@ def flatten_agent_config_structure(raw_config):
     return flattened
 
 
-def call_openai_chat(system_prompt, user_prompt, model="gpt-5.4-mini", openai_api_key=None, config=None):
+def call_openai_chat(system_prompt, user_prompt, model=DEFAULT_OPENAI_MODEL, openai_api_key=None, config=None):
     """
     Calls OpenAI ChatCompletion with a system prompt and user prompt (openai>=1.0.0).
     Returns the response text only.
@@ -97,7 +100,6 @@ def call_openai_chat(system_prompt, user_prompt, model="gpt-5.4-mini", openai_ap
         raise ImportError(
             "OpenAI personalization requires the 'agents' extra: pip install besser[agents]"
         ) from exc
-    print("calling now")
     client = OpenAI(api_key=resolved_api_key)
     response = client.chat.completions.create(
         model=model,
@@ -112,9 +114,9 @@ def call_openai_chat(system_prompt, user_prompt, model="gpt-5.4-mini", openai_ap
 
 
 
-def translate_text_batch(texts, target_language, model="gpt-5.4-mini", openai_api_key=None, config=None):
+def translate_text_batch(texts, target_language, model=DEFAULT_OPENAI_MODEL, openai_api_key=None, config=None):
     """
-    Translates each text in `texts` to the target language using OpenAI gpt-5.4-mini.
+    Translates each text in `texts` to the target language using OpenAI.
     Returns a list of translated texts in the same order as input.
     """
     if not isinstance(texts, (list, tuple)):
@@ -171,7 +173,7 @@ def translate_text_api(text, target_language):
 
 
 
-def style_text_batch(texts, style, model="gpt-5.4-mini", openai_api_key=None, config=None):
+def style_text_batch(texts, style, model=DEFAULT_OPENAI_MODEL, openai_api_key=None, config=None):
     """
     Rewrites each text in `texts` to the requested `style` while preserving meaning and content.
     `style` should be one of 'formal', 'informal', 'friendly', or 'technical'.
@@ -332,13 +334,6 @@ def replace_reply_batch(messages: list[str], config: dict, openai_api_key: str =
     config = flatten_agent_config_structure(config or {})
     personalized_messages = messages
 
-    if 'agentLanguage' in config and config['agentLanguage'] != 'none' and False:
-        target_language = config['agentLanguage']
-        # personalized_message = translate_text(personalized_message, target_language)
-    elif 'agentLanguage' in config and config['agentLanguage'] != 'none' and config['agentLanguage'] != 'original' and False:
-        target_language = config['agentLanguage']
-        for i, msg in enumerate(personalized_messages):
-            personalized_messages[i] = translate_text_api(msg, target_language)
     if 'agentLanguage' in config and config['agentLanguage'] != 'none' and config['agentLanguage'] != 'original':
         if not openai_api_key:
             raise RuntimeError(
@@ -423,7 +418,7 @@ def replace_content_profile_batch(messages: list[str], config: dict, openai_api_
 
     model_name = flattened_config.get('llm')
     if not isinstance(model_name, str) or not model_name.strip():
-        model_name = 'gpt-5.4-mini'
+        model_name = DEFAULT_OPENAI_MODEL
     else:
         model_name = model_name.strip()
 
@@ -497,7 +492,7 @@ def append_speech(match):
     text = match.group(1)
     return f"session.reply('{text}')\n    platform.reply_speech(session, '{text}')"
 
-def complexity_text_batch(texts, complexity, model="gpt-5.4-mini", openai_api_key=None, config=None):
+def complexity_text_batch(texts, complexity, model=DEFAULT_OPENAI_MODEL, openai_api_key=None, config=None):
     """
     Adjusts the complexity of each text in `texts` based on the specified `complexity` level.
     Complexity can be "simple", "medium", or "complex".
@@ -553,7 +548,7 @@ def complexity_text_batch(texts, complexity, model="gpt-5.4-mini", openai_api_ke
     return results
 
 
-def sentence_length_batch(texts, preference, model="gpt-5.4-mini", openai_api_key=None, config=None):
+def sentence_length_batch(texts, preference, model=DEFAULT_OPENAI_MODEL, openai_api_key=None, config=None):
     """
     Adjusts each text in `texts` to be more concise or verbose.
     `preference` accepts "concise" or "verbose" (case-insensitive).

--- a/besser/utilities/web_modeling_editor/backend/routers/generation_router.py
+++ b/besser/utilities/web_modeling_editor/backend/routers/generation_router.py
@@ -75,6 +75,9 @@ from besser.utilities.web_modeling_editor.backend.services.utils.user_profile_ut
     normalize_user_model_output as _normalize_user_model_output,
     safe_path as _safe_path,
 )
+from besser.utilities.web_modeling_editor.backend.services.utils.gui_personalization_utils import (
+    personalize_gui_page as run_gui_personalization,
+)
 
 # Backend configuration
 from besser.utilities.web_modeling_editor.backend.config import (
@@ -245,144 +248,27 @@ async def personalize_gui_page(payload: Dict[str, Any] = Body(...)):
     Returns the same ``{components, css}`` shape adapted in style and content,
     ready to be imported back into the editor as a page variant.
     """
-    gui_page = payload.get("guiPage")
-    if not isinstance(gui_page, dict):
-        raise ValidationError(
-            "guiPage is required and must be a JSON object with 'components' and 'css'"
-        )
+    if not isinstance(payload, dict):
+        raise ValidationError("Request body must be a JSON object")
 
-    user_profile_model = payload.get("userProfileModel")
-    if not isinstance(user_profile_model, dict):
-        raise ValidationError("userProfileModel is required and must be a JSON object")
-
-    components = gui_page.get("components")
-    if not isinstance(components, list):
-        raise ValidationError("guiPage.components must be a list")
-    css = gui_page.get("css")
-    if not isinstance(css, list):
-        css = []
-
-    page_name = payload.get("pageName") if isinstance(payload.get("pageName"), str) else "page"
-    requested_model = payload.get("model")
-    llm_model = (
-        requested_model
-        if isinstance(requested_model, str) and requested_model.strip()
-        else "gpt-5.6-luna"
+    # All validation, prompt building, the LLM call and response parsing live in
+    # gui_personalization_utils (mirroring agent_personalization). The router
+    # only resolves the API key, delegates off the event loop, and shapes the
+    # HTTP response; @handle_endpoint_errors maps ValidationError/GenerationError.
+    result = await asyncio.to_thread(
+        run_gui_personalization,
+        payload.get("guiPage"),
+        payload.get("userProfileModel"),
+        page_name=payload.get("pageName"),
+        model=payload.get("model"),
+        openai_api_key=extract_openai_api_key(payload),
     )
-
-    # Transform the user profile (UserDiagram) into its JSON object representation.
-    profile_document = _generate_user_profile_document(user_profile_model)
-
-    system_prompt = (
-        "You are a UI personalization assistant for a GrapesJS-based no-code GUI editor. "
-        "You receive a single GUI page as GrapesJS data: a 'components' array (the component "
-        "tree, each node carrying fields such as type, tagName, attributes, classes, components, "
-        "style, and text content) and a 'css' array (GrapesJS style-rule objects with 'selectors', "
-        "'selectorsAdd', 'style', and 'pageId'). You also receive a user profile model.\n\n"
-        "Your job is to adapt the page's PRESENTATION to this user, making decisions based on the "
-        "information in the profile. Presentation covers both visual styling AND the wording of the "
-        "page — its language, tone, and verbosity. Preserve the page's MEANING (its message, "
-        "purpose, and the information each element conveys), but you MAY re-express that meaning in "
-        "different words when the profile calls for it. When the profile clearly implies a "
-        "preference — for example a single language the user reads, a reading level, or a tone — "
-        "act on it decisively across the WHOLE page rather than leaving the wording unchanged.\n\n"
-        "HOW TO APPLY STYLE — TWO TIERS:\n"
-        "Tier 1 (PREFER THIS): express broad, consistent adaptations as high-level CSS rules keyed "
-        "by semantic category, appended to the 'css' array. Target a category with the "
-        "'selectorsAdd' field (a raw CSS selector string), NOT the 'selectors' array. Useful "
-        "categories: 'body' (base font-size and line-height — most text inherits from here), "
-        "headings ('h1, h2, h3, h4, h5, h6'), buttons ('button, .btn, a.button'), form fields "
-        "('input, textarea, select'), 'label', links ('a'). Many components in this editor ship "
-        "with baked-in inline/id-level styles that would otherwise win the cascade, so EVERY "
-        "declaration in a Tier-1 rule MUST end with '!important' (e.g. {\"font-size\": \"20px "
-        "!important\"}). A single 'body' rule with a larger font-size and line-height is the "
-        "correct way to enlarge text everywhere — do NOT resize each text node individually.\n"
-        "Tier 2 (USE SPARINGLY): for an adaptation a category rule cannot express (e.g. emphasizing "
-        "one specific call-to-action), you MAY edit the 'style' object of individual components in "
-        "the 'components' tree. Keep this to a small, deliberate set of nodes, and append "
-        "'!important' when overriding an existing baked-in value.\n\n"
-        "STRICT OUTPUT RULES: "
-        "1) Return ONLY a single JSON object with EXACTLY this shape: "
-        '{"components": [...], "css": [...]}. No markdown, no comments, no prose. '
-        "2) Preserve the overall structure: keep each component's 'type', 'tagName', and "
-        "'attributes.id' unchanged, and do not add, remove, or reorder components. "
-        "3) You MAY (a) append new high-level rules to the 'css' array, (b) change the 'style' "
-        "objects of existing css rules, (c) change class lists and 'style' objects of individual "
-        "components (Tier 2), and (d) rewrite the user-visible wording of the page — text-node "
-        "content and text-bearing attributes/properties (placeholder, title, alt, aria-label, link "
-        "text, button and field labels) — to translate it or adjust its tone/verbosity. Every "
-        "OTHER value must be byte-for-byte identical to the input. "
-        "3a) Preserve MEANING, not exact words: when you rewrite wording (per 3d) the message, "
-        "purpose, and information of every element must stay identical — translation and "
-        "tone/verbosity changes are allowed, but do NOT add, drop, or alter what the page tells the "
-        "user. A VISUAL adaptation such as enlarging the font is made ENTIRELY through "
-        "'style'/class/CSS-rule changes and must not touch wording; never rewrite text into a "
-        "description of the adaptation (e.g. do NOT turn a heading into 'bigger text for "
-        "readability'). "
-        "4) Keep every EXISTING css rule's 'selectors', 'selectorsAdd', and 'pageId' values exactly "
-        "as given (you may still edit its 'style'). For each NEW Tier-1 rule you add, set "
-        "'selectors' to an empty array and put the category selector in 'selectorsAdd'; you may "
-        "omit 'pageId'. "
-        "5) Return the input page verbatim if the profile gives no basis to adapt the presentation. "
-        "6) The result must be valid JSON, parseable as-is, and remain a working GrapesJS page."
-    )
-    user_prompt = (
-        f'Personalize the GUI page named "{page_name}" for the following user profile model.\n\n'
-        f"User profile model:\n{json.dumps(profile_document, ensure_ascii=False, indent=2)}\n\n"
-        "GUI page to adapt (GrapesJS):\n"
-        f"{json.dumps({'components': components, 'css': css}, ensure_ascii=False)}\n\n"
-        "Make decisions based on the information in the profile. Only adapt something when the "
-        "profile gives a clear reason to. You can assume the profile contains the most important "
-        "information about the user, and anything missing can be assumed absent.\n\n"
-        "Prefer Tier-1 category CSS rules (every declaration ending with '!important') for anything "
-        "that should apply broadly and consistently — e.g. if the user needs larger text, add a "
-        "'body' rule with a larger font-size and line-height rather than resizing individual "
-        "nodes. Use Tier-2 per-component edits only for targeted exceptions. Presentation includes "
-        "textual presentation too (tone, verbosity, language) as long as the core meaning is "
-        "preserved, as well as colors, contrast, font sizing, spacing, and forms. Your goal is the "
-        "best possible experience for this user with all their needs met.\n\n"
-        'Return only the resulting JSON object {"components": [...], "css": [...]}.'
-    )
-
-    try:
-        response_text = await asyncio.to_thread(
-            call_openai_chat,
-            system_prompt,
-            user_prompt,
-            model=llm_model,
-            openai_api_key=extract_openai_api_key(payload if isinstance(payload, dict) else {}),
-            config=payload,
-        )
-        parsed = extract_json_object(response_text)
-        personalized_components = parsed.get("components")
-        personalized_css = parsed.get("css", [])
-        if not isinstance(personalized_components, list):
-            raise GenerationError("LLM response did not include a valid 'components' list")
-        if not isinstance(personalized_css, list):
-            personalized_css = []
-
-        return {
-            "guiPage": {
-                "components": personalized_components,
-                "css": personalized_css,
-            },
-            "source": "openai",
-            "model": llm_model,
-            "generatedAt": _utc_now_iso(),
-        }
-    except RuntimeError as runtime_error:
-        # Raised by call_openai_chat when no OpenAI API key is configured.
-        raise ValidationError(str(runtime_error)) from runtime_error
-    except ValueError as parse_error:
-        logger.exception("Failed to parse LLM personalization response")
-        raise GenerationError("Failed to parse LLM personalization response") from parse_error
-    except (ValidationError, GenerationError):
-        raise
-    except HTTPException:
-        raise
-    except Exception as exc:
-        logger.exception("Failed to personalize GUI page")
-        raise GenerationError("Failed to personalize GUI page") from exc
+    return {
+        "guiPage": {"components": result["components"], "css": result["css"]},
+        "source": "openai",
+        "model": result["model"],
+        "generatedAt": _utc_now_iso(),
+    }
 
 
 @router.get("/agent-config-manual-mapping")

--- a/besser/utilities/web_modeling_editor/backend/services/utils/gui_personalization_utils.py
+++ b/besser/utilities/web_modeling_editor/backend/services/utils/gui_personalization_utils.py
@@ -1,0 +1,182 @@
+"""GUI page personalization via an LLM.
+
+Mirrors the ``agent_personalization`` module pattern: all prompt construction,
+the OpenAI call and response parsing live here so the router stays a thin HTTP
+layer. The router imports :func:`personalize_gui_page` and delegates to it.
+"""
+import json
+import logging
+
+from besser.generators.agents.agent_personalization import (
+    DEFAULT_OPENAI_MODEL,
+    call_openai_chat,
+)
+from besser.utilities.web_modeling_editor.backend.services.exceptions import (
+    GenerationError,
+    ValidationError,
+)
+from besser.utilities.web_modeling_editor.backend.services.utils.agent_config_recommendation_utils import (
+    extract_json_object,
+)
+from besser.utilities.web_modeling_editor.backend.services.utils.user_profile_utils import (
+    generate_user_profile_document,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# LLM instruction for adapting a single GrapesJS page to a user profile.
+# Kept as a module constant so it can be versioned, reviewed and tested in
+# isolation rather than being buried inside a request handler.
+GUI_PERSONALIZATION_SYSTEM_PROMPT = (
+    "You are a UI personalization assistant for a GrapesJS-based no-code GUI editor. "
+    "You receive a single GUI page as GrapesJS data: a 'components' array (the component "
+    "tree, each node carrying fields such as type, tagName, attributes, classes, components, "
+    "style, and text content) and a 'css' array (GrapesJS style-rule objects with 'selectors', "
+    "'selectorsAdd', 'style', and 'pageId'). You also receive a user profile model.\n\n"
+    "Your job is to adapt the page's PRESENTATION to this user, making decisions based on the "
+    "information in the profile. Presentation covers both visual styling AND the wording of the "
+    "page — its language, tone, and verbosity. Preserve the page's MEANING (its message, "
+    "purpose, and the information each element conveys), but you MAY re-express that meaning in "
+    "different words when the profile calls for it. When the profile clearly implies a "
+    "preference — for example a single language the user reads, a reading level, or a tone — "
+    "act on it decisively across the WHOLE page rather than leaving the wording unchanged.\n\n"
+    "HOW TO APPLY STYLE — TWO TIERS:\n"
+    "Tier 1 (PREFER THIS): express broad, consistent adaptations as high-level CSS rules keyed "
+    "by semantic category, appended to the 'css' array. Target a category with the "
+    "'selectorsAdd' field (a raw CSS selector string), NOT the 'selectors' array. Useful "
+    "categories: 'body' (base font-size and line-height — most text inherits from here), "
+    "headings ('h1, h2, h3, h4, h5, h6'), buttons ('button, .btn, a.button'), form fields "
+    "('input, textarea, select'), 'label', links ('a'). Many components in this editor ship "
+    "with baked-in inline/id-level styles that would otherwise win the cascade, so EVERY "
+    "declaration in a Tier-1 rule MUST end with '!important' (e.g. {\"font-size\": \"20px "
+    "!important\"}). A single 'body' rule with a larger font-size and line-height is the "
+    "correct way to enlarge text everywhere — do NOT resize each text node individually.\n"
+    "Tier 2 (USE SPARINGLY): for an adaptation a category rule cannot express (e.g. emphasizing "
+    "one specific call-to-action), you MAY edit the 'style' object of individual components in "
+    "the 'components' tree. Keep this to a small, deliberate set of nodes, and append "
+    "'!important' when overriding an existing baked-in value.\n\n"
+    "STRICT OUTPUT RULES: "
+    "1) Return ONLY a single JSON object with EXACTLY this shape: "
+    '{"components": [...], "css": [...]}. No markdown, no comments, no prose. '
+    "2) Preserve the overall structure: keep each component's 'type', 'tagName', and "
+    "'attributes.id' unchanged, and do not add, remove, or reorder components. "
+    "3) You MAY (a) append new high-level rules to the 'css' array, (b) change the 'style' "
+    "objects of existing css rules, (c) change class lists and 'style' objects of individual "
+    "components (Tier 2), and (d) rewrite the user-visible wording of the page — text-node "
+    "content and text-bearing attributes/properties (placeholder, title, alt, aria-label, link "
+    "text, button and field labels) — to translate it or adjust its tone/verbosity. Every "
+    "OTHER value must be byte-for-byte identical to the input. "
+    "3a) Preserve MEANING, not exact words: when you rewrite wording (per 3d) the message, "
+    "purpose, and information of every element must stay identical — translation and "
+    "tone/verbosity changes are allowed, but do NOT add, drop, or alter what the page tells the "
+    "user. A VISUAL adaptation such as enlarging the font is made ENTIRELY through "
+    "'style'/class/CSS-rule changes and must not touch wording; never rewrite text into a "
+    "description of the adaptation (e.g. do NOT turn a heading into 'bigger text for "
+    "readability'). "
+    "4) Keep every EXISTING css rule's 'selectors', 'selectorsAdd', and 'pageId' values exactly "
+    "as given (you may still edit its 'style'). For each NEW Tier-1 rule you add, set "
+    "'selectors' to an empty array and put the category selector in 'selectorsAdd'; you may "
+    "omit 'pageId'. "
+    "5) Return the input page verbatim if the profile gives no basis to adapt the presentation. "
+    "6) The result must be valid JSON, parseable as-is, and remain a working GrapesJS page."
+)
+
+
+def build_user_prompt(page_name: str, profile_document, components, css) -> str:
+    """Build the per-request user prompt for GUI page personalization."""
+    return (
+        f'Personalize the GUI page named "{page_name}" for the following user profile model.\n\n'
+        f"User profile model:\n{json.dumps(profile_document, ensure_ascii=False, indent=2)}\n\n"
+        "GUI page to adapt (GrapesJS):\n"
+        f"{json.dumps({'components': components, 'css': css}, ensure_ascii=False)}\n\n"
+        "Make decisions based on the information in the profile. Only adapt something when the "
+        "profile gives a clear reason to. You can assume the profile contains the most important "
+        "information about the user, and anything missing can be assumed absent.\n\n"
+        "Prefer Tier-1 category CSS rules (every declaration ending with '!important') for anything "
+        "that should apply broadly and consistently — e.g. if the user needs larger text, add a "
+        "'body' rule with a larger font-size and line-height rather than resizing individual "
+        "nodes. Use Tier-2 per-component edits only for targeted exceptions. Presentation includes "
+        "textual presentation too (tone, verbosity, language) as long as the core meaning is "
+        "preserved, as well as colors, contrast, font sizing, spacing, and forms. Your goal is the "
+        "best possible experience for this user with all their needs met.\n\n"
+        'Return only the resulting JSON object {"components": [...], "css": [...]}.'
+    )
+
+
+def personalize_gui_page(
+    gui_page,
+    user_profile_model,
+    *,
+    page_name: str = "page",
+    model=None,
+    openai_api_key=None,
+) -> dict:
+    """Personalize a single GrapesJS page for a user profile using an LLM.
+
+    Args:
+        gui_page: a GrapesJS page snapshot ``{"components": [...], "css": [...]}``.
+        user_profile_model: a UserDiagram UML model JSON.
+        page_name: the page name (used in the prompt only).
+        model: optional OpenAI model id; falls back to ``DEFAULT_OPENAI_MODEL``.
+        openai_api_key: resolved OpenAI API key (the caller resolves it).
+
+    Returns:
+        ``{"components": [...], "css": [...], "model": <id>}`` — the adapted page
+        plus the model actually used.
+
+    Raises:
+        ValidationError: on malformed input or a missing OpenAI API key.
+        GenerationError: when the LLM response cannot be parsed or is malformed.
+    """
+    if not isinstance(gui_page, dict):
+        raise ValidationError(
+            "guiPage is required and must be a JSON object with 'components' and 'css'"
+        )
+    if not isinstance(user_profile_model, dict):
+        raise ValidationError("userProfileModel is required and must be a JSON object")
+
+    components = gui_page.get("components")
+    if not isinstance(components, list):
+        raise ValidationError("guiPage.components must be a list")
+    css = gui_page.get("css")
+    if not isinstance(css, list):
+        css = []
+
+    if not isinstance(page_name, str) or not page_name.strip():
+        page_name = "page"
+    llm_model = model if isinstance(model, str) and model.strip() else DEFAULT_OPENAI_MODEL
+
+    # Transform the user profile (UserDiagram) into its JSON object representation.
+    profile_document = generate_user_profile_document(user_profile_model)
+    user_prompt = build_user_prompt(page_name, profile_document, components, css)
+
+    try:
+        response_text = call_openai_chat(
+            GUI_PERSONALIZATION_SYSTEM_PROMPT,
+            user_prompt,
+            model=llm_model,
+            openai_api_key=openai_api_key,
+        )
+    except RuntimeError as runtime_error:
+        # Raised by call_openai_chat when no OpenAI API key is configured.
+        raise ValidationError(str(runtime_error)) from runtime_error
+
+    try:
+        parsed = extract_json_object(response_text)
+    except ValueError as parse_error:
+        logger.exception("Failed to parse LLM personalization response")
+        raise GenerationError("Failed to parse LLM personalization response") from parse_error
+
+    personalized_components = parsed.get("components")
+    if not isinstance(personalized_components, list):
+        raise GenerationError("LLM response did not include a valid 'components' list")
+    personalized_css = parsed.get("css", [])
+    if not isinstance(personalized_css, list):
+        personalized_css = []
+
+    return {
+        "components": personalized_components,
+        "css": personalized_css,
+        "model": llm_model,
+    }

--- a/tests/utilities/web_modeling_editor/backend/services/utils/test_gui_personalization.py
+++ b/tests/utilities/web_modeling_editor/backend/services/utils/test_gui_personalization.py
@@ -1,0 +1,101 @@
+"""Tests for gui_personalization_utils.personalize_gui_page.
+
+The OpenAI call is mocked, so these run offline and exercise the validation,
+model-selection, response-parsing and error-mapping logic in isolation.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from besser.utilities.web_modeling_editor.backend.services.utils.gui_personalization_utils import (
+    personalize_gui_page,
+    DEFAULT_OPENAI_MODEL,
+)
+from besser.utilities.web_modeling_editor.backend.services.exceptions import (
+    ValidationError,
+    GenerationError,
+)
+
+MODULE = "besser.utilities.web_modeling_editor.backend.services.utils.gui_personalization_utils"
+
+_PAGE = {"components": [{"type": "text", "content": "Hello"}], "css": []}
+_PROFILE = {"type": "UserDiagram", "elements": {}, "relationships": {}}
+
+
+def _mock_llm(return_value=None, side_effect=None):
+    """Patch both the LLM call and the profile-document builder."""
+    return (
+        patch(f"{MODULE}.call_openai_chat", return_value=return_value, side_effect=side_effect),
+        patch(f"{MODULE}.generate_user_profile_document", return_value={}),
+    )
+
+
+class TestPersonalizeGuiPageValidation:
+    def test_gui_page_must_be_dict(self):
+        with pytest.raises(ValidationError):
+            personalize_gui_page("not-a-dict", _PROFILE)
+
+    def test_user_profile_must_be_dict(self):
+        with pytest.raises(ValidationError):
+            personalize_gui_page(_PAGE, "not-a-dict")
+
+    def test_components_must_be_a_list(self):
+        with pytest.raises(ValidationError):
+            personalize_gui_page({"components": "nope"}, _PROFILE)
+
+    def test_validation_happens_before_any_llm_call(self):
+        # A bad payload must never reach call_openai_chat.
+        with patch(f"{MODULE}.call_openai_chat") as chat:
+            with pytest.raises(ValidationError):
+                personalize_gui_page("bad", _PROFILE)
+        chat.assert_not_called()
+
+
+class TestPersonalizeGuiPageBehavior:
+    def test_happy_path_parses_llm_response(self):
+        llm_out = (
+            '{"components": [{"type": "text", "content": "Bonjour"}], '
+            '"css": [{"selectorsAdd": "body", "style": {"font-size": "20px !important"}}]}'
+        )
+        chat, profile = _mock_llm(return_value=llm_out)
+        with chat as chat_mock, profile:
+            result = personalize_gui_page(_PAGE, _PROFILE, openai_api_key="sk-test")
+        assert result["components"][0]["content"] == "Bonjour"
+        assert result["css"][0]["selectorsAdd"] == "body"
+        assert result["model"] == DEFAULT_OPENAI_MODEL
+        # the shared default model is what was actually sent to OpenAI
+        assert chat_mock.call_args.kwargs["model"] == DEFAULT_OPENAI_MODEL
+
+    def test_explicit_model_overrides_default(self):
+        chat, profile = _mock_llm(return_value='{"components": [], "css": []}')
+        with chat as chat_mock, profile:
+            result = personalize_gui_page(_PAGE, _PROFILE, model="gpt-5-mini", openai_api_key="sk-test")
+        assert result["model"] == "gpt-5-mini"
+        assert chat_mock.call_args.kwargs["model"] == "gpt-5-mini"
+
+    def test_missing_css_defaults_to_empty_list(self):
+        chat, profile = _mock_llm(return_value='{"components": []}')
+        with chat, profile:
+            result = personalize_gui_page(_PAGE, _PROFILE, openai_api_key="sk-test")
+        assert result["css"] == []
+
+
+class TestPersonalizeGuiPageErrors:
+    def test_missing_api_key_becomes_validation_error(self):
+        # call_openai_chat raises RuntimeError when no key is configured.
+        chat, profile = _mock_llm(side_effect=RuntimeError("OpenAI API key not found"))
+        with chat, profile:
+            with pytest.raises(ValidationError):
+                personalize_gui_page(_PAGE, _PROFILE)
+
+    def test_unparseable_llm_response_becomes_generation_error(self):
+        chat, profile = _mock_llm(return_value="this is not json")
+        with chat, profile:
+            with pytest.raises(GenerationError):
+                personalize_gui_page(_PAGE, _PROFILE, openai_api_key="sk-test")
+
+    def test_llm_response_without_components_list_raises(self):
+        chat, profile = _mock_llm(return_value='{"css": []}')
+        with chat, profile:
+            with pytest.raises(GenerationError):
+                personalize_gui_page(_PAGE, _PROFILE, openai_api_key="sk-test")


### PR DESCRIPTION
Cleanup on top of #577, addressing the organization + correctness review. Targets `feature/gui_personalization` so it lands before #577 merges to `development`.

## Organization (the main concern)
The new `/personalize-gui-page` endpoint inlined ~150 lines into `generation_router.py` — validation, a ~40-line LLM system prompt, the OpenAI call and response parsing — which breaks the codebase's own pattern (`agent_personalization.py` holds that logic; the router just calls it).

- **New `services/utils/gui_personalization_utils.py`** — mirrors `agent_personalization`: the system prompt is a **module constant**, and `personalize_gui_page()` owns validation → prompt → LLM call → parse.
- **The router endpoint is now thin** — resolve API key, `asyncio.to_thread(run_gui_personalization, …)`, shape the response; `@handle_endpoint_errors` maps `ValidationError`/`GenerationError`.

## Correctness
- **Model defaults were inconsistent and invalid** — `gpt-5.4-mini` (×7) and `gpt-5.6-luna`, neither a real OpenAI id (would 404 at runtime). Consolidated to a single **`DEFAULT_OPENAI_MODEL = "gpt-5"`** constant, used everywhere.
- Removed a leftover **`print("calling now")`** debug statement.
- Removed two **dead `… and False` branches** in `replace_reply_batch` (a disabled `translate_text_api` experiment).

## Tests
- **`test_gui_personalization.py` — 10 tests** (LLM mocked, offline): input validation, default-vs-explicit model, response parsing, and error mapping (missing key → `ValidationError`, unparseable/invalid response → `GenerationError`).
- Full converter round-trips + agent-personalization + agent-converter suites still pass (94 tests).

## Deliberately left
- The **translate-before-style reorder** in `replace_reply_batch` — appears intentional; flag for @Aran30 to confirm.
- Pre-existing **`gpt-5.5`** default at `generation_router.py:172` (a different, older endpoint) — out of this PR's scope.
- The now-unused `translate_text_api` helper is left in place (removing it is separate).