### PR TITLE
release: v7.14.1 — OCL enforcement, association-class support & dialog UX

### DIFF
--- a/besser/generators/django/django_generator.py
+++ b/besser/generators/django/django_generator.py
@@ -9,6 +9,7 @@ from besser.BUML.metamodel.gui import GUIModel, Module, Button, DataList, DataSo
 from besser.BUML.metamodel.structural import DomainModel, PrimitiveDataType, Enumeration
 from besser.generators import GeneratorInterface
 from besser.generators.pydantic_classes.ocl_utils import build_constraints_map
+from besser.generators.structural_utils import normalize_method_code
 from besser.utilities import sort_by_timestamp
 
 ##############################
@@ -49,6 +50,7 @@ class DjangoGenerator(GeneratorInterface):
         templates_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")
         self.env = Environment(loader=FileSystemLoader(templates_path), trim_blocks=True,
                                lstrip_blocks=True, extensions=['jinja2.ext.do'])
+        self.env.globals.update(normalize_code=normalize_method_code)
         # Register custom Jinja2 tests once for all methods
         self.env.tests['is_Button'] = self.is_button
         self.env.tests['is_List'] = self.is_list

--- a/besser/generators/django/templates/models.py.j2
+++ b/besser/generators/django/templates/models.py.j2
@@ -140,7 +140,7 @@ class {{ class_obj.name }}({{ inheritance | default('models.Model', true) }}):
     {%- for method in sort_by_timestamp(class_obj.methods) %}
     {%- if method.code %}
     {#- If method has code, use it directly (it should contain the full function definition) #}
-{{ method.code | indent(4, first=true) }}
+{{ normalize_code(method.code, method.name) | indent(4, first=true) }}
     {%- else %}
     {#- Otherwise generate method signature from metadata #}
     {%- set param_list = [] %}

--- a/besser/generators/django/templates/models.py.j2
+++ b/besser/generators/django/templates/models.py.j2
@@ -1,5 +1,17 @@
 {#- Django model template generator #}
 {%- import "django_fields.py.j2" as django_fields -%}
+{%- set ns_re = namespace(uses_re=false) %}
+{%- for cls_constraints in (constraints_map or {}).values() %}
+{%- for constraint in cls_constraints %}
+{%- if constraint.python_expression is defined and 're.match(' in constraint.python_expression %}
+{%- set ns_re.uses_re = true %}
+{%- endif %}
+{%- endfor %}
+{%- endfor %}
+{%- if ns_re.uses_re %}
+import re
+
+{% endif %}
 from django.db import models
 {% if constraints_map %}
 from django.core.exceptions import ValidationError
@@ -114,11 +126,10 @@ class {{ class_obj.name }}({{ inheritance | default('models.Model', true) }}):
         {% if constraint.python_expression is defined %}
         v = self.{{ constraint.property }}
         if not ({{ constraint.python_expression }}):
-            errors.setdefault('{{ constraint.property }}', []).append('{{ constraint.message }}')
+            errors.setdefault('{{ constraint.property }}', []).append({{ constraint.message_repr }})
         {% else %}
         if not (self.{{ constraint.property }} {{ constraint.python_operator }} {{ constraint.value_repr }}):
-            errors.setdefault('{{ constraint.property }}', []).append(
-                '{{ constraint.property }} must be {{ constraint.python_operator }} {{ constraint.value_repr }}')
+            errors.setdefault('{{ constraint.property }}', []).append({{ constraint.message_repr }})
         {% endif %}
         {%- endfor %}
         if errors:

--- a/besser/generators/pydantic_classes/ocl_utils.py
+++ b/besser/generators/pydantic_classes/ocl_utils.py
@@ -6,8 +6,23 @@ information from OCL constraint expressions for use in Pydantic field validators
 
 It leverages the bocl ANTLR-based visitor parser and traverses the parsed
 OCL expression tree.
+
+Three result shapes are produced:
+
+* Field validator (single property):
+  ``{'property', 'python_operator', 'value_repr', 'message', 'message_repr', ...}``
+  or ``{'property', 'python_expression', 'message', 'message_repr', ...}``
+* Model validator (two or more properties of the same class):
+  ``{'model_expression', 'message_repr', 'validator_name', ...}``
+* Skipped (collections, relationships, anything not confidently translatable):
+  ``{'skipped': True}``
+
+Every generated expression is compiled with :func:`compile` and screened with
+an AST white-list before being handed to the template, so the generator can
+never emit Python code that does not parse.
 """
 
+import ast
 import re
 from typing import Optional, Dict, Any, List
 from antlr4 import InputStream, CommonTokenStream
@@ -24,24 +39,200 @@ from besser.BUML.metamodel.ocl.ocl import (
 )
 
 
+# ---------------------------------------------------------------------------
+# Patterns
+# ---------------------------------------------------------------------------
+
+#: Matches a single- or double-quoted string literal (honouring backslash escapes).
+_STRING_LITERAL = re.compile(r"'(?:[^'\\]|\\.)*'|\"(?:[^\"\\]|\\.)*\"")
+
+#: OCL constructs that cannot be expressed as a Pydantic validator on a Create model.
+_COLLECTION_MARKERS = re.compile(
+    r"->"
+    r"|\b(?:forAll|exists|select|reject|collect|iterate|closure|allInstances"
+    r"|oclIsKindOf|oclIsTypeOf|oclAsType|oclIsUndefined|oclIsNew"
+    r"|isEmpty|notEmpty|implies|xor)\b"
+    r"|\.\s*(?:size|sum|first|last|count|asSet|asBag|asSequence|asOrderedSet)\s*\("
+)
+
+#: OCL leftovers that must never survive into generated Python.
+_RESIDUAL_OCL = re.compile(
+    r"->"
+    r"|\.\s*(?:matches|size|sum|toUpper|toLower|substring|indexOf|concat"
+    r"|includes|excludes|oclIs\w+|oclAs\w+)\s*\("
+)
+
+#: ``<target>.matches('<regex>')`` where target is ``self.<prop>`` or the ``v`` placeholder.
+_MATCHES_CALL = re.compile(
+    r"(?P<target>self\s*\.\s*\w+|\bv\b)\s*\.\s*matches\s*\(\s*"
+    r"(?:'(?P<sq>(?:[^'\\]|\\.)*)'|\"(?P<dq>(?:[^\"\\]|\\.)*)\")\s*\)"
+)
+
+#: A constraint body that consists of nothing but a single ``matches`` call.
+_PURE_MATCHES = re.compile(
+    r"^\s*self\s*\.\s*(?P<prop>\w+)\s*\.\s*matches\s*\(\s*"
+    r"(?:'(?P<sq>(?:[^'\\]|\\.)*)'|\"(?P<dq>(?:[^\"\\]|\\.)*)\")\s*\)\s*$"
+)
+
+#: Names the generated validator bodies are allowed to reference.
+_ALLOWED_NAMES = frozenset({'v', 'self', 're'})
+
+#: AST nodes allowed inside a generated validator expression.
+_ALLOWED_NODES = (
+    ast.Expression, ast.BoolOp, ast.UnaryOp, ast.BinOp, ast.Compare, ast.Constant,
+    ast.Load, ast.And, ast.Or, ast.Not, ast.USub, ast.UAdd,
+    ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE, ast.Is, ast.IsNot,
+    ast.Add, ast.Sub, ast.Mult, ast.Div, ast.FloorDiv, ast.Mod,
+)
+
+#: OCL string escapes that are safe to resolve. ``\b`` is deliberately absent:
+#: inside a regex it means "word boundary", not "backspace".
+_OCL_ESCAPES = {'\\': '\\', "'": "'", '"': '"', 'n': '\n', 't': '\t', 'r': '\r'}
+
+#: Emitted for constraints the generator refuses to translate.
+SKIP_COMMENT_TEMPLATE = (
+    "# NOTE: OCL constraint '{name}' involves collections/relationships "
+    "and is not enforced by this Create model."
+)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
 def parse_ocl_constraint(constraint, domain_model) -> Optional[Dict[str, Any]]:
     """
     Parse an OCL constraint using the BESSER OCL parser and extract validation info.
-    
+
     This uses the ANTLR-based parser to properly parse OCL expressions,
-    similar to the B-OCL-Interpreter's update_logical_exp function.
-    
+    similar to the B-OCL-Interpreter's update_logical_exp function, and falls
+    back to a regex-based translation when the tree cannot be exploited.
+
     Args:
         constraint: A Constraint object from the domain model
         domain_model: The DomainModel for context resolution
-        
+
     Returns:
-        A dict with keys: property, operator, value, python_operator
-        or for compound expressions: property, python_expression, message.
-        Returns None if the expression cannot be parsed for validation.
+        A dict describing a field validator, a model validator, or a skipped
+        constraint (``{'skipped': True}``). Never returns broken Python.
+    """
+    constraint_name = getattr(constraint, 'name', None)
+    expression = constraint.expression
+    body = _extract_expression_body(expression)
+
+    if not body or _is_untranslatable(body):
+        return {'skipped': True}
+
+    result = _parse_with_antlr(constraint, domain_model)
+
+    if result is None:
+        result = _fallback_parse(expression)
+
+    if result is None:
+        result = _model_level_parse(body, constraint_name)
+
+    if result is None:
+        return {'skipped': True}
+
+    return _finalize_result(result, constraint_name)
+
+
+def get_constraints_for_class(
+    constraints: set,
+    class_name: str,
+    domain_model,
+    include_model_level: bool = False,
+    include_skipped: bool = False,
+) -> List[Dict[str, Any]]:
+    """
+    Get all parsed constraints for a specific class.
+
+    Args:
+        constraints: Set of Constraint objects from the domain model
+        class_name: Name of the class to get constraints for
+        domain_model: The DomainModel for parsing context
+        include_model_level: Include multi-property constraints, which need a
+            model-level validator. Callers that only render per-field validators
+            (e.g. the Django generator) leave this off.
+        include_skipped: Include untranslatable constraints as ``{'skipped': True}``
+            so the caller can leave a trace comment instead of dropping them.
+
+    Returns:
+        List of parsed constraint dicts, ordered by constraint name so the
+        generated code is deterministic.
+    """
+    parsed = []
+    used_validator_names = set()
+
+    relevant = [
+        c for c in constraints
+        if c.context is not None and c.context.name == class_name and c.language == "OCL"
+    ]
+
+    for constraint in sorted(relevant, key=lambda c: (c.name or "")):
+        result = parse_ocl_constraint(constraint, domain_model)
+        if not result:
+            continue
+        if result.get('skipped') and not include_skipped:
+            continue
+        if 'model_expression' in result and not include_model_level:
+            continue
+        result['constraint_name'] = constraint.name
+        if 'validator_name' in result:
+            result['validator_name'] = _unique_name(
+                result['validator_name'], used_validator_names
+            )
+        parsed.append(result)
+
+    return parsed
+
+
+def build_constraints_map(
+    domain_model,
+    include_model_level: bool = False,
+    include_skipped: bool = False,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Build a mapping from class names to their parsed OCL constraints.
+
+    Args:
+        domain_model: The DomainModel object
+        include_model_level: Include multi-property (model-level) constraints
+        include_skipped: Include untranslatable constraints as ``{'skipped': True}``
+
+    Returns:
+        Dict mapping class name -> list of parsed constraints
+    """
+    constraints_map = {}
+
+    if not domain_model.constraints:
+        return constraints_map
+
+    for cls in domain_model.get_classes():
+        class_constraints = get_constraints_for_class(
+            domain_model.constraints,
+            cls.name,
+            domain_model,
+            include_model_level=include_model_level,
+            include_skipped=include_skipped,
+        )
+        if class_constraints:
+            constraints_map[cls.name] = class_constraints
+
+    return constraints_map
+
+
+# ---------------------------------------------------------------------------
+# ANTLR-based extraction
+# ---------------------------------------------------------------------------
+
+def _parse_with_antlr(constraint, domain_model) -> Optional[Dict[str, Any]]:
+    """
+    Run the ANTLR visitor parser and try to extract validation info from the tree.
+
+    Returns None when the parser errors out or the tree yields nothing usable.
     """
     try:
-        # Parse using the bocl ANTLR visitor parser
         input_stream = InputStream(constraint.expression)
 
         lexer = BOCLLexer(input_stream)
@@ -57,38 +248,29 @@ def parse_ocl_constraint(constraint, domain_model) -> Optional[Dict[str, Any]]:
         tree = parser.oclFile()
 
         if error_listener.has_errors():
-            return _fallback_parse(constraint.expression)
+            return None
 
         visitor = BOCLVisitorImpl(domain_model, None, constraint.context)
         root = visitor.visit(tree)
-        
+
         if root is None:
-            # Fallback to regex parsing if no root was produced
-            return _fallback_parse(constraint.expression)
-        
-        # Extract validation info from the parsed tree
-        result = _extract_from_tree(root)
-        if result:
-            return result
-        
-        # If tree extraction failed, try fallback
-        return _fallback_parse(constraint.expression)
-        
+            return None
+
+        return _extract_from_tree(root)
     except Exception:
-        # Fallback to regex parsing if OCL parser fails
-        return _fallback_parse(constraint.expression)
+        return None
 
 
 def _extract_from_tree(tree) -> Optional[Dict[str, Any]]:
     """
     Extract validation info from a parsed OCL expression tree.
-    
+
     Handles simple expressions of the form: self.property <operator> value
     Similar to the update_logical_exp function in B-OCL-Interpreter.
-    
+
     Args:
         tree: The root of the parsed OCL expression tree
-        
+
     Returns:
         Dict with validation info or None
     """
@@ -96,34 +278,34 @@ def _extract_from_tree(tree) -> Optional[Dict[str, Any]]:
         result = _extract_from_operation(tree)
         if result:
             return result
-    
+
     # Check if we need to traverse source to find the operation
     if hasattr(tree, 'source') and tree.source is not None:
         return _extract_from_tree(tree.source)
-    
+
     return None
 
 
 def _extract_from_operation(op_exp: OperationCallExpression) -> Optional[Dict[str, Any]]:
     """
     Extract validation info from an OperationCallExpression.
-    
-    Based on the B-OCL-Interpreter's handling in update_logical_exp (lines 417-439).
-    
+
+    Based on the B-OCL-Interpreter's handling in update_logical_exp.
+
     Args:
         op_exp: An OperationCallExpression node
-        
+
     Returns:
         Dict with validation info or None
     """
     args = op_exp.arguments
-    
+
     property_name = None
     operator = None
     value = None
     value_repr = None
     value_type = None
-    
+
     for arg in args:
         if isinstance(arg, PropertyCallExpression):
             property_name = arg.property.name
@@ -139,7 +321,7 @@ def _extract_from_operation(op_exp: OperationCallExpression) -> Optional[Dict[st
             value_type = 'float'
         elif isinstance(arg, StringLiteralExpression):
             value = arg.value
-            value_repr = f"'{arg.value}'"
+            value_repr = repr(arg.value)
             value_type = 'str'
         elif isinstance(arg, BooleanLiteralExpression):
             value = arg.value
@@ -147,31 +329,21 @@ def _extract_from_operation(op_exp: OperationCallExpression) -> Optional[Dict[st
             value_type = 'bool'
         elif isinstance(arg, DateLiteralExpression):
             value = arg.value
-            value_repr = f"'{arg.value}'"
+            value_repr = repr(str(arg.value))
             value_type = 'date'
-    
+
     # Also check the referredOperation for the operator
     if operator is None and op_exp.referredOperation is not None:
         if hasattr(op_exp.referredOperation, 'get_infix_operator'):
             operator = op_exp.referredOperation.get_infix_operator()
         elif hasattr(op_exp.referredOperation, 'operator'):
             operator = op_exp.referredOperation.operator
-    
+
     if property_name is None or operator is None or value is None:
         return None
-    
-    # Map OCL operators to Python operators
-    operator_map = {
-        '>': '>',
-        '<': '<',
-        '>=': '>=',
-        '<=': '<=',
-        '=': '==',
-        '<>': '!='
-    }
-    
-    python_operator = operator_map.get(operator, operator)
-    
+
+    python_operator = _OPERATOR_MAP.get(operator, operator)
+
     return {
         'property': property_name,
         'operator': operator,
@@ -180,6 +352,21 @@ def _extract_from_operation(op_exp: OperationCallExpression) -> Optional[Dict[st
         'value_repr': value_repr,
         'value_type': value_type
     }
+
+
+# ---------------------------------------------------------------------------
+# Expression helpers
+# ---------------------------------------------------------------------------
+
+#: Map OCL operators to Python operators.
+_OPERATOR_MAP = {
+    '>': '>',
+    '<': '<',
+    '>=': '>=',
+    '<=': '<=',
+    '=': '==',
+    '<>': '!='
+}
 
 
 def _extract_expression_body(expression: str) -> str:
@@ -197,114 +384,219 @@ def _extract_expression_body(expression: str) -> str:
     return expression
 
 
+def _strip_string_literals(text: str) -> str:
+    """
+    Blank out quoted string literals so structural checks ignore their contents.
+    """
+    return _STRING_LITERAL.sub("''", text)
+
+
+def _is_untranslatable(body: str) -> bool:
+    """
+    Report whether an OCL body uses constructs the Pydantic generator cannot express.
+    """
+    return bool(_COLLECTION_MARKERS.search(_strip_string_literals(body)))
+
+
 def _apply_outside_quotes(text: str, transform) -> str:
     """
-    Apply a transformation function only to text outside single-quoted strings.
+    Apply a transformation function only to text outside quoted string literals.
     """
-    parts = text.split("'")
-    for idx in range(0, len(parts), 2):
-        parts[idx] = transform(parts[idx])
-    return "'".join(parts)
+    pieces = []
+    position = 0
+    for match in _STRING_LITERAL.finditer(text):
+        pieces.append(transform(text[position:match.start()]))
+        pieces.append(match.group(0))
+        position = match.end()
+    pieces.append(transform(text[position:]))
+    return "".join(pieces)
 
 
 def _replace_outside_quotes(text: str, pattern: str, repl: str) -> str:
     """
-    Regex replace outside single-quoted strings.
+    Regex replace outside quoted string literals.
     """
     return _apply_outside_quotes(text, lambda part: re.sub(pattern, repl, part))
 
 
 def _collapse_whitespace_outside_quotes(text: str) -> str:
     """
-    Collapse consecutive whitespace outside single-quoted strings.
+    Collapse consecutive whitespace outside quoted string literals.
     """
     return _apply_outside_quotes(text, lambda part: re.sub(r"\s+", " ", part)).strip()
+
+
+def _unescape_ocl_string(raw: str) -> str:
+    """
+    Resolve the escape sequences of an OCL string literal.
+
+    ``\\b`` is left untouched on purpose: within a regex it is a word boundary.
+    """
+    out = []
+    index = 0
+    length = len(raw)
+    while index < length:
+        char = raw[index]
+        if char == '\\' and index + 1 < length and raw[index + 1] in _OCL_ESCAPES:
+            out.append(_OCL_ESCAPES[raw[index + 1]])
+            index += 2
+            continue
+        out.append(char)
+        index += 1
+    return "".join(out)
+
+
+def _regex_literal(regex: str) -> str:
+    """
+    Render a regex as a Python literal, preferring a raw string when it is safe.
+
+    A raw string cannot end with an odd number of backslashes and cannot contain
+    its own quote character or a newline, so those cases fall back to ``repr``.
+    """
+    trailing_backslashes = len(regex) - len(regex.rstrip('\\'))
+    if trailing_backslashes % 2 == 0 and '\n' not in regex and '\r' not in regex:
+        if "'" not in regex:
+            return f"r'{regex}'"
+        if '"' not in regex:
+            return f'r"{regex}"'
+    return repr(regex)
+
+
+def _translate_matches(text: str) -> str:
+    """
+    Translate OCL ``<target>.matches('<regex>')`` calls into Python ``re.match`` calls.
+    """
+    def replace(match: "re.Match") -> str:
+        raw = match.group('sq')
+        if raw is None:
+            raw = match.group('dq')
+        regex = _unescape_ocl_string(raw)
+        target = re.sub(r"\s+", "", match.group('target'))
+        return f"re.match({_regex_literal(regex)}, {target}) is not None"
+
+    return _MATCHES_CALL.sub(replace, text)
+
+
+def _normalize_operators(expression: str) -> str:
+    """
+    Rewrite OCL comparison operators as Python operators, outside string literals.
+    """
+    normalized = _replace_outside_quotes(expression, r"<>", "!=")
+    normalized = _replace_outside_quotes(normalized, r"(?<![<>=!])=(?!=)", "==")
+    return normalized
 
 
 def _normalize_ocl_expression(expression: str, property_name: str) -> str:
     """
     Normalize an OCL expression into a Python expression for a single property.
+
+    The property reference becomes the ``v`` placeholder used by field validators.
     """
-    normalized = expression
-    normalized = _replace_outside_quotes(normalized, r"<>", "!=")
-    normalized = _replace_outside_quotes(normalized, r"(?<![<>=!])=(?!=)", "==")
+    normalized = _normalize_operators(expression)
     normalized = _replace_outside_quotes(
         normalized,
         rf"\bself\.{re.escape(property_name)}\b",
         "v"
     )
-    return _collapse_whitespace_outside_quotes(normalized)
+    normalized = _collapse_whitespace_outside_quotes(normalized)
+    return _translate_matches(normalized)
 
+
+def _normalize_model_expression(expression: str) -> str:
+    """
+    Normalize an OCL expression into a Python expression that keeps ``self.<prop>``
+    references, as used by model-level validators.
+    """
+    normalized = _normalize_operators(expression)
+    normalized = _collapse_whitespace_outside_quotes(normalized)
+    normalized = _replace_outside_quotes(normalized, r"\bself\s*\.\s*(\w+)", r"self.\1")
+    return _translate_matches(normalized)
+
+
+def _safe_identifier(name: str) -> str:
+    """
+    Turn a constraint name into a valid Python identifier.
+    """
+    identifier = re.sub(r"\W", "_", name or "")
+    if not identifier:
+        identifier = "constraint"
+    if identifier[0].isdigit():
+        identifier = f"_{identifier}"
+    return identifier
+
+
+def _unique_name(base: str, used: set) -> str:
+    """
+    Return `base`, suffixed with a counter if it has already been handed out.
+    """
+    candidate = base
+    counter = 2
+    while candidate in used:
+        candidate = f"{base}_{counter}"
+        counter += 1
+    used.add(candidate)
+    return candidate
+
+
+# ---------------------------------------------------------------------------
+# Regex-based parsing
+# ---------------------------------------------------------------------------
 
 def _fallback_parse(expression: str) -> Optional[Dict[str, Any]]:
     """
-    Fallback regex-based parser for simple OCL constraint expressions.
+    Fallback regex-based parser for single-property OCL constraint expressions.
     Used when the ANTLR parser doesn't produce usable results.
-    
+
     Args:
         expression: The OCL constraint expression string
-        
+
     Returns:
         A dict with keys: property, operator, value, python_operator
         or for compound expressions: property, python_expression, message.
-        Returns None if the expression cannot be parsed.
+        Returns None if the expression references anything but one property.
     """
     # Extract the core OCL expression body (after "inv:")
     expression_body = _extract_expression_body(expression)
     if not expression_body:
         return None
-    
+
     # Identify properties referenced in the expression
     properties = re.findall(r"\bself\.(\w+)\b", expression_body)
     if not properties:
         return None
-    
+
     unique_properties = set(properties)
     if len(unique_properties) != 1:
-        # Only support single-property constraints for field validators
+        # Multi-property constraints are handled by _model_level_parse
         return None
-    
+
     property_name = unique_properties.pop()
     multiple_references = len(properties) > 1
-    
+
     # Pattern to match: self.<property> <operator> <value>
     simple_pattern = rf"self\.{re.escape(property_name)}\s*(>=|<=|<>|>|<|=)\s*(.+)"
     match = re.fullmatch(simple_pattern, expression_body.strip())
     if not match or multiple_references:
         # Handle compound expressions like "self.age > 10 and self.age < 20"
         python_expression = _normalize_ocl_expression(expression_body, property_name)
-        message_expression = _replace_outside_quotes(
-            python_expression,
-            r"\bv\b",
-            ""
-        )
-        message_expression = _collapse_whitespace_outside_quotes(message_expression)
         return {
             'property': property_name,
             'python_expression': python_expression,
-            'message': f"{property_name} must be {message_expression}"
+            'message': _build_compound_message(
+                property_name, expression_body, python_expression
+            )
         }
-    
+
     operator = match.group(1)
     value_str = match.group(2).strip()
-    
-    # Map OCL operators to Python operators
-    operator_map = {
-        '>': '>',
-        '<': '<',
-        '>=': '>=',
-        '<=': '<=',
-        '=': '==',
-        '<>': '!='
-    }
-    
-    python_operator = operator_map.get(operator)
+
+    python_operator = _OPERATOR_MAP.get(operator)
     if not python_operator:
         return None
-    
+
     # Parse the value
     parsed_value = _parse_value(value_str)
-    
+
     return {
         'property': property_name,
         'operator': operator,
@@ -315,86 +607,173 @@ def _fallback_parse(expression: str) -> Optional[Dict[str, Any]]:
     }
 
 
+def _model_level_parse(body: str, constraint_name: Optional[str]) -> Optional[Dict[str, Any]]:
+    """
+    Build a model-level validator for constraints referencing 2+ properties
+    of the same class (e.g. ``self.check_in <= self.check_out``).
+
+    Args:
+        body: The OCL expression body (already stripped of the context header)
+        constraint_name: Name of the constraint, used for the validator name
+
+    Returns:
+        A dict with ``model_expression`` / ``message`` / ``validator_name`` or None
+    """
+    properties = re.findall(r"\bself\.(\w+)\b", body)
+    if len(set(properties)) < 2:
+        return None
+
+    model_expression = _normalize_model_expression(body)
+    readable = _collapse_whitespace_outside_quotes(body)
+
+    return {
+        'properties': sorted(set(properties)),
+        'model_expression': model_expression,
+        'validator_name': _safe_identifier(constraint_name),
+        'message': _build_model_message(constraint_name, readable)
+    }
+
+
+def _build_compound_message(property_name: str, body: str, python_expression: str) -> str:
+    """
+    Build a human-readable error message for a single-property compound constraint.
+    """
+    pure_match = _PURE_MATCHES.match(body.strip())
+    if pure_match:
+        raw = pure_match.group('sq')
+        if raw is None:
+            raw = pure_match.group('dq')
+        return f"{property_name} must match '{_unescape_ocl_string(raw)}'"
+
+    if 're.match(' in python_expression:
+        readable = _collapse_whitespace_outside_quotes(body)
+        return f"{property_name} must satisfy: {readable}"
+
+    message_expression = _replace_outside_quotes(python_expression, r"\bv\b", "")
+    message_expression = _collapse_whitespace_outside_quotes(message_expression)
+    return f"{property_name} must be {message_expression}"
+
+
+def _build_model_message(constraint_name: Optional[str], readable: str) -> str:
+    """
+    Build a human-readable error message for a model-level constraint.
+    """
+    if constraint_name:
+        return f"Constraint '{constraint_name}' violated: {readable}"
+    return f"Constraint violated: {readable}"
+
+
 def _parse_value(value_str: str) -> Dict[str, Any]:
     """
     Parse an OCL value and determine its type.
     """
     value_str = value_str.strip()
-    
+
     # Check for integer
     try:
         int_val = int(value_str)
         return {'value': int_val, 'repr': str(int_val), 'type': 'int'}
     except ValueError:
         pass
-    
+
     # Check for float
     try:
         float_val = float(value_str)
         return {'value': float_val, 'repr': str(float_val), 'type': 'float'}
     except ValueError:
         pass
-    
+
     # Check for string (single quotes in OCL)
     if value_str.startswith("'") and value_str.endswith("'"):
-        str_val = value_str[1:-1]
-        return {'value': str_val, 'repr': f"'{str_val}'", 'type': 'str'}
-    
+        str_val = _unescape_ocl_string(value_str[1:-1])
+        return {'value': str_val, 'repr': repr(str_val), 'type': 'str'}
+
     # Check for boolean
     if value_str.lower() in ('true', 'false'):
         bool_val = value_str.lower() == 'true'
         return {'value': bool_val, 'repr': str(bool_val), 'type': 'bool'}
-    
+
     # Default: treat as raw value
     return {'value': value_str, 'repr': value_str, 'type': 'unknown'}
 
 
-def get_constraints_for_class(constraints: set, class_name: str, domain_model) -> List[Dict[str, Any]]:
+# ---------------------------------------------------------------------------
+# Safety net
+# ---------------------------------------------------------------------------
+
+def _is_safe_expression(expression: str, allow_self: bool) -> bool:
     """
-    Get all parsed constraints for a specific class.
-    
-    Args:
-        constraints: Set of Constraint objects from the domain model
-        class_name: Name of the class to get constraints for
-        domain_model: The DomainModel for parsing context
-        
-    Returns:
-        List of parsed constraint dicts
+    Check that a generated expression parses and only uses white-listed constructs.
+
+    ``compile(expression, '<ocl>', 'eval')`` guarantees the emitted code is at
+    least syntactically valid; the AST walk additionally rejects leaked OCL
+    identifiers, unknown free variables and arbitrary calls.
     """
-    parsed = []
-    
-    for constraint in constraints:
-        if constraint.context.name == class_name and constraint.language == "OCL":
-            result = parse_ocl_constraint(constraint, domain_model)
-            if result:
-                result['constraint_name'] = constraint.name
-                parsed.append(result)
-    
-    return parsed
+    try:
+        compile(expression, '<ocl>', 'eval')
+        tree = ast.parse(expression, mode='eval')
+    except (SyntaxError, ValueError):
+        return False
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            if node.id not in _ALLOWED_NAMES:
+                return False
+            if node.id == 'self' and not allow_self:
+                return False
+        elif isinstance(node, ast.Attribute):
+            # Only single-level attribute access on a white-listed name.
+            if not isinstance(node.value, ast.Name):
+                return False
+        elif isinstance(node, ast.Call):
+            func = node.func
+            is_re_match = (
+                isinstance(func, ast.Attribute)
+                and func.attr == 'match'
+                and isinstance(func.value, ast.Name)
+                and func.value.id == 're'
+            )
+            if not is_re_match:
+                return False
+        elif not isinstance(node, _ALLOWED_NODES):
+            return False
+
+    return True
 
 
-def build_constraints_map(domain_model) -> Dict[str, List[Dict[str, Any]]]:
+def _finalize_result(
+    result: Optional[Dict[str, Any]], constraint_name: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
     """
-    Build a mapping from class names to their parsed OCL constraints.
-    
-    Args:
-        domain_model: The DomainModel object
-        
-    Returns:
-        Dict mapping class name -> list of parsed constraints
+    Validate a parsed constraint and enrich it with template-ready fields.
+
+    Adds ``message_repr`` (a safely quoted Python literal, so the template never
+    interpolates raw text into a quoted string) and ``uses_re``. Falls back to
+    ``{'skipped': True}`` whenever the expression would not compile or still
+    contains OCL syntax.
     """
-    constraints_map = {}
-    
-    if not domain_model.constraints:
-        return constraints_map
-    
-    for cls in domain_model.get_classes():
-        class_constraints = get_constraints_for_class(
-            domain_model.constraints, 
-            cls.name,
-            domain_model
+    if result is None or result.get('skipped'):
+        return result
+
+    if 'model_expression' in result:
+        expression = result['model_expression']
+        allow_self = True
+        result.setdefault('validator_name', _safe_identifier(constraint_name))
+    elif 'python_expression' in result:
+        expression = result['python_expression']
+        allow_self = False
+    else:
+        expression = f"v {result['python_operator']} {result['value_repr']}"
+        allow_self = False
+        result.setdefault(
+            'message',
+            f"{result['property']} must be {result['python_operator']} {result['value_repr']}"
         )
-        if class_constraints:
-            constraints_map[cls.name] = class_constraints
-    
-    return constraints_map
+
+    stripped = _strip_string_literals(expression)
+    if _RESIDUAL_OCL.search(stripped) or not _is_safe_expression(expression, allow_self):
+        return {'skipped': True}
+
+    result['message_repr'] = repr(result['message'])
+    result['uses_re'] = 're.match(' in stripped
+    return result

--- a/besser/generators/pydantic_classes/pydantic_classes_generator.py
+++ b/besser/generators/pydantic_classes/pydantic_classes_generator.py
@@ -2,10 +2,11 @@ import os
 import re
 import unicodedata
 from jinja2 import Environment, FileSystemLoader
-from besser.BUML.metamodel.structural import DomainModel
+from besser.BUML.metamodel.structural import DomainModel, AssociationClass
 from besser.generators import GeneratorInterface
 from besser.generators.structural_utils import get_foreign_keys
 from besser.generators.pydantic_classes.ocl_utils import build_constraints_map
+from besser.utilities.utils import sort_by_timestamp
 
 class PydanticGenerator(GeneratorInterface):
     """
@@ -60,10 +61,38 @@ class PydanticGenerator(GeneratorInterface):
         # Use DomainModel's built-in method to sort classes by inheritance (parents before children)
         sorted_classes = self.domain_model.classes_sorted_by_inheritance()
 
-        # Build constraints map for OCL validation
-        constraints_map = build_constraints_map(self.domain_model)
+        # Build constraints map for OCL validation. The Pydantic template can
+        # render model-level validators and leave a NOTE comment for the
+        # constraints it cannot enforce, so it asks for both.
+        constraints_map = build_constraints_map(
+            self.domain_model, include_model_level=True, include_skipped=True
+        )
 
         class_names = {cls.name for cls in sorted_classes}
+
+        # Associations that carry an association class exchange their links as
+        # <AssocClass>LinkCreate payloads (target id + association attributes),
+        # mirroring the shapes the REST API generator consumes.
+        assoc_by_association = {}
+        assoc_link_meta = []
+        assoc_end_fields = {}
+        for cls in sorted_classes:
+            if not isinstance(cls, AssociationClass):
+                continue
+            link_class = f"{cls.name}LinkCreate"
+            assoc_by_association[cls.association.name] = link_class
+            assoc_link_meta.append({
+                "link_class": link_class,
+                "attributes": [
+                    {"name": attr.name, "type_name": attr.type.name}
+                    for attr in sort_by_timestamp(cls.attributes)
+                ],
+            })
+            assoc_end_fields[cls.name] = [
+                {"name": end.name, "type_name": end.type.name}
+                for end in sorted(cls.association.ends, key=lambda e: e.name)
+            ]
+
         with open(file_path, mode="w", newline='\n', encoding="utf-8") as f:
             generated_code = template.render(
                 domain=self.domain_model,
@@ -72,7 +101,10 @@ class PydanticGenerator(GeneratorInterface):
                 nested_creations=self.nested_creations,
                 constraints_map=constraints_map,
                 fkeys=get_foreign_keys(self.domain_model),
-                class_names=class_names
+                class_names=class_names,
+                assoc_by_association=assoc_by_association,
+                assoc_link_meta=assoc_link_meta,
+                assoc_end_fields=assoc_end_fields
             )
             f.write(generated_code)
             print("Code generated in the location: " + file_path)

--- a/besser/generators/pydantic_classes/templates/pydantic_classes_template.py.j2
+++ b/besser/generators/pydantic_classes/templates/pydantic_classes_template.py.j2
@@ -1,7 +1,23 @@
+{% set ocl_ns = namespace(needs_re=false, needs_model_validator=false) -%}
+{% if constraints_map -%}
+    {% for constraint_list in constraints_map.values() -%}
+        {% for constraint in constraint_list -%}
+            {% if constraint.uses_re -%}
+                {% set ocl_ns.needs_re = true -%}
+            {% endif -%}
+            {% if constraint.model_expression is defined -%}
+                {% set ocl_ns.needs_model_validator = true -%}
+            {% endif -%}
+        {% endfor -%}
+    {% endfor -%}
+{% endif -%}
+{% if ocl_ns.needs_re %}
+import re
+{% endif %}
 from datetime import datetime, date, time
 from typing import Any, List, Optional, Union, Set
 from enum import Enum
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator{{ ", model_validator" if ocl_ns.needs_model_validator else "" }}
 
 {% set ns = namespace(abstract_found=false, id_found = false, same_name_found = false, has_field = false )-%}
 {% for class in domain.get_classes() -%}
@@ -26,6 +42,20 @@ class {{ enum.name }}(Enum):
 
 {% endfor -%}
 
+{% if backend and assoc_link_meta %}
+############################################
+# Association-class link payloads
+############################################
+
+{% for link in assoc_link_meta %}
+class {{ link.link_class }}(BaseModel):
+    target: int  # primary key of the linked entity
+{% for attr in link.attributes %}
+    {{ attr.name }}: {{ 'Any' if attr.type_name == 'any' else attr.type_name }}
+{% endfor %}
+
+{% endfor %}
+{% endif %}
 ############################################
 # Classes are defined here
 ############################################
@@ -63,8 +93,35 @@ class {{ class.name }}{% if backend %}Create{% endif %}{% if class.parents() %}(
     id: int  # id created
     {% set ns.has_field = true %}
     {% endif %}
+    {%- if backend and assoc_end_fields and class.name in assoc_end_fields %}
+    {%- for ef in assoc_end_fields[class.name] %}
+    {{ ef.name }}: int  # association end -> {{ ef.type_name }} primary key
+    {% set ns.has_field = true %}
+    {%- endfor %}
+    {%- endif %}
     {%- for association in class.associations %}
         {%- if association.ends|length == 2 %}
+            {%- set link_class = assoc_by_association.get(association.name) if backend and assoc_by_association else none %}
+            {%- if link_class %}
+            {# The association carries an association class: links travel as
+               <AssocClass>LinkCreate payloads (target id + association attributes). #}
+            {%- for end in association.ends %}
+                {%- if end.type.name != class.name %}
+                    {%- if end.multiplicity.max > 1 %}
+                        {%- if end.multiplicity.min == 0 %}
+    {{ end.name }}: Optional[List[Union["{{ link_class }}", int]]] = None  # via association class (optional)
+    {% set ns.has_field = true %}
+                        {%- else %}
+    {{ end.name }}: List[Union["{{ link_class }}", int]]  # via association class
+    {% set ns.has_field = true %}
+                        {%- endif %}
+                    {%- else %}
+    {{ end.name }}: Optional[Union["{{ link_class }}", int]] = None  # via association class (link is created from the other side or via its own endpoint)
+    {% set ns.has_field = true %}
+                    {%- endif %}
+                {%- endif %}
+            {%- endfor %}
+            {%- else %}
             {%- set ends_list = association.ends | list %}
             {%- set is_self_assoc = (ends_list[0].type.name == ends_list[1].type.name) %}
             {%- if is_self_assoc %}
@@ -261,6 +318,7 @@ class {{ class.name }}{% if backend %}Create{% endif %}{% if class.parents() %}(
                 {%- endif %}
             {%- endif %}
             {%- endif %}
+            {%- endif %}
         {%- endif %}
     {%- endfor %}
     {%- if not ns.has_field %}
@@ -269,6 +327,18 @@ class {{ class.name }}{% if backend %}Create{% endif %}{% if class.parents() %}(
     {# OCL Constraint Validators #}
     {%- if constraints_map and class.name in constraints_map %}
     {%- for constraint in constraints_map[class.name] %}
+    {%- if constraint.skipped %}
+
+    # NOTE: OCL constraint '{{ constraint.constraint_name }}' involves collections/relationships and is not enforced by this Create model.
+    {%- elif constraint.model_expression is defined %}
+
+    @model_validator(mode='after')
+    def validate_{{ constraint.validator_name }}(self):
+        """OCL Constraint: {{ constraint.constraint_name }}"""
+        if not ({{ constraint.model_expression }}):
+            raise ValueError({{ constraint.message_repr }})
+        return self
+    {%- else %}
 
     @field_validator('{{ constraint.property }}')
     @classmethod
@@ -276,12 +346,13 @@ class {{ class.name }}{% if backend %}Create{% endif %}{% if class.parents() %}(
         """OCL Constraint: {{ constraint.constraint_name }}"""
         {% if constraint.python_expression is defined %}
         if not ({{ constraint.python_expression }}):
-            raise ValueError('{{ constraint.message }}')
+            raise ValueError({{ constraint.message_repr }})
         {% else %}
         if not (v {{ constraint.python_operator }} {{ constraint.value_repr }}):
-            raise ValueError('{{ constraint.property }} must be {{ constraint.python_operator }} {{ constraint.value_repr }}')
+            raise ValueError({{ constraint.message_repr }})
         {% endif %}
         return v
+    {%- endif %}
     {%- endfor %}
     {%- endif %}
 

--- a/besser/generators/python_classes/python_classes_generator.py
+++ b/besser/generators/python_classes/python_classes_generator.py
@@ -2,6 +2,7 @@ import os
 from jinja2 import Environment, FileSystemLoader
 from besser.BUML.metamodel.structural import DomainModel
 from besser.generators import GeneratorInterface
+from besser.generators.structural_utils import normalize_method_code
 from besser.utilities import sort_by_timestamp
 
 class PythonGenerator(GeneratorInterface):
@@ -31,6 +32,7 @@ class PythonGenerator(GeneratorInterface):
         templates_path = os.path.join(os.path.dirname(
             os.path.abspath(__file__)), "templates")
         env = Environment(loader=FileSystemLoader(templates_path))
+        env.globals.update(normalize_code=normalize_method_code)
         template = env.get_template('python_classes_template.py.j2')
         with open(file_path, mode="w", encoding='utf-8') as f:
             generated_code = template.render(domain=self.model, sort_by_timestamp=sort_by_timestamp)

--- a/besser/generators/python_classes/templates/python_classes_template.py.j2
+++ b/besser/generators/python_classes/templates/python_classes_template.py.j2
@@ -116,7 +116,7 @@ class {{ class.name }}{% if class.parents() %}({% for parent in class.parents() 
     {%- for method in class.methods %}
     {%- if method.code %}
     {#- If method has code, use it directly (it contains the full function definition) #}
-{{ method.code | indent(4, first=true) }}
+{{ normalize_code(method.code, method.name) | indent(4, first=true) }}
     {%- else %}
     {#- Otherwise generate method signature from metadata #}
     {%- if method.is_abstract %}

--- a/besser/generators/react/serialization.py
+++ b/besser/generators/react/serialization.py
@@ -604,6 +604,14 @@ class GuiSerializationMixin:
 
                     form_columns.append(column_dict)
 
+                # Display fields the user configured on the table's lookup columns:
+                # the dialog's selects should show the same values as the table.
+                configured_lookup_fields = {
+                    c.get("path"): c.get("field")
+                    for c in columns
+                    if c.get("column_type") == "lookup" and c.get("path") and c.get("field")
+                }
+
                 ends = list(domain_concept.all_association_ends())
                 ends = sort_by_timestamp(ends) if ends else []
                 for end in ends:
@@ -614,7 +622,10 @@ class GuiSerializationMixin:
                     target_attrs = []
                     if target and hasattr(target, "all_attributes"):
                         target_attrs = sort_by_timestamp(list(target.all_attributes()))
-                    lookup_field = target_attrs[0].name if target_attrs else ""
+                    lookup_field = (
+                        configured_lookup_fields.get(end.name)
+                        or self._select_display_field(target_attrs)
+                    )
                     # The identifying attribute of the target class: option values,
                     # payload ids and edit prefill key on it, while lookup_field
                     # stays the human-readable label source.
@@ -1213,6 +1224,35 @@ class GuiSerializationMixin:
     @staticmethod
     def _to_pretty_json(payload: Dict[str, Any]) -> str:
         return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False)
+
+    @staticmethod
+    def _select_display_field(attributes: List[Any]) -> str:
+        """Pick the attribute shown for a related record in lookup selects.
+
+        Preference order: an attribute literally named ``name``, then the first
+        string attribute that is not the id, then the first non-id attribute,
+        then the first attribute.
+        """
+        if not attributes:
+            return ""
+        if any(attr.name == "name" for attr in attributes):
+            return "name"
+        string_attr = next(
+            (attr for attr in attributes
+             if not getattr(attr, "is_id", False) and attr.name != "id"
+             and getattr(getattr(attr, "type", None), "name", "") == "str"),
+            None,
+        )
+        if string_attr is not None:
+            return string_attr.name
+        non_id = next(
+            (attr for attr in attributes
+             if not getattr(attr, "is_id", False) and attr.name != "id"),
+            None,
+        )
+        if non_id is not None:
+            return non_id.name
+        return attributes[0].name
 
     @staticmethod
     def _select_lookup_field(attributes: List[Any]) -> str:

--- a/besser/generators/react/serialization.py
+++ b/besser/generators/react/serialization.py
@@ -40,7 +40,7 @@ from besser.BUML.metamodel.gui.events_actions import (
     Transition,
     Update,
 )
-from besser.BUML.metamodel.structural import Class, Enumeration
+from besser.BUML.metamodel.structural import AssociationClass, Class, Enumeration
 from besser.utilities import sort_by_timestamp
 
 
@@ -633,6 +633,14 @@ class GuiSerializationMixin:
                     if multiplicity and getattr(multiplicity, "min", 0) > 0:
                         column_dict["required"] = True
 
+                    # List ends whose association is materialized by an association class
+                    # carry the association class attributes so the create/edit form can
+                    # collect them per selected target.
+                    if is_list:
+                        association_class_meta = self._association_class_metadata(end)
+                        if association_class_meta:
+                            column_dict["association_class"] = association_class_meta
+
                     form_columns.append(column_dict)
 
             if form_columns:
@@ -1206,6 +1214,65 @@ class GuiSerializationMixin:
         non_id_attrs = [attr for attr in attributes if not getattr(attr, "is_id", False)]
         selected = non_id_attrs[0] if non_id_attrs else attributes[0]
         return getattr(selected, "name", "")
+
+    def _association_class_index(self) -> Dict[str, AssociationClass]:
+        """Map the name of each association to the AssociationClass materializing it."""
+        index: Dict[str, AssociationClass] = {}
+        domain_model = getattr(self, "model", None)
+        for type_ in getattr(domain_model, "types", None) or []:
+            if not isinstance(type_, AssociationClass):
+                continue
+            association_name = getattr(getattr(type_, "association", None), "name", None)
+            if association_name:
+                index[association_name] = type_
+        return index
+
+    def _association_class_metadata(self, end: Any) -> Optional[Dict[str, Any]]:
+        """Association class metadata for an association end, or None when there is none.
+
+        The generated create/edit form uses it to collect the association class
+        attributes for every selected target of the relationship.
+        """
+        association_name = getattr(getattr(end, "owner", None), "name", None)
+        if not association_name:
+            return None
+        association_class = self._association_class_index().get(association_name)
+        if association_class is None:
+            return None
+        return {
+            "entity": association_class.name,
+            "fields": self._association_class_fields(association_class),
+        }
+
+    @staticmethod
+    def _association_class_fields(association_class: AssociationClass) -> List[Dict[str, Any]]:
+        """Serialize the attributes of an association class in model (timestamp) order."""
+        if hasattr(association_class, "all_attributes"):
+            attributes = list(association_class.all_attributes())
+        else:
+            attributes = list(getattr(association_class, "attributes", None) or [])
+        attributes = sort_by_timestamp(attributes) if attributes else []
+
+        fields: List[Dict[str, Any]] = []
+        for attr in attributes:
+            attr_type = getattr(attr, "type", None)
+            field_dict: Dict[str, Any] = {"name": attr.name, "type": "str"}
+
+            if isinstance(attr_type, Enumeration):
+                field_dict["type"] = "enum"
+                field_dict["options"] = sorted([literal.name for literal in attr_type.literals])
+            elif attr_type is not None and getattr(attr_type, "name", None):
+                field_dict["type"] = attr_type.name
+
+            required = False
+            if not getattr(attr, "is_optional", False):
+                multiplicity = getattr(attr, "multiplicity", None)
+                if multiplicity and getattr(multiplicity, "min", 0) > 0:
+                    required = True
+            field_dict["required"] = required
+
+            fields.append(field_dict)
+        return fields
 
     @staticmethod
     def _sorted_by_name(items: Iterable[Any]) -> List[Any]:

--- a/besser/generators/react/serialization.py
+++ b/besser/generators/react/serialization.py
@@ -615,6 +615,12 @@ class GuiSerializationMixin:
                     if target and hasattr(target, "all_attributes"):
                         target_attrs = sort_by_timestamp(list(target.all_attributes()))
                     lookup_field = target_attrs[0].name if target_attrs else ""
+                    # The identifying attribute of the target class: option values,
+                    # payload ids and edit prefill key on it, while lookup_field
+                    # stays the human-readable label source.
+                    target_field = next(
+                        (a.name for a in target_attrs if getattr(a, "is_id", False)), "id"
+                    )
 
                     max_mult = getattr(getattr(end, "multiplicity", None), "max", None)
                     is_list = max_mult == "*" or (isinstance(max_mult, int) and max_mult > 1)
@@ -624,6 +630,7 @@ class GuiSerializationMixin:
                         "path": end.name,
                         "field": end.name,
                         "lookup_field": lookup_field,
+                        "target_field": target_field,
                         "entity": getattr(target, "name", "") if target else "",
                         "type": "list" if is_list else "str",
                         "required": False,

--- a/besser/generators/react/templates/src/components/table/TableComponent.css.j2
+++ b/besser/generators/react/templates/src/components/table/TableComponent.css.j2
@@ -33,3 +33,38 @@
 .table-scroll::-webkit-scrollbar-track {
   background-color: transparent;
 }
+
+/* ── Add/Edit modal ─────────────────────────────────────────────── */
+
+.bsr-modal input:focus,
+.bsr-modal select:focus,
+.bsr-modal textarea:focus {
+  outline: 2px solid #6366f1;
+  outline-offset: 1px;
+  border-color: #6366f1 !important;
+}
+
+.bsr-modal input[type="checkbox"]:focus {
+  outline-offset: 2px;
+}
+
+.bsr-modal button[type="submit"]:hover {
+  filter: brightness(1.1);
+}
+
+.bsr-modal button:hover[aria-label="Close"] {
+  background: #e2e8f0;
+}
+
+.bsr-modal ::-webkit-scrollbar {
+  width: 8px;
+}
+
+.bsr-modal ::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.5);
+  border-radius: 9999px;
+}
+
+.bsr-modal ::-webkit-scrollbar-track {
+  background-color: transparent;
+}

--- a/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
+++ b/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
@@ -6,6 +6,20 @@ import { ColumnFilter } from "./ColumnFilter";
 import { ColumnSort } from "./ColumnSort";
 import "./TableComponent.css";
 
+// Attribute of an association class carried by an N:M relationship
+interface AssociationClassField {
+  name: string;
+  type?: string;
+  required?: boolean;
+  options?: string[];
+}
+
+// Association class attached to a list lookup column (e.g. Booking -> Room through ReservedRoom)
+interface AssociationClassMeta {
+  entity: string;
+  fields: AssociationClassField[];
+}
+
 interface TableColumn {
   field: string;
   label: string;
@@ -17,6 +31,7 @@ interface TableColumn {
   required?: boolean;
   lookupField?: string;
   relationshipKey?: string;
+  associationClass?: AssociationClassMeta;
 }
 
 interface TableOptions {
@@ -103,8 +118,14 @@ export const TableComponent: React.FC<Props> = ({
       (col: any) => typeof col === 'object' && col.column_type === 'lookup'
     );
     
+    // Association class attributes (the `<end>_links` payload) are only part of the
+    // detailed response, and the edit form needs them to prefill the link attributes
+    const hasAssociationClassColumns = ((options as any)?.formColumns ?? (options as any)?.form_columns ?? []).some(
+      (col: any) => typeof col === 'object' && col && (col.association_class ?? col.associationClass)
+    );
+
     // Add detailed=true query param if there are lookup columns
-    const urlParams = hasLookupColumns ? '?detailed=true' : '';
+    const urlParams = (hasLookupColumns || hasAssociationClassColumns) ? '?detailed=true' : '';
     const url = endpoint.startsWith("/") 
       ? backendBase + endpoint + urlParams
       : endpoint + urlParams;
@@ -163,6 +184,13 @@ export const TableComponent: React.FC<Props> = ({
           ? col.path
           : undefined;
         const lookupField = (col as any).lookup_field ?? (col as any).lookupField ?? col.field;
+        const rawAssociationClass = (col as any).association_class ?? (col as any).associationClass;
+        const associationClass: AssociationClassMeta | undefined = rawAssociationClass
+          ? {
+              entity: rawAssociationClass.entity,
+              fields: Array.isArray(rawAssociationClass.fields) ? rawAssociationClass.fields : [],
+            }
+          : undefined;
         return {
           field: actualField,
           label: humanize(col.label || col.field),
@@ -174,6 +202,7 @@ export const TableComponent: React.FC<Props> = ({
           required: col.required ?? false,
           lookupField: col.column_type === "lookup" ? lookupField : undefined,
           relationshipKey: relationshipKey,
+          associationClass: col.column_type === "lookup" ? associationClass : undefined,
         };
       });
   };
@@ -427,6 +456,49 @@ export const TableComponent: React.FC<Props> = ({
   const [editRowData, setEditRowData] = useState<any>(null);
   const [lookupOptions, setLookupOptions] = useState<Record<string, any[]>>({});
   const [validationError, setValidationError] = useState<string>("");
+  // Association class attributes of the selected targets, keyed by
+  // { [column field]: { [target id]: { [association class attribute]: value } } }
+  const [linkAttrValues, setLinkAttrValues] = useState<Record<string, Record<string, Record<string, any>>>>({});
+
+  const getLinkAttrValue = (field: string, targetId: string, attribute: string): any => {
+    return linkAttrValues[field]?.[targetId]?.[attribute] ?? "";
+  };
+
+  const setLinkAttrValue = (field: string, targetId: string, attribute: string, value: any) => {
+    setLinkAttrValues(prev => ({
+      ...prev,
+      [field]: {
+        ...(prev[field] ?? {}),
+        [targetId]: { ...((prev[field] ?? {})[targetId] ?? {}), [attribute]: value },
+      },
+    }));
+  };
+
+  // Convert an association class attribute to the type expected by the API
+  const coerceLinkAttrValue = (type: string | undefined, value: any): any => {
+    if (type === 'int') {
+      const intValue = parseInt(value, 10);
+      return isNaN(intValue) ? 0 : intValue;
+    }
+    if (type === 'float') {
+      const floatValue = parseFloat(value);
+      return isNaN(floatValue) ? 0 : floatValue;
+    }
+    if (type === 'bool' || type === 'boolean') {
+      return Boolean(value);
+    }
+    return value;
+  };
+
+  // Label shown for a related record (same fallbacks as the lookup selects)
+  const getLookupOptionLabel = (col: TableColumn, targetId: string): string => {
+    const options = lookupOptions[(col.entity || "").toLowerCase()] || [];
+    const option = options.find((item: any) => String(item?.id) === String(targetId));
+    if (!option) {
+      return `ID: ${targetId}`;
+    }
+    return (col.lookupField && option[col.lookupField]) || option.pages || option.stock || option.title || `ID: ${option.id}`;
+  };
 
   useEffect(() => {
     setCurrentPage(1);
@@ -488,6 +560,39 @@ export const TableComponent: React.FC<Props> = ({
         }
       });
       setFormValues(initialValues);
+
+      // Prefill the association class attributes from the `<end>_links` payload
+      // returned by the detailed GET (falls back to empty attributes).
+      const initialLinkValues: Record<string, Record<string, Record<string, any>>> = {};
+      formColumns.forEach(col => {
+        if (!col.associationClass || col.columnType !== 'lookup' || col.type !== 'list') {
+          return;
+        }
+        const perTarget: Record<string, Record<string, any>> = {};
+        const relationshipKey = col.path || col.field;
+        const links = modalMode === 'edit' && editRowData
+          ? editRowData[`${relationshipKey}_links`]
+          : null;
+        if (Array.isArray(links)) {
+          links.forEach((link: any) => {
+            if (!link || typeof link !== 'object') {
+              return;
+            }
+            // `target` is the documented key; link rows expose the raw FK column
+            const targetId = String(link.target ?? link[`${relationshipKey}_id`] ?? "");
+            if (!targetId) {
+              return;
+            }
+            const attributes: Record<string, any> = {};
+            col.associationClass!.fields.forEach(linkField => {
+              attributes[linkField.name] = link[linkField.name] ?? "";
+            });
+            perTarget[targetId] = attributes;
+          });
+        }
+        initialLinkValues[col.field] = perTarget;
+      });
+      setLinkAttrValues(initialLinkValues);
 
       // Fetch lookup options for lookup columns
       const fetchLookupOptions = async () => {
@@ -695,8 +800,24 @@ export const TableComponent: React.FC<Props> = ({
                         }
                       }
                     }
+
+                    // Required association class attributes of every selected target
+                    if (col.columnType === 'lookup' && col.type === 'list' && col.associationClass) {
+                      const selected = Array.isArray(formValues[col.field]) ? formValues[col.field] : [];
+                      selected.forEach((targetId: string) => {
+                        col.associationClass!.fields.forEach(linkField => {
+                          if (!linkField.required || linkField.type === 'bool' || linkField.type === 'boolean') {
+                            return;
+                          }
+                          const value = getLinkAttrValue(col.field, String(targetId), linkField.name);
+                          if (value === undefined || value === null || value === "") {
+                            missingFields.push(`${col.label} - ${getLookupOptionLabel(col, String(targetId))} - ${linkField.name}`);
+                          }
+                        });
+                      });
+                    }
                   });
-                  
+
                   if (missingFields.length > 0) {
                     setValidationError(`Please fill in the following required fields: ${missingFields.join(', ')}`);
                     return;
@@ -711,10 +832,27 @@ export const TableComponent: React.FC<Props> = ({
                   formColumns.forEach(col => {
                     // For lookup columns, use the path as the API field name
                     if (col.columnType === 'lookup' && col.path) {
-                      if (col.type === 'list') {
+                      if (col.type === 'list' && col.associationClass) {
+                        // For N:M lookups through an association class, send
+                        // [{ target: <id>, <association class attributes> }]
+                        const value = formValues[col.field];
+                        const selected: string[] = Array.isArray(value) ? value : [];
+                        processedValues[col.path] = selected
+                          .filter(v => !isNaN(parseInt(v, 10)))
+                          .map(v => {
+                            const link: Record<string, any> = { target: parseInt(v, 10) };
+                            col.associationClass!.fields.forEach(linkField => {
+                              link[linkField.name] = coerceLinkAttrValue(
+                                linkField.type,
+                                getLinkAttrValue(col.field, String(v), linkField.name)
+                              );
+                            });
+                            return link;
+                          });
+                      } else if (col.type === 'list') {
                         // For list-type lookups (N:M or 1:N), send array of IDs
                         const value = formValues[col.field];
-                        processedValues[col.path] = Array.isArray(value) 
+                        processedValues[col.path] = Array.isArray(value)
                           ? value.map(v => parseInt(v, 10)).filter(v => !isNaN(v))
                           : [];
                       } else {
@@ -906,10 +1044,116 @@ export const TableComponent: React.FC<Props> = ({
                               })
                             )}
                           </div>
+                          {col.associationClass && col.associationClass.fields.length > 0 && selectedValues.length > 0 && (
+                            <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+                              <span style={{ fontSize: "11px", color: "#64748b" }}>
+                                {humanize(col.associationClass.entity)} details
+                              </span>
+                              {selectedValues.map((targetId: string) => (
+                                <div
+                                  key={`${col.field}-link-${targetId}`}
+                                  style={{
+                                    display: "flex",
+                                    flexDirection: "column",
+                                    gap: "8px",
+                                    border: "1px solid #cbd5f5",
+                                    borderRadius: "6px",
+                                    padding: "8px",
+                                    background: "#f8fafc",
+                                  }}
+                                >
+                                  {col.associationClass!.fields.map((linkField) => {
+                                    const linkInputId = `modal-input-${col.field}-${targetId}-${linkField.name}`;
+                                    const linkValue = getLinkAttrValue(col.field, String(targetId), linkField.name);
+                                    const linkLabel = (
+                                      <label htmlFor={linkInputId} style={{ fontWeight: 500, color: "#334155", fontSize: "13px" }}>
+                                        {getLookupOptionLabel(col, String(targetId))} &mdash; {linkField.name}
+                                        {linkField.required && <span style={{ color: "#ef4444", marginLeft: "4px" }}>*</span>}
+                                      </label>
+                                    );
+
+                                    if (linkField.type === 'enum' && linkField.options && linkField.options.length > 0) {
+                                      return (
+                                        <div key={linkInputId} style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                                          {linkLabel}
+                                          <select
+                                            id={linkInputId}
+                                            value={linkValue ?? ""}
+                                            onChange={e => setLinkAttrValue(col.field, String(targetId), linkField.name, e.target.value)}
+                                            style={{
+                                              padding: "6px 10px",
+                                              borderRadius: "6px",
+                                              border: "1px solid #cbd5f5",
+                                              fontSize: "14px",
+                                              color: "#1e293b",
+                                              background: "#ffffff",
+                                            }}
+                                          >
+                                            <option value="">-- Select {linkField.name} --</option>
+                                            {linkField.options.map((option: string) => (
+                                              <option key={option} value={option}>
+                                                {option}
+                                              </option>
+                                            ))}
+                                          </select>
+                                        </div>
+                                      );
+                                    }
+
+                                    if (linkField.type === 'bool' || linkField.type === 'boolean') {
+                                      return (
+                                        <div key={linkInputId} style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                                          <input
+                                            id={linkInputId}
+                                            type="checkbox"
+                                            checked={Boolean(linkValue)}
+                                            onChange={e => setLinkAttrValue(col.field, String(targetId), linkField.name, e.target.checked)}
+                                            style={{
+                                              width: "16px",
+                                              height: "16px",
+                                              cursor: "pointer",
+                                            }}
+                                          />
+                                          {linkLabel}
+                                        </div>
+                                      );
+                                    }
+
+                                    return (
+                                      <div key={linkInputId} style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                                        {linkLabel}
+                                        <input
+                                          id={linkInputId}
+                                          type={
+                                            linkField.type === 'int' || linkField.type === 'float' ? 'number' :
+                                            linkField.type === 'date' ? 'date' :
+                                            linkField.type === 'datetime' ? 'datetime-local' :
+                                            linkField.type === 'time' ? 'time' :
+                                            'text'
+                                          }
+                                          step={linkField.type === 'float' ? 'any' : undefined}
+                                          value={linkValue ?? ""}
+                                          onChange={e => setLinkAttrValue(col.field, String(targetId), linkField.name, e.target.value)}
+                                          style={{
+                                            padding: "6px 10px",
+                                            borderRadius: "6px",
+                                            border: "1px solid #cbd5f5",
+                                            fontSize: "14px",
+                                            color: "#1e293b",
+                                            background: "#ffffff",
+                                          }}
+                                        />
+                                      </div>
+                                    );
+                                  })}
+                                </div>
+                              ))}
+                            </div>
+                          )}
                         </div>
                       );
                     }
-                    
+
                     // For single lookups (N:1), use regular select
                     return (
                       <div key={col.field} style={{ display: "flex", flexDirection: "column", gap: "4px" }}>

--- a/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
+++ b/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
@@ -1016,8 +1016,12 @@ export const TableComponent: React.FC<Props> = ({
                       const filterText = (lookupFilters[col.field] || "").toLowerCase();
                       const optionLabel = (option: any) =>
                         String((col.lookupField && option[col.lookupField]) || option.pages || option.stock || option.title || `ID: ${option.id}`);
+                      // Checked options stay visible even when the filter excludes
+                      // them, so their inline association panels never disappear.
                       const visibleOptions = filterText
-                        ? options.filter((option: any) => optionLabel(option).toLowerCase().includes(filterText))
+                        ? options.filter((option: any) =>
+                            selectedValues.includes(getOptionValue(col, option)) ||
+                            optionLabel(option).toLowerCase().includes(filterText))
                         : options;
 
                       return (
@@ -1046,7 +1050,7 @@ export const TableComponent: React.FC<Props> = ({
                             />
                           )}
                           <div style={{
-                            maxHeight: "170px",
+                            maxHeight: col.associationClass && col.associationClass.fields.length > 0 ? "320px" : "170px",
                             overflowY: "auto",
                             border: "1px solid #cbd5f5",
                             borderRadius: "6px",
@@ -1063,13 +1067,16 @@ export const TableComponent: React.FC<Props> = ({
                               </div>
                             ) : (
                               visibleOptions.map((option: any) => {
-                                const isChecked = selectedValues.includes(getOptionValue(col, option));
+                                const optionValue = getOptionValue(col, option);
+                                const isChecked = selectedValues.includes(optionValue);
+                                const hasLinkFields = Boolean(col.associationClass && col.associationClass.fields.length > 0);
+                                const targetId = optionValue;
                                 return (
-                                  <div 
-                                    key={getOptionValue(col, option)}
-                                    style={{ 
-                                      display: "flex", 
-                                      alignItems: "center", 
+                                  <React.Fragment key={optionValue}>
+                                  <div
+                                    style={{
+                                      display: "flex",
+                                      alignItems: "center",
                                       gap: "8px",
                                       padding: "6px 4px",
                                       cursor: "pointer",
@@ -1078,10 +1085,9 @@ export const TableComponent: React.FC<Props> = ({
                                     onMouseEnter={(e) => e.currentTarget.style.background = "#e0e7ff"}
                                     onMouseLeave={(e) => e.currentTarget.style.background = "transparent"}
                                     onClick={() => {
-                                      const valueStr = getOptionValue(col, option);
                                       const newSelected = isChecked
-                                        ? selectedValues.filter((v: string) => v !== valueStr)
-                                        : [...selectedValues, valueStr];
+                                        ? selectedValues.filter((v: string) => v !== optionValue)
+                                        : [...selectedValues, optionValue];
                                       setFormValues(fv => ({ ...fv, [col.field]: newSelected }));
                                     }}
                                   >
@@ -1095,40 +1101,24 @@ export const TableComponent: React.FC<Props> = ({
                                         cursor: "pointer",
                                       }}
                                     />
-                                    <span style={{ fontSize: "14px", color: "#1e293b" }}>
-                                      {(col.lookupField && option[col.lookupField]) || option.pages || option.stock || option.title || `ID: ${option.id}`}
+                                    <span style={{ fontSize: "14px", color: "#1e293b", fontWeight: isChecked && hasLinkFields ? 600 : 400 }}>
+                                      {optionLabel(option)}
                                     </span>
                                   </div>
-                                );
-                              })
-                            )}
-                          </div>
-                          {col.associationClass && col.associationClass.fields.length > 0 && selectedValues.length > 0 && (
-                            <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-                              <span style={{
-                                fontSize: "11px",
-                                fontWeight: 700,
-                                letterSpacing: "0.06em",
-                                textTransform: "uppercase",
-                                color: "#64748b",
-                                marginTop: "2px",
-                              }}>
-                                {humanize(col.associationClass.entity)} details
-                              </span>
-                              {selectedValues.map((targetId: string) => (
-                                <div
-                                  key={`${col.field}-link-${targetId}`}
-                                  style={{
-                                    border: "1px solid #dbe3f0",
-                                    borderRadius: "8px",
-                                    padding: "10px 12px",
-                                    background: "#f8fafc",
-                                  }}
-                                >
-                                  <div style={{ fontWeight: 600, fontSize: "13px", color: "#1e293b", marginBottom: "8px" }}>
-                                    {getLookupOptionLabel(col, String(targetId))}
-                                  </div>
-                                  <div style={{ display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: "10px 14px" }}>
+                                  {/* The association attributes unfold right under the
+                                      option they describe: this room, at this price. */}
+                                  {isChecked && hasLinkFields && (
+                                    <div style={{
+                                      margin: "0 4px 8px 26px",
+                                      padding: "10px 12px",
+                                      border: "1px solid #dbe3f0",
+                                      borderLeft: "3px solid #6366f1",
+                                      borderRadius: "8px",
+                                      background: "#ffffff",
+                                      display: "grid",
+                                      gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+                                      gap: "10px 14px",
+                                    }}>
                                   {col.associationClass!.fields.map((linkField) => {
                                     const linkInputId = `modal-input-${col.field}-${targetId}-${linkField.name}`;
                                     const linkValue = getLinkAttrValue(col.field, String(targetId), linkField.name);
@@ -1213,10 +1203,17 @@ export const TableComponent: React.FC<Props> = ({
                                       </div>
                                     );
                                   })}
-                                  </div>
-                                </div>
-                              ))}
-                            </div>
+                                    </div>
+                                  )}
+                                  </React.Fragment>
+                                );
+                              })
+                            )}
+                          </div>
+                          {col.associationClass && col.associationClass.fields.length > 0 && selectedValues.length === 0 && (
+                            <span style={{ fontSize: "12px", color: "#94a3b8" }}>
+                              Tick an option above to fill in its {humanize(col.associationClass.entity).toLowerCase()} values.
+                            </span>
                           )}
                         </div>
                       );

--- a/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
+++ b/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
@@ -30,6 +30,7 @@ interface TableColumn {
   options?: string[];
   required?: boolean;
   lookupField?: string;
+  targetField?: string;
   relationshipKey?: string;
   associationClass?: AssociationClassMeta;
 }
@@ -184,6 +185,7 @@ export const TableComponent: React.FC<Props> = ({
           ? col.path
           : undefined;
         const lookupField = (col as any).lookup_field ?? (col as any).lookupField ?? col.field;
+        const targetField = (col as any).target_field ?? (col as any).targetField;
         const rawAssociationClass = (col as any).association_class ?? (col as any).associationClass;
         const associationClass: AssociationClassMeta | undefined = rawAssociationClass
           ? {
@@ -201,6 +203,7 @@ export const TableComponent: React.FC<Props> = ({
           options: col.options,
           required: col.required ?? false,
           lookupField: col.column_type === "lookup" ? lookupField : undefined,
+          targetField: col.column_type === "lookup" ? targetField : undefined,
           relationshipKey: relationshipKey,
           associationClass: col.column_type === "lookup" ? associationClass : undefined,
         };
@@ -490,15 +493,17 @@ export const TableComponent: React.FC<Props> = ({
     return value;
   };
 
-  // Canonical value of a related record: its lookup field (the entity's id
-  // attribute, which is not necessarily named `id` — e.g. Room.number),
-  // falling back to `id` for entities that use the default primary key.
+  // Canonical value of a related record: the target class's identifying
+  // attribute (target_field — not necessarily named `id`, e.g. Room.number).
+  // Falls back to `id`, then to the display field, for older metadata.
   const getOptionValue = (col: TableColumn, option: any): string => {
-    const raw =
-      col.lookupField && option?.[col.lookupField] !== undefined && option?.[col.lookupField] !== null
-        ? option[col.lookupField]
-        : option?.id;
-    return raw === undefined || raw === null ? "" : String(raw);
+    const candidates = [col.targetField, "id", col.lookupField];
+    for (const key of candidates) {
+      if (key && option?.[key] !== undefined && option?.[key] !== null) {
+        return String(option[key]);
+      }
+    }
+    return "";
   };
 
   // Label shown for a related record (same fallbacks as the lookup selects)

--- a/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
+++ b/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
@@ -462,6 +462,8 @@ export const TableComponent: React.FC<Props> = ({
   // Association class attributes of the selected targets, keyed by
   // { [column field]: { [target id]: { [association class attribute]: value } } }
   const [linkAttrValues, setLinkAttrValues] = useState<Record<string, Record<string, Record<string, any>>>>({});
+  // Text filters for the multi-select option lists, keyed by column field
+  const [lookupFilters, setLookupFilters] = useState<Record<string, string>>({});
 
   const getLinkAttrValue = (field: string, targetId: string, attribute: string): any => {
     return linkAttrValues[field]?.[targetId]?.[attribute] ?? "";
@@ -539,6 +541,7 @@ export const TableComponent: React.FC<Props> = ({
   useEffect(() => {
     if (showModal) {
       setValidationError("");
+      setLookupFilters({});
       const initialValues: Record<string, any> = {};
       formColumns.forEach(col => {
         if (modalMode === 'edit' && editRowData) {
@@ -758,24 +761,30 @@ export const TableComponent: React.FC<Props> = ({
           }}
           >
             <div
+              className="bsr-modal"
               onClick={e => e.stopPropagation()}
               style={{
               background: "#fff",
-              borderRadius: "12px",
-              boxShadow: "0 4px 24px rgba(30,41,59,0.18)",
-              padding: "32px 24px 24px 24px",
+              borderRadius: "14px",
+              boxShadow: "0 20px 50px rgba(15,23,42,0.25)",
+              padding: "24px",
               minWidth: "320px",
-              maxWidth: "90vw",
-              width: "400px",
+              maxWidth: "92vw",
+              width: "620px",
               position: "relative",
               maxHeight: "90vh",
               display: "flex",
               flexDirection: "column",
             }}
             >
-              <h4 style={{ margin: 0, marginBottom: "18px", color: "#1e293b" }}>
-                {modalMode === 'edit' ? `Edit ${dataBinding?.entity || 'Register'}` : `Add ${dataBinding?.entity || 'Register'}`}
-              </h4>
+              <div style={{ marginBottom: "16px", paddingRight: "28px" }}>
+                <h4 style={{ margin: 0, fontSize: "18px", fontWeight: 700, color: "#0f172a" }}>
+                  {modalMode === 'edit' ? `Edit ${dataBinding?.entity || 'Register'}` : `Add ${dataBinding?.entity || 'Register'}`}
+                </h4>
+                <div style={{ marginTop: "3px", fontSize: "13px", color: "#64748b" }}>
+                  Fields marked <span style={{ color: "#ef4444" }}>*</span> are required
+                </div>
+              </div>
               {validationError && (
                 <div style={{
                   padding: "12px",
@@ -980,14 +989,22 @@ export const TableComponent: React.FC<Props> = ({
                 }}
               >
                 <div style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: "12px",
+                  display: "grid",
+                  gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+                  gap: "14px 18px",
+                  alignItems: "start",
                   overflowY: "auto",
-                  maxHeight: "60vh",
-                  paddingRight: "4px",
+                  maxHeight: "62vh",
+                  padding: "2px 6px 8px 2px",
                 }}>
-                {formColumns.map(col => {
+                {formColumns.map((col, colIdx) => {
+                  const prevCol = formColumns[colIdx - 1];
+                  const isRelation = Boolean(col.columnType === 'lookup' && col.entity);
+                  const prevIsRelation = Boolean(prevCol && prevCol.columnType === 'lookup' && prevCol.entity);
+                  const sectionTitle = colIdx === 0
+                    ? (isRelation ? 'Relationships' : 'Details')
+                    : (isRelation && !prevIsRelation ? 'Relationships' : null);
+                  const fieldNode = (() => {
                   // For lookup columns, render a select dropdown
                   if (col.columnType === 'lookup' && col.entity) {
                     const endpoint = col.entity.toLowerCase();
@@ -996,9 +1013,15 @@ export const TableComponent: React.FC<Props> = ({
                     // For list-type lookups (1:N or N:M), use checkbox list
                     if (col.type === 'list') {
                       const selectedValues = formValues[col.field] || [];
-                      
+                      const filterText = (lookupFilters[col.field] || "").toLowerCase();
+                      const optionLabel = (option: any) =>
+                        String((col.lookupField && option[col.lookupField]) || option.pages || option.stock || option.title || `ID: ${option.id}`);
+                      const visibleOptions = filterText
+                        ? options.filter((option: any) => optionLabel(option).toLowerCase().includes(filterText))
+                        : options;
+
                       return (
-                        <div key={col.field} style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+                        <div key={col.field} style={{ gridColumn: "1 / -1", display: "flex", flexDirection: "column", gap: "8px" }}>
                           <label style={{ fontWeight: 500, color: "#334155" }}>
                             {col.label}
                             {col.required && <span style={{ color: "#ef4444", marginLeft: "4px" }}>*</span>}
@@ -1006,8 +1029,24 @@ export const TableComponent: React.FC<Props> = ({
                               ({selectedValues.length} selected)
                             </span>
                           </label>
+                          {options.length > 6 && (
+                            <input
+                              type="search"
+                              value={lookupFilters[col.field] || ""}
+                              onChange={e => setLookupFilters(f => ({ ...f, [col.field]: e.target.value }))}
+                              placeholder={`Filter ${col.label.toLowerCase()}...`}
+                              style={{
+                                padding: "6px 10px",
+                                borderRadius: "6px",
+                                border: "1px solid #cbd5f5",
+                                fontSize: "13px",
+                                color: "#1e293b",
+                                background: "#ffffff",
+                              }}
+                            />
+                          )}
                           <div style={{
-                            maxHeight: "160px",
+                            maxHeight: "170px",
                             overflowY: "auto",
                             border: "1px solid #cbd5f5",
                             borderRadius: "6px",
@@ -1018,8 +1057,12 @@ export const TableComponent: React.FC<Props> = ({
                               <div style={{ padding: "8px", color: "#64748b", fontSize: "14px" }}>
                                 No options available
                               </div>
+                            ) : visibleOptions.length === 0 ? (
+                              <div style={{ padding: "8px", color: "#64748b", fontSize: "14px" }}>
+                                No matches
+                              </div>
                             ) : (
-                              options.map((option: any) => {
+                              visibleOptions.map((option: any) => {
                                 const isChecked = selectedValues.includes(getOptionValue(col, option));
                                 return (
                                   <div 
@@ -1062,28 +1105,36 @@ export const TableComponent: React.FC<Props> = ({
                           </div>
                           {col.associationClass && col.associationClass.fields.length > 0 && selectedValues.length > 0 && (
                             <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-                              <span style={{ fontSize: "11px", color: "#64748b" }}>
+                              <span style={{
+                                fontSize: "11px",
+                                fontWeight: 700,
+                                letterSpacing: "0.06em",
+                                textTransform: "uppercase",
+                                color: "#64748b",
+                                marginTop: "2px",
+                              }}>
                                 {humanize(col.associationClass.entity)} details
                               </span>
                               {selectedValues.map((targetId: string) => (
                                 <div
                                   key={`${col.field}-link-${targetId}`}
                                   style={{
-                                    display: "flex",
-                                    flexDirection: "column",
-                                    gap: "8px",
-                                    border: "1px solid #cbd5f5",
-                                    borderRadius: "6px",
-                                    padding: "8px",
+                                    border: "1px solid #dbe3f0",
+                                    borderRadius: "8px",
+                                    padding: "10px 12px",
                                     background: "#f8fafc",
                                   }}
                                 >
+                                  <div style={{ fontWeight: 600, fontSize: "13px", color: "#1e293b", marginBottom: "8px" }}>
+                                    {getLookupOptionLabel(col, String(targetId))}
+                                  </div>
+                                  <div style={{ display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: "10px 14px" }}>
                                   {col.associationClass!.fields.map((linkField) => {
                                     const linkInputId = `modal-input-${col.field}-${targetId}-${linkField.name}`;
                                     const linkValue = getLinkAttrValue(col.field, String(targetId), linkField.name);
                                     const linkLabel = (
                                       <label htmlFor={linkInputId} style={{ fontWeight: 500, color: "#334155", fontSize: "13px" }}>
-                                        {getLookupOptionLabel(col, String(targetId))} &mdash; {linkField.name}
+                                        {humanize(linkField.name)}
                                         {linkField.required && <span style={{ color: "#ef4444", marginLeft: "4px" }}>*</span>}
                                       </label>
                                     );
@@ -1162,6 +1213,7 @@ export const TableComponent: React.FC<Props> = ({
                                       </div>
                                     );
                                   })}
+                                  </div>
                                 </div>
                               ))}
                             </div>
@@ -1290,34 +1342,66 @@ export const TableComponent: React.FC<Props> = ({
                       />
                     </div>
                   );
+                  })();
+
+                  return (
+                    <React.Fragment key={`section-${col.field}`}>
+                      {sectionTitle && (
+                        <div style={{
+                          gridColumn: "1 / -1",
+                          marginTop: colIdx === 0 ? 0 : "8px",
+                          paddingBottom: "4px",
+                          borderBottom: "1px solid #e2e8f0",
+                          fontSize: "11px",
+                          fontWeight: 700,
+                          letterSpacing: "0.08em",
+                          textTransform: "uppercase",
+                          color: "#64748b",
+                        }}>
+                          {sectionTitle}
+                        </div>
+                      )}
+                      {fieldNode}
+                    </React.Fragment>
+                  );
                 })}
                 </div>
-                <div style={{ display: "flex", justifyContent: "flex-end", gap: "12px", marginTop: "8px" }}>
+                <div style={{
+                  display: "flex",
+                  justifyContent: "flex-end",
+                  gap: "10px",
+                  marginTop: "16px",
+                  paddingTop: "14px",
+                  borderTop: "1px solid #e2e8f0",
+                }}>
                   <button
                     type="button"
                     onClick={() => setShowModal(false)}
                     style={{
-                      padding: "8px 18px",
-                      borderRadius: "6px",
-                      border: "1px solid #cbd5f5",
-                      background: "#f8fafc",
+                      padding: "9px 18px",
+                      borderRadius: "8px",
+                      border: "1px solid #cbd5e1",
+                      background: "#ffffff",
                       color: "#475569",
-                      fontWeight: 500,
+                      fontWeight: 600,
+                      fontSize: "14px",
                       cursor: "pointer",
                     }}
                   >Cancel</button>
                   <button
                     type="submit"
                     style={{
-                      padding: "8px 18px",
-                      borderRadius: "6px",
+                      padding: "9px 22px",
+                      borderRadius: "8px",
                       border: "none",
-                      background: "linear-gradient(90deg, #2563eb 0%, #1e40af 100%)",
+                      background: "#2563eb",
                       color: "#fff",
                       fontWeight: 700,
+                      fontSize: "14px",
                       cursor: "pointer",
+                      boxShadow: "0 1px 2px rgba(37,99,235,0.4)",
                     }}
-                  >Save</button>
+                  >{modalMode === 'edit' ? 'Save changes' : `Add ${dataBinding?.entity || ''}`}</button>
                 </div>
               </form>
               <button
@@ -1325,16 +1409,21 @@ export const TableComponent: React.FC<Props> = ({
                 onClick={() => setShowModal(false)}
                 style={{
                   position: "absolute",
-                  top: "12px",
-                  right: "12px",
-                  background: "none",
+                  top: "14px",
+                  right: "14px",
+                  width: "28px",
+                  height: "28px",
+                  lineHeight: "26px",
+                  textAlign: "center",
+                  borderRadius: "8px",
+                  background: "#f1f5f9",
                   border: "none",
-                  fontSize: "20px",
-                  color: "#64748b",
+                  fontSize: "16px",
+                  color: "#475569",
                   cursor: "pointer",
                 }}
                 aria-label="Close"
-              >x</button>
+              >&times;</button>
             </div>
           </div>,
           document.body

--- a/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
+++ b/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
@@ -490,10 +490,21 @@ export const TableComponent: React.FC<Props> = ({
     return value;
   };
 
+  // Canonical value of a related record: its lookup field (the entity's id
+  // attribute, which is not necessarily named `id` — e.g. Room.number),
+  // falling back to `id` for entities that use the default primary key.
+  const getOptionValue = (col: TableColumn, option: any): string => {
+    const raw =
+      col.lookupField && option?.[col.lookupField] !== undefined && option?.[col.lookupField] !== null
+        ? option[col.lookupField]
+        : option?.id;
+    return raw === undefined || raw === null ? "" : String(raw);
+  };
+
   // Label shown for a related record (same fallbacks as the lookup selects)
   const getLookupOptionLabel = (col: TableColumn, targetId: string): string => {
     const options = lookupOptions[(col.entity || "").toLowerCase()] || [];
-    const option = options.find((item: any) => String(item?.id) === String(targetId));
+    const option = options.find((item: any) => getOptionValue(col, item) === String(targetId));
     if (!option) {
       return `ID: ${targetId}`;
     }
@@ -532,7 +543,7 @@ export const TableComponent: React.FC<Props> = ({
               // For list-type lookups (1:N or N:M), get array of IDs from related objects
               const relatedArray = editRowData[col.relationshipKey || col.field];
               if (Array.isArray(relatedArray)) {
-                initialValues[col.field] = relatedArray.map((item: any) => String(item.id));
+                initialValues[col.field] = relatedArray.map((item: any) => getOptionValue(col, item));
               } else {
                 initialValues[col.field] = [];
               }
@@ -1004,10 +1015,10 @@ export const TableComponent: React.FC<Props> = ({
                               </div>
                             ) : (
                               options.map((option: any) => {
-                                const isChecked = selectedValues.includes(String(option.id));
+                                const isChecked = selectedValues.includes(getOptionValue(col, option));
                                 return (
                                   <div 
-                                    key={option.id} 
+                                    key={getOptionValue(col, option)}
                                     style={{ 
                                       display: "flex", 
                                       alignItems: "center", 
@@ -1019,7 +1030,7 @@ export const TableComponent: React.FC<Props> = ({
                                     onMouseEnter={(e) => e.currentTarget.style.background = "#e0e7ff"}
                                     onMouseLeave={(e) => e.currentTarget.style.background = "transparent"}
                                     onClick={() => {
-                                      const valueStr = String(option.id);
+                                      const valueStr = getOptionValue(col, option);
                                       const newSelected = isChecked
                                         ? selectedValues.filter((v: string) => v !== valueStr)
                                         : [...selectedValues, valueStr];
@@ -1176,7 +1187,7 @@ export const TableComponent: React.FC<Props> = ({
                         >
                           <option value="">-- Select {col.label} --</option>
                           {options.map((option: any) => (
-                            <option key={option.id} value={option.id}>
+                            <option key={getOptionValue(col, option)} value={getOptionValue(col, option)}>
                               {(col.lookupField && option[col.lookupField]) || option.pages || option.stock || option.title || `ID: ${option.id}`}
                             </option>
                           ))}

--- a/besser/generators/rest_api/rest_api_generator.py
+++ b/besser/generators/rest_api/rest_api_generator.py
@@ -5,7 +5,7 @@ from jinja2 import Environment, FileSystemLoader
 from besser.BUML.metamodel.structural import AssociationClass, DomainModel
 from besser.BUML.notations.action_language.ActionLanguageASTBuilder import parse_bal
 from besser.generators import GeneratorInterface
-from besser.generators.structural_utils import get_foreign_keys
+from besser.generators.structural_utils import get_foreign_keys, normalize_method_code
 from besser.generators.action_language.RESTGenerator import bal_to_rest
 from besser.generators.pydantic_classes import PydanticGenerator
 from besser.utilities.utils import sort_by_timestamp
@@ -155,7 +155,8 @@ class RESTAPIGenerator(GeneratorInterface):
                           trim_blocks=True, lstrip_blocks=True, extensions=['jinja2.ext.do'])
             env.filters['clean_method_name'] = clean_method_name
             env.filters['pk'] = pk_of
-            env.globals.update(parse_bal=parse_bal, bal_to_rest=bal_to_rest)
+            env.globals.update(parse_bal=parse_bal, bal_to_rest=bal_to_rest,
+                               normalize_code=normalize_method_code)
             template = env.get_template('backend_fast_api_template.py.j2')
             with open(file_path, mode="w", encoding="utf-8") as f:
                 generated_code = template.render(
@@ -182,7 +183,8 @@ class RESTAPIGenerator(GeneratorInterface):
             os.path.abspath(__file__)), "templates")
             env = Environment(loader=FileSystemLoader(templates_path),
                           trim_blocks=True, lstrip_blocks=True, extensions=['jinja2.ext.do'])
-            env.globals.update(parse_bal=parse_bal, bal_to_rest=bal_to_rest)
+            env.globals.update(parse_bal=parse_bal, bal_to_rest=bal_to_rest,
+                               normalize_code=normalize_method_code)
             template = env.get_template('fast_api_template.py.j2')
             with open(file_path, mode="w", encoding="utf-8") as f:
                 generated_code = template.render(

--- a/besser/generators/rest_api/rest_api_generator.py
+++ b/besser/generators/rest_api/rest_api_generator.py
@@ -1,11 +1,14 @@
 import os
+from typing import Dict
+
 from jinja2 import Environment, FileSystemLoader
-from besser.BUML.metamodel.structural import DomainModel
+from besser.BUML.metamodel.structural import AssociationClass, DomainModel
 from besser.BUML.notations.action_language.ActionLanguageASTBuilder import parse_bal
 from besser.generators import GeneratorInterface
 from besser.generators.structural_utils import get_foreign_keys
 from besser.generators.action_language.RESTGenerator import bal_to_rest
 from besser.generators.pydantic_classes import PydanticGenerator
+from besser.utilities.utils import sort_by_timestamp
 
 class RESTAPIGenerator(GeneratorInterface):
     """
@@ -41,6 +44,60 @@ class RESTAPIGenerator(GeneratorInterface):
         self.backend = backend
         self.nested_creations = nested_creations
         self.port = port
+
+    def get_pk_names(self) -> Dict[str, str]:
+        """
+        Maps every class name of the model to the name of its primary key attribute.
+
+        The selection mirrors the one of the SQLAlchemy generator: the attribute flagged
+        with ``is_id``, otherwise an attribute literally named ``id``, otherwise the
+        surrogate ``id`` column that SQLAlchemy adds to the table.
+
+        Returns:
+            dict: A dictionary with class names as keys and primary key attribute names as values.
+        """
+        pk_names: Dict[str, str] = {}
+        for cls in self.model.get_classes():
+            attributes = sort_by_timestamp(cls.attributes)
+            id_attr = next((attr.name for attr in attributes if attr.is_id), None)
+            if not id_attr:
+                id_attr = next((attr.name for attr in attributes if attr.name == "id"), None)
+            pk_names[cls.name] = id_attr or "id"
+        return pk_names
+
+    def get_association_classes(self) -> Dict[str, dict]:
+        """
+        Describes the association classes of the model.
+
+        An association carrying an association class is materialized by the SQLAlchemy
+        generator as a mapped class (with one ``<end name>_id`` foreign key column per
+        association end plus the attributes of the association class) instead of a plain
+        secondary table, so the REST API has to go through that class to read and write
+        the links.
+
+        Returns:
+            dict: A dictionary with association class names as keys and a description
+            (``association``, ``ends`` and ``attributes``) as values.
+        """
+        assoc_classes: Dict[str, dict] = {}
+        for cls in self.model.get_classes():
+            if not isinstance(cls, AssociationClass):
+                continue
+            assoc_classes[cls.name] = {
+                "association": cls.association.name,
+                "ends": [
+                    {"name": end.name, "type_name": end.type.name}
+                    for end in sorted(cls.association.ends, key=lambda end: end.name)
+                ],
+                "attributes": [
+                    {
+                        "name": attribute.name,
+                        "is_enum": attribute.type.__class__.__name__ == "Enumeration",
+                    }
+                    for attribute in sort_by_timestamp(cls.attributes)
+                ],
+            }
+        return assoc_classes
 
     def generate_requirements(self):
         """
@@ -80,12 +137,24 @@ class RESTAPIGenerator(GeneratorInterface):
             return str(name).strip()
 
         if self.backend:
+            pk_names = self.get_pk_names()
+            assoc_classes = self.get_association_classes()
+            assoc_by_association = {
+                info["association"]: assoc_class_name
+                for assoc_class_name, info in assoc_classes.items()
+            }
+
+            def pk_of(class_name: str) -> str:
+                """Jinja filter returning the primary key attribute name of a class."""
+                return pk_names.get(str(class_name), "id")
+
             file_path = self.build_generation_path(file_name="main_api.py")
             templates_path = os.path.join(os.path.dirname(
             os.path.abspath(__file__)), "templates")
             env = Environment(loader=FileSystemLoader(templates_path),
                           trim_blocks=True, lstrip_blocks=True, extensions=['jinja2.ext.do'])
             env.filters['clean_method_name'] = clean_method_name
+            env.filters['pk'] = pk_of
             env.globals.update(parse_bal=parse_bal, bal_to_rest=bal_to_rest)
             template = env.get_template('backend_fast_api_template.py.j2')
             with open(file_path, mode="w", encoding="utf-8") as f:
@@ -96,7 +165,10 @@ class RESTAPIGenerator(GeneratorInterface):
                     http_methods=self.http_methods,
                     nested_creations=self.nested_creations,
                     port=self.port,
-                    fkeys=get_foreign_keys(self.model)
+                    fkeys=get_foreign_keys(self.model),
+                    pk_names=pk_names,
+                    assoc_classes=assoc_classes,
+                    assoc_by_association=assoc_by_association
                 )
                 f.write(generated_code)
             print("Code generated in the location: " + file_path)

--- a/besser/generators/rest_api/templates/backend_fast_api_template.py.j2
+++ b/besser/generators/rest_api/templates/backend_fast_api_template.py.j2
@@ -146,13 +146,17 @@ async def sqlalchemy_error_handler(request: Request, exc: SQLAlchemyError):
 
 @app.exception_handler(HTTPException)
 async def http_exception_handler(request: Request, exc: HTTPException):
-    """Handle HTTP exceptions with consistent format."""
+    """Handle HTTP exceptions with consistent format.
+
+    `detail` carries the endpoint's actual message — clients (including the
+    generated frontend dialog) read it to show the user what went wrong.
+    """
     return JSONResponse(
         status_code=exc.status_code,
         content={
             "error": exc.detail if isinstance(exc.detail, str) else "HTTP Error",
             "message": exc.detail,
-            "detail": f"HTTP {exc.status_code} error occurred"
+            "detail": exc.detail
         }
     )
 

--- a/besser/generators/rest_api/templates/backend_fast_api_template.py.j2
+++ b/besser/generators/rest_api/templates/backend_fast_api_template.py.j2
@@ -1475,6 +1475,9 @@ async def get_{{x[2]}}_of_{{ class.name | lower}}({{ class.name | lower}}_id: in
 {% elif method.implementation_type.name == "CODE" %}
 {% set method_code = method.code %}
 {% endif %}
+{# Users mix tabs and spaces in the editor's code box; normalize (and
+   compile-gate) the body so one broken method cannot break the whole app. #}
+{% set method_code = normalize_code(method_code, method.name) %}
 
 {# Detect if method is class-level by checking if it does NOT have 'self' as first param #}
 {% set is_class_method = '(self' not in method_code and '(self,' not in method_code %}

--- a/besser/generators/rest_api/templates/backend_fast_api_template.py.j2
+++ b/besser/generators/rest_api/templates/backend_fast_api_template.py.j2
@@ -1,3 +1,4 @@
+{% macro link_attr_names(assoc_class_name) %}({% for attribute in assoc_classes[assoc_class_name].attributes %}'{{ attribute.name }}', {% endfor %}){% endmacro %}
 import uvicorn
 import os, json
 import time as time_module
@@ -265,6 +266,52 @@ async def BAL_reduce(sequence:list, reduce_fn, aggregator) -> any:
         aggregator = reduce_fn(aggregator, elem)
     return aggregator
 
+{% if assoc_classes %}
+
+############################################
+#
+#   Association class link helpers
+#
+############################################
+from enum import Enum as _Enum
+
+_UNSET = object()
+
+
+def _link_target(link):
+    """Return the id of the entity a relationship link payload points to.
+
+    A payload is either a plain id, a mapping, or a model exposing a ``target`` field.
+    """
+    if link is None or isinstance(link, (int, str)):
+        return link
+    if isinstance(link, dict):
+        return link.get("target")
+    return getattr(link, "target", link)
+
+
+def _link_attrs(link, names):
+    """Return the association class attributes carried by a relationship link payload.
+
+    Attributes the payload does not provide are left out, so that they are neither
+    inserted as NULL nor used to overwrite the stored values of an existing link.
+    """
+    if link is None or isinstance(link, (int, str)):
+        return {}
+    values = {}
+    for name in names:
+        if isinstance(link, dict):
+            if name not in link:
+                continue
+            value = link[name]
+        else:
+            value = getattr(link, name, _UNSET)
+            if value is _UNSET:
+                continue
+        values[name] = value.value if isinstance(value, _Enum) else value
+    return values
+
+{% endif %}
 
 {% for class in classes %}
 ############################################
@@ -272,7 +319,9 @@ async def BAL_reduce(sequence:list, reduce_fn, aggregator) -> any:
 #   {{ class.name }} functions
 #
 ############################################
-{% set ns = namespace(end_name_one=[], end_name_multiple=[], one_to_many=[]) %}
+{% set ns = namespace(end_name_one=[], end_name_multiple=[], one_to_many=[], assoc_links=[]) %}
+{% set pk = class.name | pk %}
+{% set is_assoc_class = class.name in assoc_classes %}
 {% set all_parents = class.all_parents() | sort(attribute='name') %}
 {% for association in class.associations %}
     {% if association.ends|length == 2 and association.name not in ns.processed_associations %}
@@ -292,7 +341,10 @@ async def BAL_reduce(sequence:list, reduce_fn, aggregator) -> any:
         {% set name_end1 = lns.end1.name %}
         {% set name_end2 = lns.end2.name %}
         {% if lns.end2.is_navigable %}
-        {% if lns.end1.multiplicity.max > 1 and lns.end2.multiplicity.max > 1 %}
+        {% if association.name in assoc_by_association %}
+            {# The association is materialized by an association class, not by a foreign key or a secondary table #}
+            {% do ns.assoc_links.append((class1_name, class2_name, name_end1, name_end2, assoc_by_association[association.name], lns.end2.multiplicity.min, lns.end2.multiplicity.max)) %}
+        {% elif lns.end1.multiplicity.max > 1 and lns.end2.multiplicity.max > 1 %}
             {% do ns.end_name_multiple.append((class1_name, class2_name, name_end1, name_end2, association.name.lower(), lns.end2.multiplicity.min, lns.end2.multiplicity.max)) %}
         {% elif lns.end1.multiplicity.max == 1 and lns.end2.multiplicity.max > 1 %}
             {# 1:N relationship - Library has many Books #}
@@ -325,7 +377,10 @@ async def BAL_reduce(sequence:list, reduce_fn, aggregator) -> any:
         {% set name_end1 = plns.end1.name %}
         {% set name_end2 = plns.end2.name %}
         {% if plns.end2.is_navigable %}
-        {% if plns.end1.multiplicity.max > 1 and plns.end2.multiplicity.max > 1 %}
+        {% if association.name in assoc_by_association %}
+            {# The inherited association is materialized by an association class #}
+            {% do ns.assoc_links.append((class1_name, class2_name, name_end1, name_end2, assoc_by_association[association.name], plns.end2.multiplicity.min, plns.end2.multiplicity.max)) %}
+        {% elif plns.end1.multiplicity.max > 1 and plns.end2.multiplicity.max > 1 %}
             {% do ns.end_name_multiple.append((class1_name, class2_name, name_end1, name_end2, association.name.lower(), plns.end2.multiplicity.min, plns.end2.multiplicity.max)) %}
         {% elif plns.end1.multiplicity.max == 1 and plns.end2.multiplicity.max > 1 %}
             {# 1:N inherited relationship #}
@@ -345,7 +400,7 @@ async def BAL_reduce(sequence:list, reduce_fn, aggregator) -> any:
 def get_all_{{ class.name | lower}}(detailed: bool = False, database: Session = Depends(get_db)) -> list:
     from sqlalchemy.orm import joinedload
 
-    {% if ns.end_name_one or ns.end_name_multiple or ns.one_to_many %}
+    {% if ns.end_name_one or ns.end_name_multiple or ns.one_to_many or ns.assoc_links %}
     # Use detailed=true to get entities with eagerly loaded relationships (for tables with lookup columns)
     if detailed:
         # Eagerly load all relationships to avoid N+1 queries
@@ -375,7 +430,7 @@ def get_all_{{ class.name | lower}}(detailed: bool = False, database: Session = 
             {% if ns.end_name_multiple or ns.one_to_many %}
             # Add many-to-many and one-to-many relationship objects (full details)
             {% for x in ns.end_name_multiple %}
-            {{x[1] | lower}}_list = database.query({{x[1]}}).join({{x[4]}}, {{x[1]}}.id == {{x[4]}}.c.{{x[3]}}).filter({{x[4]}}.c.{{x[2]}} == {{ class.name | lower}}_item.id).all()
+            {{x[1] | lower}}_list = database.query({{x[1]}}).join({{x[4]}}, {{x[1]}}.{{ x[1] | pk }} == {{x[4]}}.c.{{x[3]}}).filter({{x[4]}}.c.{{x[2]}} == {{ class.name | lower}}_item.{{ pk }}).all()
             item_dict['{{x[3]}}'] = []
             for {{x[1] | lower}}_obj in {{x[1] | lower}}_list:
                 {{x[1] | lower}}_dict = {{x[1] | lower}}_obj.__dict__.copy()
@@ -383,12 +438,28 @@ def get_all_{{ class.name | lower}}(detailed: bool = False, database: Session = 
                 item_dict['{{x[3]}}'].append({{x[1] | lower}}_dict)
             {% endfor %}
             {% for x in ns.one_to_many %}
-            {{x[0] | lower}}_list = database.query({{x[0]}}).filter({{x[0]}}.{{x[1]}}_id == {{ class.name | lower}}_item.id).all()
+            {{x[0] | lower}}_list = database.query({{x[0]}}).filter({{x[0]}}.{{x[1]}}_id == {{ class.name | lower}}_item.{{ pk }}).all()
             item_dict['{{x[2]}}'] = []
             for {{x[0] | lower}}_obj in {{x[0] | lower}}_list:
                 {{x[0] | lower}}_dict = {{x[0] | lower}}_obj.__dict__.copy()
                 {{x[0] | lower}}_dict.pop('_sa_instance_state', None)
                 item_dict['{{x[2]}}'].append({{x[0] | lower}}_dict)
+            {% endfor %}
+            {% endif %}
+            {% if ns.assoc_links %}
+            # Add association class links (target entities and the link rows themselves)
+            {% for x in ns.assoc_links %}
+            {{x[3]}}_link_rows = database.query({{x[4]}}).filter({{x[4]}}.{{x[2]}}_id == {{ class.name | lower}}_item.{{ pk }}).all()
+            item_dict['{{x[3]}}_links'] = []
+            for link_row in {{x[3]}}_link_rows:
+                link_dict = link_row.__dict__.copy()
+                link_dict.pop('_sa_instance_state', None)
+                item_dict['{{x[3]}}_links'].append(link_dict)
+            item_dict['{{x[3]}}'] = []
+            for {{x[1] | lower}}_obj in database.query({{x[1]}}).filter({{x[1]}}.{{ x[1] | pk }}.in_([getattr(link_row, '{{x[3]}}_id') for link_row in {{x[3]}}_link_rows])).all():
+                {{x[1] | lower}}_dict = {{x[1] | lower}}_obj.__dict__.copy()
+                {{x[1] | lower}}_dict.pop('_sa_instance_state', None)
+                item_dict['{{x[3]}}'].append({{x[1] | lower}}_dict)
             {% endfor %}
             {% endif %}
 
@@ -414,7 +485,7 @@ def get_paginated_{{ class.name | lower}}(skip: int = 0, limit: int = 100, detai
     """Get paginated list of {{ class.name }} entities"""
     total = database.query({{ class.name }}).count()
     {{ class.name | lower}}_list = database.query({{ class.name }}).offset(skip).limit(limit).all()
-    {% if ns.end_name_multiple or ns.one_to_many %}
+    {% if ns.end_name_multiple or ns.one_to_many or ns.assoc_links %}
     # By default, return flat entities (for charts/widgets)
     # Use detailed=true to get entities with relationships
     if not detailed:
@@ -428,15 +499,21 @@ def get_paginated_{{ class.name | lower}}(skip: int = 0, limit: int = 100, detai
     result = []
     for {{ class.name | lower}}_item in {{ class.name | lower}}_list:
         {% for x in ns.end_name_multiple %}
-        {{x[1] | lower}}_ids = database.query({{x[4]}}.c.{{x[3]}}).filter({{x[4]}}.c.{{x[2]}} == {{ class.name | lower}}_item.id).all()
+        {{x[1] | lower}}_ids = database.query({{x[4]}}.c.{{x[3]}}).filter({{x[4]}}.c.{{x[2]}} == {{ class.name | lower}}_item.{{ pk }}).all()
+        {% endfor %}
+        {% for x in ns.assoc_links %}
+        {{x[3]}}_ids = database.query({{x[4]}}.{{x[3]}}_id).filter({{x[4]}}.{{x[2]}}_id == {{ class.name | lower}}_item.{{ pk }}).all()
         {% endfor %}
         {% for x in ns.one_to_many %}
-        {{x[2]}}_ids = database.query({{x[0]}}.id).filter({{x[0]}}.{{x[1]}}_id == {{ class.name | lower}}_item.id).all()
+        {{x[2]}}_ids = database.query({{x[0]}}.{{ x[0] | pk }}).filter({{x[0]}}.{{x[1]}}_id == {{ class.name | lower}}_item.{{ pk }}).all()
         {% endfor %}
         item_data = {
             "{{class.name | lower}}": {{ class.name | lower}}_item,
             {% for x in ns.end_name_multiple %}
             "{{x[1] | lower}}_ids": [x[0] for x in {{x[1] | lower}}_ids],
+            {% endfor %}
+            {% for x in ns.assoc_links %}
+            "{{x[3]}}_ids": [x[0] for x in {{x[3]}}_ids],
             {% endfor %}
             {% for x in ns.one_to_many %}
             "{{x[2]}}_ids": [x[0] for x in {{x[2]}}_ids]{% if not loop.last %},{% endif %}
@@ -486,20 +563,40 @@ def search_{{ class.name | lower}}(
     return results
 
 
+{% if is_assoc_class %}
+{% set ac_ends = assoc_classes[class.name].ends %}
+{# An association class is keyed by the foreign keys of its two association ends, so it is
+   addressed as /{{ class.name | lower }}/{<{{ ac_ends[0].name }} id>}/{<{{ ac_ends[1].name }} id>}/ #}
+@app.get("/{{ class.name | lower}}/{% raw %}{{% endraw %}{{ ac_ends[0].name }}_id{% raw %}}{% endraw %}/{% raw %}{{% endraw %}{{ ac_ends[1].name }}_id{% raw %}}{% endraw %}/", response_model=None, tags=["{{ class.name }}"])
+async def get_{{ class.name | lower}}({{ ac_ends[0].name }}_id: int, {{ ac_ends[1].name }}_id: int, database: Session = Depends(get_db)) -> {{ class.name }}:
+    """Get the {{ class.name }} link between a {{ ac_ends[0].type_name }} and a {{ ac_ends[1].type_name }}"""
+    db_{{ class.name | lower}} = database.query({{ class.name }}).filter(
+        ({{ class.name }}.{{ ac_ends[0].name }}_id == {{ ac_ends[0].name }}_id) &
+        ({{ class.name }}.{{ ac_ends[1].name }}_id == {{ ac_ends[1].name }}_id)
+    ).first()
+    if db_{{ class.name | lower}} is None:
+        raise HTTPException(status_code=404, detail="{{ class.name }} not found")
+    return db_{{ class.name | lower}}
+{% else %}
 @app.get("/{{ class.name | lower}}/{% raw %}{{% endraw %}{{ class.name | lower}}_id{% raw %}}{% endraw %}/", response_model=None, tags=["{{ class.name }}"])
 async def get_{{ class.name | lower}}({{ class.name | lower}}_id: int, database: Session = Depends(get_db)) -> {{ class.name }}:
-    db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.id == {{ class.name | lower}}_id).first()
+    db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.{{ pk }} == {{ class.name | lower}}_id).first()
     if db_{{ class.name | lower}} is None:
         raise HTTPException(status_code=404, detail="{{ class.name }} not found")
 
     {% if ns.end_name_multiple  %}
     {% for x in ns.end_name_multiple %}
-    {{x[1] | lower}}_ids = database.query({{x[4]}}.c.{{x[3]}}).filter({{x[4]}}.c.{{x[2]}} == db_{{ class.name | lower}}.id).all()
+    {{x[1] | lower}}_ids = database.query({{x[4]}}.c.{{x[3]}}).filter({{x[4]}}.c.{{x[2]}} == db_{{ class.name | lower}}.{{ pk }}).all()
+    {% endfor %}
+    {% endif %}
+    {% if ns.assoc_links %}
+    {% for x in ns.assoc_links %}
+    {{x[3]}}_ids = database.query({{x[4]}}.{{x[3]}}_id).filter({{x[4]}}.{{x[2]}}_id == db_{{ class.name | lower}}.{{ pk }}).all()
     {% endfor %}
     {% endif %}
     {% if ns.one_to_many %}
     {% for x in ns.one_to_many %}
-    {{x[2]}}_ids = database.query({{x[0]}}.id).filter({{x[0]}}.{{x[1]}}_id == db_{{ class.name | lower}}.id).all()
+    {{x[2]}}_ids = database.query({{x[0]}}.{{ x[0] | pk }}).filter({{x[0]}}.{{x[1]}}_id == db_{{ class.name | lower}}.{{ pk }}).all()
     {% endfor %}
     {% endif %}
     response_data = {
@@ -507,16 +604,52 @@ async def get_{{ class.name | lower}}({{ class.name | lower}}_id: int, database:
         {% for x in ns.end_name_multiple %}
         "{{x[1] | lower}}_ids": [x[0] for x in {{x[1] | lower}}_ids],
         {% endfor %}
+        {% for x in ns.assoc_links %}
+        "{{x[3]}}_ids": [x[0] for x in {{x[3]}}_ids],
+        {% endfor %}
         {% for x in ns.one_to_many %}
         "{{x[2]}}_ids": [x[0] for x in {{x[2]}}_ids]{% if not loop.last %},{% endif %}
         {% endfor -%}
     }
     return response_data
+{% endif %}
 
 {% endif %}
 
 
 {% if "POST" in http_methods %}
+{% if is_assoc_class %}
+{% set ac_ends = assoc_classes[class.name].ends %}
+@app.post("/{{ class.name | lower}}/", response_model=None, tags=["{{ class.name }}"])
+async def create_{{ class.name | lower}}({{ class.name | lower}}_data: {{ class.name }}Create, database: Session = Depends(get_db)) -> {{ class.name }}:
+    """Create a {{ class.name }} link.
+
+    The Create model carries one field per association end ({% for end in ac_ends %}`{{ end.name }}`{% if not loop.last %}, {% endif %}{% endfor %}) holding
+    the id of the linked entity, plus the attributes of the association class.
+    """
+    {% for end in ac_ends %}
+    {{ end.name }}_target = _link_target(getattr({{ class.name | lower}}_data, '{{ end.name }}', None))
+    if {{ end.name }}_target is None:
+        raise HTTPException(status_code=400, detail="{{ end.type_name }} ID is required")
+    db_{{ end.name }} = database.query({{ end.type_name }}).filter({{ end.type_name }}.{{ end.type_name | pk }} == {{ end.name }}_target).first()
+    if db_{{ end.name }} is None:
+        raise HTTPException(status_code=404, detail=f"{{ end.type_name }} with ID {% raw %}{{% endraw %}{{ end.name }}_target{% raw %}}{% endraw %} not found")
+    {% endfor %}
+
+    db_{{ class.name | lower}} = {{ class.name }}(
+        {% for end in ac_ends %}
+        {{ end.name }}_id={{ end.name }}_target,
+        {% endfor %}
+        {% for attribute in assoc_classes[class.name].attributes %}
+        {{ attribute.name }}={{ class.name | lower}}_data.{{ attribute.name }}{% if attribute.is_enum %}.value{% endif %}{% if not loop.last %},{% endif %}
+        {% endfor %}
+        )
+
+    database.add(db_{{ class.name | lower}})
+    database.commit()
+    database.refresh(db_{{ class.name | lower}})
+    return db_{{ class.name | lower}}
+{% else %}
 @app.post("/{{ class.name | lower}}/", response_model=None, tags=["{{ class.name }}"])
 async def create_{{ class.name | lower}}({{ class.name | lower}}_data: {{ class.name }}Create, database: Session = Depends(get_db)) -> {{ class.name }}:
 
@@ -525,7 +658,7 @@ async def create_{{ class.name | lower}}({{ class.name | lower}}_data: {{ class.
     {%- set has_fk = (fkeys.get(x[3], [''])[0] == class.name) -%}
     {% if has_fk %}
     if {{ class.name | lower}}_data.{{x[2]}} {% if x[1]==1 %}is not None{%endif%}:
-        db_{{x[2]}} = database.query({{x[0]}}).filter({{x[0]}}.id == {{ class.name | lower}}_data.{{x[2]}}).first()
+        db_{{x[2]}} = database.query({{x[0]}}).filter({{x[0]}}.{{ x[0] | pk }} == {{ class.name | lower}}_data.{{x[2]}}).first()
         if not db_{{x[2]}}:
             raise HTTPException(status_code=400, detail="{{x[0]}} not found")
     {%if x[1] == 1 %}
@@ -551,10 +684,10 @@ async def create_{{ class.name | lower}}({{ class.name | lower}}_data: {{ class.
                 {% endfor %}
             {% endif %}
             {%- if (plns.end1.multiplicity.max == 1 or plns.end1.multiplicity.max > 1) and plns.end2.multiplicity.max == 1 -%}
-                {%- set parent_has_fk = (fkeys.get(association.name, [''])[0] == parent.name) -%}
+                {%- set parent_has_fk = (fkeys.get(association.name, [''])[0] == parent.name and association.name not in assoc_by_association) -%}
                 {% if parent_has_fk %}
     if {{ class.name | lower}}_data.{{plns.end2.name}} {% if plns.end2.multiplicity.min==1 %}is not None{%endif%}:
-        db_{{plns.end2.name}} = database.query({{plns.end2.type.name}}).filter({{plns.end2.type.name}}.id == {{ class.name | lower}}_data.{{plns.end2.name}}).first()
+        db_{{plns.end2.name}} = database.query({{plns.end2.type.name}}).filter({{plns.end2.type.name}}.{{ plns.end2.type.name | pk }} == {{ class.name | lower}}_data.{{plns.end2.name}}).first()
         if not db_{{plns.end2.name}}:
             raise HTTPException(status_code=400, detail="{{plns.end2.type.name}} not found")
     {%if plns.end2.multiplicity.min == 1 %}
@@ -577,9 +710,39 @@ async def create_{{ class.name | lower}}({{ class.name | lower}}_data: {{ class.
     if {{ class.name | lower}}_data.{{x[3]}}:
         for id in {{ class.name | lower}}_data.{{x[3]}}:
             # Entity already validated before creation
-            db_{{x[1] | lower}} = database.query({{x[1]}}).filter({{x[1]}}.id == id).first()
+            db_{{x[1] | lower}} = database.query({{x[1]}}).filter({{x[1]}}.{{ x[1] | pk }} == id).first()
             if not db_{{x[1] | lower}}:
                 raise HTTPException(status_code=404, detail=f"{{x[1]}} with ID {id} not found")
+    {% endfor %}
+    {% endif %}
+    {% if ns.assoc_links %}
+    {# Validate the targets of the association class links before creating the main entity.
+       The link payloads are read with getattr because the Create model only exposes the
+       navigable ends of the association. #}
+    {% for x in ns.assoc_links %}
+    {{x[3]}}_payload = getattr({{ class.name | lower}}_data, '{{x[3]}}', None)
+    {% if x[6] > 1 %}
+    {% if x[5] > 0 %}
+    if not {{x[3]}}_payload or len({{x[3]}}_payload) < {{x[5]}}:
+        raise HTTPException(status_code=400, detail="At least {{x[5]}} {{x[1]}}(s) required")
+    {% endif %}
+    if {{x[3]}}_payload:
+        for link in {{x[3]}}_payload:
+            {{x[3]}}_target = _link_target(link)
+            db_{{x[1] | lower}} = database.query({{x[1]}}).filter({{x[1]}}.{{ x[1] | pk }} == {{x[3]}}_target).first()
+            if not db_{{x[1] | lower}}:
+                raise HTTPException(status_code=404, detail=f"{{x[1]}} with ID {% raw %}{{% endraw %}{{x[3]}}_target{% raw %}}{% endraw %} not found")
+    {% else %}
+    {# To-one end through an association class: the link is optional at creation
+       time (it can be established later from the other side or via the
+       association-class endpoint), otherwise neither entity could be created
+       first. #}
+    if {{x[3]}}_payload is not None:
+        {{x[3]}}_target = _link_target({{x[3]}}_payload)
+        db_{{x[1] | lower}} = database.query({{x[1]}}).filter({{x[1]}}.{{ x[1] | pk }} == {{x[3]}}_target).first()
+        if not db_{{x[1] | lower}}:
+            raise HTTPException(status_code=404, detail=f"{{x[1]}} with ID {% raw %}{{% endraw %}{{x[3]}}_target{% raw %}}{% endraw %} not found")
+    {% endif %}
     {% endfor %}
     {% endif %}
 
@@ -625,12 +788,12 @@ async def create_{{ class.name | lower}}({{ class.name | lower}}_data: {{ class.
                 {% endfor %}
             {% endif %}
             {%- if plns.end1.multiplicity.max == 1 and plns.end2.multiplicity.max == 1 -%}
-                {%- set parent_has_fk = (fkeys.get(association.name, [''])[0] == parent.name) -%}
+                {%- set parent_has_fk = (fkeys.get(association.name, [''])[0] == parent.name and association.name not in assoc_by_association) -%}
                 {% if parent_has_fk %}
     {% do ns_args.args.append(plns.end2.name ~ '_id=' ~ class.name|lower ~ '_data.' ~ plns.end2.name) %}
                 {% endif -%}
             {%- elif plns.end1.multiplicity.max > 1 and plns.end2.multiplicity.max == 1 -%}
-                {%- set parent_has_fk = (fkeys.get(association.name, [''])[0] == parent.name) -%}
+                {%- set parent_has_fk = (fkeys.get(association.name, [''])[0] == parent.name and association.name not in assoc_by_association) -%}
                 {% if parent_has_fk %}
     {% do ns_args.args.append(plns.end2.name ~ '_id=' ~ class.name|lower ~ '_data.' ~ plns.end2.name) %}
                 {% endif -%}
@@ -655,26 +818,49 @@ async def create_{{ class.name | lower}}({{ class.name | lower}}_data: {{ class.
     if {{ class.name | lower }}_data.{{x[2]}}:
         # Validate that all {{x[0]}} IDs exist
         for {{x[0] | lower}}_id in {{ class.name | lower }}_data.{{x[2]}}:
-            db_{{x[0] | lower}} = database.query({{x[0]}}).filter({{x[0]}}.id == {{x[0] | lower}}_id).first()
+            db_{{x[0] | lower}} = database.query({{x[0]}}).filter({{x[0]}}.{{ x[0] | pk }} == {{x[0] | lower}}_id).first()
             if not db_{{x[0] | lower}}:
                 raise HTTPException(status_code=400, detail=f"{{x[0]}} with id {% raw %}{{% endraw %}{{x[0] | lower}}_id{% raw %}}{% endraw %} not found")
 
         # Update the related entities with the new foreign key
-        database.query({{x[0]}}).filter({{x[0]}}.id.in_({{ class.name | lower }}_data.{{x[2]}})).update(
-            {{"{"}}{{x[0]}}.{{x[1]}}_id: db_{{ class.name | lower }}.id{{"}"}}, synchronize_session=False
+        database.query({{x[0]}}).filter({{x[0]}}.{{ x[0] | pk }}.in_({{ class.name | lower }}_data.{{x[2]}})).update(
+            {{"{"}}{{x[0]}}.{{x[1]}}_id: db_{{ class.name | lower }}.{{ pk }}{{"}"}}, synchronize_session=False
         )
         database.commit()
     {% endfor %}
     {% endif %}
 
+    {# Create the association class rows carrying the links of this entity #}
+    {% if ns.assoc_links %}
+    {% for x in ns.assoc_links %}
+    {% if x[6] > 1 %}
+    if {{x[3]}}_payload:
+        for link in {{x[3]}}_payload:
+            database.add({{x[4]}}(
+                {{x[2]}}_id=db_{{ class.name | lower }}.{{ pk }},
+                {{x[3]}}_id=_link_target(link),
+                **_link_attrs(link, {{ link_attr_names(x[4]) }})
+            ))
+        database.commit()
+    {% else %}
+    if {{x[3]}}_payload is not None:
+        database.add({{x[4]}}(
+            {{x[2]}}_id=db_{{ class.name | lower }}.{{ pk }},
+            {{x[3]}}_id=_link_target({{x[3]}}_payload),
+            **_link_attrs({{x[3]}}_payload, {{ link_attr_names(x[4]) }})
+        ))
+        database.commit()
+    {% endif %}
+    {% endfor %}
+    {% endif %}
     {% if ns.end_name_multiple and not nested_creations %}
     {% for x in ns.end_name_multiple %}
     if {{ class.name | lower}}_data.{{x[3]}}:
         for id in {{ class.name | lower}}_data.{{x[3]}}:
             # Entity already validated before creation
-            db_{{x[1] | lower}} = database.query({{x[1]}}).filter({{x[1]}}.id == id).first()
+            db_{{x[1] | lower}} = database.query({{x[1]}}).filter({{x[1]}}.{{ x[1] | pk }} == id).first()
             # Create the association
-            association = {{x[4]}}.insert().values({{ x[2] }}=db_{{ class.name | lower }}.id, {{ x[3] }}=db_{{ x[1]|lower }}.id)
+            association = {{x[4]}}.insert().values({{ x[2] }}=db_{{ class.name | lower }}.{{ pk }}, {{ x[3] }}=db_{{ x[1]|lower }}.{{ x[1] | pk }})
             database.execute(association)
             database.commit()
     {% endfor -%}
@@ -687,7 +873,7 @@ async def create_{{ class.name | lower}}({{ class.name | lower}}_data: {{ class.
             {%for lk_class in classes%}
             {% if lk_class.name == x[1] %}
             if isinstance(x, int):
-                db_{{x[1] | lower}} = database.query({{x[1]}}).filter({{x[1]}}.id == x).first()
+                db_{{x[1] | lower}} = database.query({{x[1]}}).filter({{x[1]}}.{{ x[1] | pk }} == x).first()
                 if db_{{x[1] | lower}} is None:
                     raise HTTPException(status_code=404, detail=f"{{x[1]}} with ID {x} not found")
             else:
@@ -699,7 +885,7 @@ async def create_{{ class.name | lower}}({{ class.name | lower}}_data: {{ class.
             database.add(db_{{x[1] | lower}})
             database.commit()
             # Create the association
-            association = {{x[4]}}.insert().values({{ class.name | lower}}_id=db_{{ class.name | lower}}.id, {{ x[1]|lower }}_id=db_{{ x[1]|lower }}.id)
+            association = {{x[4]}}.insert().values({{ class.name | lower}}_id=db_{{ class.name | lower}}.{{ pk }}, {{ x[1]|lower }}_id=db_{{ x[1]|lower }}.{{ x[1] | pk }})
             database.execute(association)
             database.commit()
             {% endif %}
@@ -707,18 +893,24 @@ async def create_{{ class.name | lower}}({{ class.name | lower}}_data: {{ class.
     {% endfor %}
     {% endif %}
 
-    {% if ns.end_name_multiple or ns.one_to_many %}
+    {% if ns.end_name_multiple or ns.one_to_many or ns.assoc_links %}
     {# Return response with relationship IDs like GET endpoint #}
     {% for x in ns.end_name_multiple %}
-    {{x[1] | lower}}_ids = database.query({{x[4]}}.c.{{x[3]}}).filter({{x[4]}}.c.{{x[2]}} == db_{{ class.name | lower}}.id).all()
+    {{x[1] | lower}}_ids = database.query({{x[4]}}.c.{{x[3]}}).filter({{x[4]}}.c.{{x[2]}} == db_{{ class.name | lower}}.{{ pk }}).all()
+    {% endfor %}
+    {% for x in ns.assoc_links %}
+    {{x[3]}}_ids = database.query({{x[4]}}.{{x[3]}}_id).filter({{x[4]}}.{{x[2]}}_id == db_{{ class.name | lower}}.{{ pk }}).all()
     {% endfor %}
     {% for x in ns.one_to_many %}
-    {{x[2]}}_ids = database.query({{x[0]}}.id).filter({{x[0]}}.{{x[1]}}_id == db_{{ class.name | lower}}.id).all()
+    {{x[2]}}_ids = database.query({{x[0]}}.{{ x[0] | pk }}).filter({{x[0]}}.{{x[1]}}_id == db_{{ class.name | lower}}.{{ pk }}).all()
     {% endfor %}
     response_data = {
         "{{class.name | lower}}": db_{{ class.name | lower}},
         {% for x in ns.end_name_multiple %}
         "{{x[1] | lower}}_ids": [x[0] for x in {{x[1] | lower}}_ids],
+        {% endfor %}
+        {% for x in ns.assoc_links %}
+        "{{x[3]}}_ids": [x[0] for x in {{x[3]}}_ids],
         {% endfor %}
         {% for x in ns.one_to_many %}
         "{{x[2]}}_ids": [x[0] for x in {{x[2]}}_ids]{% if not loop.last %},{% endif %}
@@ -728,10 +920,11 @@ async def create_{{ class.name | lower}}({{ class.name | lower}}_data: {{ class.
     {% else %}
     return db_{{ class.name | lower}}
     {% endif %}
+{% endif %}
 
 {% endif %}
 
-{% if "POST" in http_methods %}
+{% if "POST" in http_methods and not is_assoc_class %}
 @app.post("/{{ class.name | lower}}/bulk/", response_model=None, tags=["{{ class.name }}"])
 async def bulk_create_{{ class.name | lower}}(items: list[{{ class.name }}Create], database: Session = Depends(get_db)) -> dict:
     """Create multiple {{ class.name }} entities at once"""
@@ -766,7 +959,7 @@ async def bulk_create_{{ class.name | lower}}(items: list[{{ class.name }}Create
                         {% endfor %}
                     {% endif %}
                     {%- if (plns.end1.multiplicity.max == 1 or plns.end1.multiplicity.max > 1) and plns.end2.multiplicity.max == 1 -%}
-                        {%- set parent_has_fk = (fkeys.get(association.name, [''])[0] == parent.name) -%}
+                        {%- set parent_has_fk = (fkeys.get(association.name, [''])[0] == parent.name and association.name not in assoc_by_association) -%}
                         {% if parent_has_fk and plns.end2.multiplicity.min == 1 %}
             if not item_data.{{plns.end2.name}}:
                 raise ValueError("{{plns.end2.type.name}} ID is required")
@@ -818,12 +1011,12 @@ async def bulk_create_{{ class.name | lower}}(items: list[{{ class.name }}Create
                         {% endfor %}
                     {% endif %}
                     {%- if plns.end1.multiplicity.max == 1 and plns.end2.multiplicity.max == 1 -%}
-                        {%- set parent_has_fk = (fkeys.get(association.name, [''])[0] == parent.name) -%}
+                        {%- set parent_has_fk = (fkeys.get(association.name, [''])[0] == parent.name and association.name not in assoc_by_association) -%}
                         {% if parent_has_fk %}
             {% do ns_bulk_args.args.append(plns.end2.name ~ '_id=item_data.' ~ plns.end2.name) %}
                         {% endif -%}
                     {%- elif plns.end1.multiplicity.max > 1 and plns.end2.multiplicity.max == 1 -%}
-                        {%- set parent_has_fk = (fkeys.get(association.name, [''])[0] == parent.name) -%}
+                        {%- set parent_has_fk = (fkeys.get(association.name, [''])[0] == parent.name and association.name not in assoc_by_association) -%}
                         {% if parent_has_fk %}
             {% do ns_bulk_args.args.append(plns.end2.name ~ '_id=item_data.' ~ plns.end2.name) %}
                         {% endif -%}
@@ -838,7 +1031,7 @@ async def bulk_create_{{ class.name | lower}}(items: list[{{ class.name }}Create
             )
             database.add(db_{{ class.name | lower}})
             database.flush()  # Get ID without committing
-            created_items.append(db_{{ class.name | lower}}.id)
+            created_items.append(db_{{ class.name | lower}}.{{ pk }})
         except Exception as e:
             errors.append({"index": idx, "error": str(e)})
 
@@ -861,7 +1054,7 @@ async def bulk_delete_{{ class.name | lower}}(ids: list[int], database: Session 
     not_found = []
 
     for item_id in ids:
-        db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.id == item_id).first()
+        db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.{{ pk }} == item_id).first()
         if db_{{ class.name | lower}}:
             database.delete(db_{{ class.name | lower}})
             deleted_count += 1
@@ -879,9 +1072,28 @@ async def bulk_delete_{{ class.name | lower}}(ids: list[int], database: Session 
 
 {% if class.is_read_only == False %}
 {% if "PUT" in http_methods %}
+{% if is_assoc_class %}
+{% set ac_ends = assoc_classes[class.name].ends %}
+@app.put("/{{ class.name | lower }}/{% raw %}{{% endraw %}{{ ac_ends[0].name }}_id{% raw %}}{% endraw %}/{% raw %}{{% endraw %}{{ ac_ends[1].name }}_id{% raw %}}{% endraw %}/", response_model=None, tags=["{{ class.name }}"])
+async def update_{{ class.name | lower }}({{ ac_ends[0].name }}_id: int, {{ ac_ends[1].name }}_id: int, {{ class.name | lower }}_data: {{ class.name }}Create, database: Session = Depends(get_db)) -> {{ class.name }}:
+    """Update the attributes of the {{ class.name }} link identified by both foreign keys"""
+    db_{{ class.name | lower }} = database.query({{ class.name }}).filter(
+        ({{ class.name }}.{{ ac_ends[0].name }}_id == {{ ac_ends[0].name }}_id) &
+        ({{ class.name }}.{{ ac_ends[1].name }}_id == {{ ac_ends[1].name }}_id)
+    ).first()
+    if db_{{ class.name | lower }} is None:
+        raise HTTPException(status_code=404, detail="{{ class.name }} not found")
+
+    {% for attribute in assoc_classes[class.name].attributes %}
+    setattr(db_{{ class.name | lower }}, '{{ attribute.name }}', {{ class.name | lower }}_data.{{ attribute.name }}{% if attribute.is_enum %}.value{% endif %})
+    {% endfor %}
+    database.commit()
+    database.refresh(db_{{ class.name | lower }})
+    return db_{{ class.name | lower }}
+{% else %}
 @app.put("/{{ class.name | lower }}/{% raw %}{{% endraw %}{{ class.name | lower }}_id{% raw %}}{% endraw %}/", response_model=None, tags=["{{ class.name }}"])
 async def update_{{ class.name | lower }}({{ class.name | lower }}_id: int, {{ class.name | lower }}_data: {{ class.name }}Create, database: Session = Depends(get_db)) -> {{ class.name }}:
-    db_{{ class.name | lower }} = database.query({{ class.name }}).filter({{ class.name }}.id == {{ class.name | lower }}_id).first()
+    db_{{ class.name | lower }} = database.query({{ class.name }}).filter({{ class.name }}.{{ pk }} == {{ class.name | lower }}_id).first()
     if db_{{ class.name | lower }} is None:
         raise HTTPException(status_code=404, detail="{{ class.name }} not found")
 
@@ -895,7 +1107,7 @@ async def update_{{ class.name | lower }}({{ class.name | lower }}_id: int, {{ c
     {%- set has_fk = (fkeys.get(x[3], [''])[0] == class.name) -%}
     {% if has_fk %}
     if {{ class.name | lower}}_data.{{x[2]}} is not None:
-        db_{{x[2]}} = database.query({{x[0]}}).filter({{x[0]}}.id == {{ class.name | lower}}_data.{{x[2]}}).first()
+        db_{{x[2]}} = database.query({{x[0]}}).filter({{x[0]}}.{{ x[0] | pk }} == {{ class.name | lower}}_data.{{x[2]}}).first()
         if not db_{{x[2]}}:
             raise HTTPException(status_code=400, detail="{{x[0]}} not found")
         setattr(db_{{ class.name | lower }}, '{{x[2]}}_id', {{ class.name | lower }}_data.{{x[2]}})
@@ -912,7 +1124,7 @@ async def update_{{ class.name | lower }}({{ class.name | lower }}_id: int, {{ c
     {# x[0] = related class, x[1] = foreign key field name, x[2] = relationship name #}
     if {{ class.name | lower }}_data.{{x[2]}} is not None:
         # Clear all existing relationships (set foreign key to NULL)
-        database.query({{x[0]}}).filter({{x[0]}}.{{x[1]}}_id == db_{{ class.name | lower }}.id).update(
+        database.query({{x[0]}}).filter({{x[0]}}.{{x[1]}}_id == db_{{ class.name | lower }}.{{ pk }}).update(
             {{"{"}}{{x[0]}}.{{x[1]}}_id: None{{"}"}}, synchronize_session=False
         )
 
@@ -920,51 +1132,89 @@ async def update_{{ class.name | lower }}({{ class.name | lower }}_id: int, {{ c
         if {{ class.name | lower }}_data.{{x[2]}}:
             # Validate that all IDs exist
             for {{x[0] | lower}}_id in {{ class.name | lower }}_data.{{x[2]}}:
-                db_{{x[0] | lower}} = database.query({{x[0]}}).filter({{x[0]}}.id == {{x[0] | lower}}_id).first()
+                db_{{x[0] | lower}} = database.query({{x[0]}}).filter({{x[0]}}.{{ x[0] | pk }} == {{x[0] | lower}}_id).first()
                 if not db_{{x[0] | lower}}:
                     raise HTTPException(status_code=400, detail=f"{{x[0]}} with id {% raw %}{{% endraw %}{{x[0] | lower}}_id{% raw %}}{% endraw %} not found")
 
             # Update the related entities with the new foreign key
-            database.query({{x[0]}}).filter({{x[0]}}.id.in_({{ class.name | lower }}_data.{{x[2]}})).update(
-                {{"{"}}{{x[0]}}.{{x[1]}}_id: db_{{ class.name | lower }}.id{{"}"}}, synchronize_session=False
+            database.query({{x[0]}}).filter({{x[0]}}.{{ x[0] | pk }}.in_({{ class.name | lower }}_data.{{x[2]}})).update(
+                {{"{"}}{{x[0]}}.{{x[1]}}_id: db_{{ class.name | lower }}.{{ pk }}{{"}"}}, synchronize_session=False
             )
+    {% endfor %}
+    {% endif %}
+    {# Reconcile the association class links -#}
+    {% if ns.assoc_links %}
+    {% for x in ns.assoc_links %}
+    {{x[3]}}_payload = getattr({{ class.name | lower }}_data, '{{x[3]}}', None)
+    if {{x[3]}}_payload is not None:
+        existing_{{x[3]}}_links = {getattr(link_row, '{{x[3]}}_id'): link_row for link_row in database.query({{x[4]}}).filter(
+            {{x[4]}}.{{x[2]}}_id == db_{{ class.name | lower }}.{{ pk }}).all()}
+        incoming_{{x[3]}}_links = {}
+        for link in {% if x[6] > 1 %}{{x[3]}}_payload{% else %}[{{x[3]}}_payload]{% endif %}:
+            {{x[3]}}_target = _link_target(link)
+            db_{{x[1]|lower}} = database.query({{x[1]}}).filter({{x[1]}}.{{ x[1] | pk }} == {{x[3]}}_target).first()
+            if db_{{x[1]|lower}} is None:
+                raise HTTPException(status_code=404, detail=f"{{x[1]}} with ID {% raw %}{{% endraw %}{{x[3]}}_target{% raw %}}{% endraw %} not found")
+            incoming_{{x[3]}}_links[{{x[3]}}_target] = link
+
+        for {{x[3]}}_target, link_row in existing_{{x[3]}}_links.items():
+            if {{x[3]}}_target not in incoming_{{x[3]}}_links:
+                database.delete(link_row)
+
+        for {{x[3]}}_target, link in incoming_{{x[3]}}_links.items():
+            link_row = existing_{{x[3]}}_links.get({{x[3]}}_target)
+            if link_row is None:
+                database.add({{x[4]}}(
+                    {{x[2]}}_id=db_{{ class.name | lower }}.{{ pk }},
+                    {{x[3]}}_id={{x[3]}}_target,
+                    **_link_attrs(link, {{ link_attr_names(x[4]) }})
+                ))
+            else:
+                for link_attr_name, link_attr_value in _link_attrs(link, {{ link_attr_names(x[4]) }}).items():
+                    setattr(link_row, link_attr_name, link_attr_value)
     {% endfor %}
     {% endif %}
     {% if ns.end_name_multiple  %}
     {% for x in ns.end_name_multiple %}
     existing_{{x[1] | lower}}_ids = [assoc.{{x[3]}} for assoc in database.execute(
-        {{x[4]}}.select().where({{x[4]}}.c.{{x[2]}} == db_{{ class.name | lower }}.id))]
+        {{x[4]}}.select().where({{x[4]}}.c.{{x[2]}} == db_{{ class.name | lower }}.{{ pk }}))]
 
     {{x[1]|lower}}s_to_remove = set(existing_{{x[1]|lower}}_ids) - set({{ class.name | lower }}_data.{{x[3]}}{%if not nested_creations %}{%endif%})
     for {{x[1]|lower}}_id in {{x[1]|lower}}s_to_remove:
         association = {{x[4]}}.delete().where(
-            ({{x[4]}}.c.{{x[2]}} == db_{{ class.name | lower }}.id) & ({{x[4]}}.c.{{x[3]}} == {{x[1]|lower}}_id))
+            ({{x[4]}}.c.{{x[2]}} == db_{{ class.name | lower }}.{{ pk }}) & ({{x[4]}}.c.{{x[3]}} == {{x[1]|lower}}_id))
         database.execute(association)
 
     new_{{x[1]|lower}}_ids = set({{ class.name | lower }}_data.{{x[3]}}{%if not nested_creations %}{%endif%}) - set(existing_{{x[1]|lower}}_ids)
     for {{x[1]|lower}}_id in new_{{x[1]|lower}}_ids:
-        db_{{x[1]|lower}} = database.query({{x[1]}}).filter({{x[1]}}.id == {{x[1]|lower}}_id).first()
+        db_{{x[1]|lower}} = database.query({{x[1]}}).filter({{x[1]}}.{{ x[1] | pk }} == {{x[1]|lower}}_id).first()
         if db_{{x[1]|lower}} is None:
             raise HTTPException(status_code=404, detail=f"{{x[1]}} with ID {% raw %}{{% endraw %}{{x[1]|lower}}_id{% raw %}}{% endraw %} not found")
-        association = {{x[4]}}.insert().values({{x[3]}}=db_{{x[1]|lower}}.id, {{x[2]}}=db_{{ class.name | lower }}.id)
+        association = {{x[4]}}.insert().values({{x[3]}}=db_{{x[1]|lower}}.{{ x[1] | pk }}, {{x[2]}}=db_{{ class.name | lower }}.{{ pk }})
         database.execute(association)
     {% endfor %}
     {% endif %}
     database.commit()
     database.refresh(db_{{ class.name | lower }})
 
-    {% if ns.end_name_multiple or ns.one_to_many %}
+    {% if ns.end_name_multiple or ns.one_to_many or ns.assoc_links %}
     {# Return response with relationship IDs like GET endpoint #}
     {% for x in ns.end_name_multiple %}
-    {{x[1] | lower}}_ids = database.query({{x[4]}}.c.{{x[3]}}).filter({{x[4]}}.c.{{x[2]}} == db_{{ class.name | lower}}.id).all()
+    {{x[1] | lower}}_ids = database.query({{x[4]}}.c.{{x[3]}}).filter({{x[4]}}.c.{{x[2]}} == db_{{ class.name | lower}}.{{ pk }}).all()
+    {% endfor %}
+    {% for x in ns.assoc_links %}
+    {{x[3]}}_ids = database.query({{x[4]}}.{{x[3]}}_id).filter({{x[4]}}.{{x[2]}}_id == db_{{ class.name | lower}}.{{ pk }}).all()
     {% endfor %}
     {% for x in ns.one_to_many %}
-    {{x[2]}}_ids = database.query({{x[0]}}.id).filter({{x[0]}}.{{x[1]}}_id == db_{{ class.name | lower}}.id).all()
+    {{x[2]}}_ids = database.query({{x[0]}}.{{ x[0] | pk }}).filter({{x[0]}}.{{x[1]}}_id == db_{{ class.name | lower}}.{{ pk }}).all()
     {% endfor %}
     response_data = {
         "{{class.name | lower}}": db_{{ class.name | lower}},
         {% for x in ns.end_name_multiple %}
         "{{x[1] | lower}}_ids": [x[0] for x in {{x[1] | lower}}_ids],
+        {% endfor %}
+        {% for x in ns.assoc_links %}
+        "{{x[3]}}_ids": [x[0] for x in {{x[3]}}_ids],
         {% endfor %}
         {% for x in ns.one_to_many %}
         "{{x[2]}}_ids": [x[0] for x in {{x[2]}}_ids]{% if not loop.last %},{% endif %}
@@ -975,17 +1225,34 @@ async def update_{{ class.name | lower }}({{ class.name | lower }}_id: int, {{ c
     return db_{{ class.name | lower }}
     {% endif %}
 {% endif %}
+{% endif %}
 
 
 {% if "DELETE" in http_methods %}
-@app.delete("/{{ class.name | lower}}/{% raw %}{{% endraw %}{{ class.name | lower}}_id{% raw %}}{% endraw %}/", response_model=None, tags=["{{ class.name }}"])
-async def delete_{{ class.name | lower}}({{ class.name | lower}}_id: int, database: Session = Depends(get_db)):
-    db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.id == {{ class.name | lower}}_id).first()
+{% if is_assoc_class %}
+{% set ac_ends = assoc_classes[class.name].ends %}
+@app.delete("/{{ class.name | lower}}/{% raw %}{{% endraw %}{{ ac_ends[0].name }}_id{% raw %}}{% endraw %}/{% raw %}{{% endraw %}{{ ac_ends[1].name }}_id{% raw %}}{% endraw %}/", response_model=None, tags=["{{ class.name }}"])
+async def delete_{{ class.name | lower}}({{ ac_ends[0].name }}_id: int, {{ ac_ends[1].name }}_id: int, database: Session = Depends(get_db)):
+    """Delete the {{ class.name }} link identified by both foreign keys"""
+    db_{{ class.name | lower}} = database.query({{ class.name }}).filter(
+        ({{ class.name }}.{{ ac_ends[0].name }}_id == {{ ac_ends[0].name }}_id) &
+        ({{ class.name }}.{{ ac_ends[1].name }}_id == {{ ac_ends[1].name }}_id)
+    ).first()
     if db_{{ class.name | lower}} is None:
         raise HTTPException(status_code=404, detail="{{ class.name }} not found")
     database.delete(db_{{ class.name | lower}})
     database.commit()
     return db_{{ class.name | lower}}
+{% else %}
+@app.delete("/{{ class.name | lower}}/{% raw %}{{% endraw %}{{ class.name | lower}}_id{% raw %}}{% endraw %}/", response_model=None, tags=["{{ class.name }}"])
+async def delete_{{ class.name | lower}}({{ class.name | lower}}_id: int, database: Session = Depends(get_db)):
+    db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.{{ pk }} == {{ class.name | lower}}_id).first()
+    if db_{{ class.name | lower}} is None:
+        raise HTTPException(status_code=404, detail="{{ class.name }} not found")
+    database.delete(db_{{ class.name | lower}})
+    database.commit()
+    return db_{{ class.name | lower}}
+{% endif %}
 {% endif %}
 
 {% if ns.end_name_multiple %}
@@ -997,11 +1264,11 @@ async def delete_{{ class.name | lower}}({{ class.name | lower}}_id: int, databa
 @app.post("/{{ class.name | lower}}/{% raw %}{{% endraw %}{{ class.name | lower}}_id{% raw %}}{% endraw %}/{{x[3]}}/{% raw %}{{% endraw %}{{ related_path_param }}{% raw %}}{% endraw %}/", response_model=None, tags=["{{ class.name }} Relationships"])
 async def add_{{x[3]}}_to_{{ class.name | lower}}({{ class.name | lower}}_id: int, {{ related_param_name }}: int, database: Session = Depends(get_db)):
     """Add a {{x[1]}} to this {{ class.name }}'s {{x[3]}} relationship"""
-    db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.id == {{ class.name | lower}}_id).first()
+    db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.{{ pk }} == {{ class.name | lower}}_id).first()
     if db_{{ class.name | lower}} is None:
         raise HTTPException(status_code=404, detail="{{ class.name }} not found")
 
-    db_{{x[1]|lower}} = database.query({{x[1]}}).filter({{x[1]}}.id == {{ related_param_name }}).first()
+    db_{{x[1]|lower}} = database.query({{x[1]}}).filter({{x[1]}}.{{ x[1] | pk }} == {{ related_param_name }}).first()
     if db_{{x[1]|lower}} is None:
         raise HTTPException(status_code=404, detail="{{x[1]}} not found")
 
@@ -1025,7 +1292,7 @@ async def add_{{x[3]}}_to_{{ class.name | lower}}({{ class.name | lower}}_id: in
 @app.delete("/{{ class.name | lower}}/{% raw %}{{% endraw %}{{ class.name | lower}}_id{% raw %}}{% endraw %}/{{x[3]}}/{% raw %}{{% endraw %}{{ related_path_param }}{% raw %}}{% endraw %}/", response_model=None, tags=["{{ class.name }} Relationships"])
 async def remove_{{x[3]}}_from_{{ class.name | lower}}({{ class.name | lower}}_id: int, {{ related_param_name }}: int, database: Session = Depends(get_db)):
     """Remove a {{x[1]}} from this {{ class.name }}'s {{x[3]}} relationship"""
-    db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.id == {{ class.name | lower}}_id).first()
+    db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.{{ pk }} == {{ class.name | lower}}_id).first()
     if db_{{ class.name | lower}} is None:
         raise HTTPException(status_code=404, detail="{{ class.name }} not found")
 
@@ -1052,17 +1319,101 @@ async def remove_{{x[3]}}_from_{{ class.name | lower}}({{ class.name | lower}}_i
 @app.get("/{{ class.name | lower}}/{% raw %}{{% endraw %}{{ class.name | lower}}_id{% raw %}}{% endraw %}/{{x[3]}}/", response_model=None, tags=["{{ class.name }} Relationships"])
 async def get_{{x[3]}}_of_{{ class.name | lower}}({{ class.name | lower}}_id: int, database: Session = Depends(get_db)):
     """Get all {{x[1]}} entities related to this {{ class.name }} through {{x[3]}}"""
-    db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.id == {{ class.name | lower}}_id).first()
+    db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.{{ pk }} == {{ class.name | lower}}_id).first()
     if db_{{ class.name | lower}} is None:
         raise HTTPException(status_code=404, detail="{{ class.name }} not found")
 
     {{x[1]|lower}}_ids = database.query({{x[4]}}.c.{{x[3]}}).filter({{x[4]}}.c.{{x[2]}} == {{ class.name | lower}}_id).all()
-    {{x[1]|lower}}_list = database.query({{x[1]}}).filter({{x[1]}}.id.in_([id[0] for id in {{x[1]|lower}}_ids])).all()
+    {{x[1]|lower}}_list = database.query({{x[1]}}).filter({{x[1]}}.{{ x[1] | pk }}.in_([id[0] for id in {{x[1]|lower}}_ids])).all()
 
     return {
         "{{ class.name | lower}}_id": {{ class.name | lower}}_id,
         "{{x[3]}}_count": len({{x[1]|lower}}_list),
         "{{x[3]}}": {{x[1]|lower}}_list
+    }
+
+{% endfor %}
+{% endif %}
+{% if ns.assoc_links %}
+
+{# Add relationship-specific endpoints for the associations materialized by an association class #}
+{% for x in ns.assoc_links %}
+{# Handle self-referential relationships by using different parameter names #}
+{% set related_param_name = 'related_' ~ x[1]|lower ~ '_id' if class.name|lower == x[1]|lower else x[1]|lower ~ '_id' %}
+@app.post("/{{ class.name | lower}}/{% raw %}{{% endraw %}{{ class.name | lower}}_id{% raw %}}{% endraw %}/{{x[3]}}/{% raw %}{{% endraw %}{{ related_param_name }}{% raw %}}{% endraw %}/", response_model=None, tags=["{{ class.name }} Relationships"])
+async def add_{{x[3]}}_to_{{ class.name | lower}}({{ class.name | lower}}_id: int, {{ related_param_name }}: int, link: dict = Body(default=None), database: Session = Depends(get_db)):
+    """Add a {{x[1]}} to this {{ class.name }}'s {{x[3]}} relationship.
+
+    The request body carries the {{x[4]}} attributes ({% for attribute in assoc_classes[x[4]].attributes %}{{ attribute.name }}{% if not loop.last %}, {% endif %}{% endfor %}).
+    A `target` field in the body is ignored: the target is taken from the path.
+    """
+    db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.{{ pk }} == {{ class.name | lower}}_id).first()
+    if db_{{ class.name | lower}} is None:
+        raise HTTPException(status_code=404, detail="{{ class.name }} not found")
+
+    db_{{x[1]|lower}} = database.query({{x[1]}}).filter({{x[1]}}.{{ x[1] | pk }} == {{ related_param_name }}).first()
+    if db_{{x[1]|lower}} is None:
+        raise HTTPException(status_code=404, detail="{{x[1]}} not found")
+
+    # Check if relationship already exists
+    existing = database.query({{x[4]}}).filter(
+        ({{x[4]}}.{{x[2]}}_id == {{ class.name | lower}}_id) &
+        ({{x[4]}}.{{x[3]}}_id == {{ related_param_name }})
+    ).first()
+
+    if existing:
+        raise HTTPException(status_code=400, detail="Relationship already exists")
+
+    # Create the association class row
+    database.add({{x[4]}}(
+        {{x[2]}}_id={{ class.name | lower}}_id,
+        {{x[3]}}_id={{ related_param_name }},
+        **_link_attrs(link, {{ link_attr_names(x[4]) }})
+    ))
+    database.commit()
+
+    return {"message": "{{x[1]}} added to {{x[3]}} successfully"}
+
+
+@app.delete("/{{ class.name | lower}}/{% raw %}{{% endraw %}{{ class.name | lower}}_id{% raw %}}{% endraw %}/{{x[3]}}/{% raw %}{{% endraw %}{{ related_param_name }}{% raw %}}{% endraw %}/", response_model=None, tags=["{{ class.name }} Relationships"])
+async def remove_{{x[3]}}_from_{{ class.name | lower}}({{ class.name | lower}}_id: int, {{ related_param_name }}: int, database: Session = Depends(get_db)):
+    """Remove a {{x[1]}} from this {{ class.name }}'s {{x[3]}} relationship"""
+    db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.{{ pk }} == {{ class.name | lower}}_id).first()
+    if db_{{ class.name | lower}} is None:
+        raise HTTPException(status_code=404, detail="{{ class.name }} not found")
+
+    # Check if relationship exists
+    existing = database.query({{x[4]}}).filter(
+        ({{x[4]}}.{{x[2]}}_id == {{ class.name | lower}}_id) &
+        ({{x[4]}}.{{x[3]}}_id == {{ related_param_name }})
+    ).first()
+
+    if not existing:
+        raise HTTPException(status_code=404, detail="Relationship not found")
+
+    # Delete the association class row
+    database.delete(existing)
+    database.commit()
+
+    return {"message": "{{x[1]}} removed from {{x[3]}} successfully"}
+
+
+@app.get("/{{ class.name | lower}}/{% raw %}{{% endraw %}{{ class.name | lower}}_id{% raw %}}{% endraw %}/{{x[3]}}/", response_model=None, tags=["{{ class.name }} Relationships"])
+async def get_{{x[3]}}_of_{{ class.name | lower}}({{ class.name | lower}}_id: int, database: Session = Depends(get_db)):
+    """Get all {{x[1]}} entities related to this {{ class.name }} through {{x[3]}}, with their {{x[4]}} links"""
+    db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.{{ pk }} == {{ class.name | lower}}_id).first()
+    if db_{{ class.name | lower}} is None:
+        raise HTTPException(status_code=404, detail="{{ class.name }} not found")
+
+    {{x[3]}}_link_rows = database.query({{x[4]}}).filter({{x[4]}}.{{x[2]}}_id == {{ class.name | lower}}_id).all()
+    {{x[1]|lower}}_list = database.query({{x[1]}}).filter({{x[1]}}.{{ x[1] | pk }}.in_(
+        [getattr(link_row, '{{x[3]}}_id') for link_row in {{x[3]}}_link_rows])).all()
+
+    return {
+        "{{ class.name | lower}}_id": {{ class.name | lower}}_id,
+        "{{x[3]}}_count": len({{x[1]|lower}}_list),
+        "{{x[3]}}": {{x[1]|lower}}_list,
+        "{{x[3]}}_links": {{x[3]}}_link_rows
     }
 
 {% endfor %}
@@ -1073,7 +1424,7 @@ async def get_{{x[3]}}_of_{{ class.name | lower}}({{ class.name | lower}}_id: in
 @app.get("/{{ class.name | lower}}/{% raw %}{{% endraw %}{{ class.name | lower}}_id{% raw %}}{% endraw %}/{{x[2]}}/", response_model=None, tags=["{{ class.name }} Relationships"])
 async def get_{{x[2]}}_of_{{ class.name | lower}}({{ class.name | lower}}_id: int, database: Session = Depends(get_db)):
     """Get all {{x[0]}} entities related to this {{ class.name }} through {{x[2]}}"""
-    db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.id == {{ class.name | lower}}_id).first()
+    db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.{{ pk }} == {{ class.name | lower}}_id).first()
     if db_{{ class.name | lower}} is None:
         raise HTTPException(status_code=404, detail="{{ class.name }} not found")
 
@@ -1227,7 +1578,7 @@ async def execute_{{ class.name | lower }}_{{ clean_name }}(
     {% endif %}
     """
     # Retrieve the entity from the database
-    _{{ class.name | lower }}_object = database.query({{ class.name }}).filter({{ class.name }}.id == {{ class.name | lower }}_id).first()
+    _{{ class.name | lower }}_object = database.query({{ class.name }}).filter({{ class.name }}.{{ pk }} == {{ class.name | lower }}_id).first()
     if _{{ class.name | lower }}_object is None:
         raise HTTPException(status_code=404, detail="{{ class.name }} not found")
 

--- a/besser/generators/structural_utils.py
+++ b/besser/generators/structural_utils.py
@@ -40,3 +40,42 @@ def get_foreign_keys(model: DomainModel) -> Dict[str, List[str]]:
             fkeys[association.name] = [end1.type.name, end0.name]
 
     return fkeys
+
+
+def normalize_method_code(code, method_name="method"):
+    """Normalize user-written method code so it can be embedded in generated files.
+
+    The editor's code box lets users mix tabs and spaces, which Python rejects
+    with an IndentationError the moment the generated module is imported --
+    taking the whole application down with it. Tabs are expanded to 4 spaces
+    and whitespace-only lines are blanked; if the result still does not
+    compile, a stub carrying the original code as comments is emitted instead,
+    so one broken method body can never prevent the generated app from
+    starting.
+    """
+    if not code or not code.strip():
+        return code or ""
+
+    lines = []
+    for line in code.splitlines():
+        line = line.expandtabs(4).rstrip()
+        lines.append(line if line.strip() else "")
+    normalized = "\n".join(lines)
+
+    try:
+        compile(normalized, f"<{method_name}>", "exec")
+        return normalized
+    except SyntaxError:
+        pass
+
+    commented = "\n".join(
+        ("    # " + line) if line else "    #" for line in normalized.splitlines()
+    )
+    return (
+        f"def {method_name}(self):\n"
+        f"    # NOTE: the original code of '{method_name}' does not compile and was\n"
+        f"    # commented out so the generated application can still start.\n"
+        f"    # Fix the method body in the editor and regenerate.\n"
+        f"{commented}\n"
+        f"    raise NotImplementedError(\"Method '{method_name}' has invalid code\")"
+    )

--- a/docs/source/generators/pydantic.rst
+++ b/docs/source/generators/pydantic.rst
@@ -100,3 +100,15 @@ For each OCL constraint, the generator produces a Pydantic ``field_validator``:
 
 These validators automatically enforce constraints when creating or updating entities via the REST API, 
 and the error messages are displayed in the frontend web application.
+OCL constraint support details
+------------------------------
+
+- ``self.<attr>.matches('<regex>')`` becomes a ``re.match(...)`` field validator
+  (the module imports ``re`` automatically).
+- Constraints comparing two attributes of the same class (e.g.
+  ``self.check_in <= self.check_out``) become ``@model_validator(mode='after')``
+  validators.
+- Constraints that involve collections or relationships (``->size()``,
+  ``->collect()``, ``->sum()``, …) cannot be enforced on a Create payload; the
+  generator emits an explanatory ``# NOTE:`` comment instead of broken code, and
+  every emitted validator is syntax-checked before it is written.

--- a/docs/source/generators/rest_api.rst
+++ b/docs/source/generators/rest_api.rst
@@ -80,3 +80,26 @@ When you run the code generated, the OpenAPI specifications will be generated:
    when you run the generated FastAPI application with ``uvicorn rest_api:app``.
 
         
+Association classes
+-------------------
+
+When a binary association carries an **association class** (e.g. ``Booking`` — ``Room``
+through ``ReservedRoom`` with attributes ``agreed_price`` and ``additional_charges``),
+the generated API manages the link through the association class instead of a plain
+join table:
+
+- The Create/Update payload of each navigable end carries **link objects** instead of
+  bare ids: ``"rooms": [{"target": 101, "agreed_price": 95.0, "additional_charges": 5.0}]``
+  (``target`` is the primary key of the linked entity; plain ids are still accepted, in
+  which case the association attributes are left unset). To-one ends through an
+  association class are optional at creation time — the link can be established later
+  from the other side or via the association class's own endpoint.
+- ``PUT`` reconciles links: removed targets delete the association row, new targets
+  create one, and kept targets have their association attributes updated.
+- ``GET ...?detailed=true`` additionally returns ``<end>_links`` with the full
+  association rows.
+- The association class gets its own endpoints; its Create model carries one id field
+  per association end plus the association attributes, and single-item routes are
+  keyed by both foreign keys.
+- Primary keys are respected everywhere: a class whose id attribute is not named
+  ``id`` (e.g. ``Room.number``) is queried by its actual primary key.

--- a/docs/source/releases/v7.rst
+++ b/docs/source/releases/v7.rst
@@ -4,6 +4,7 @@ Version 7
 .. toctree::
    :maxdepth: 1
 
+   v7/v7.14.1
    v7/v7.14.0
    v7/v7.13.0
    v7/v7.12.0

--- a/docs/source/releases/v7/v7.14.1.rst
+++ b/docs/source/releases/v7/v7.14.1.rst
@@ -1,0 +1,61 @@
+Version 7.14.1
+==============
+
+Patch release: **working OCL enforcement, full association-class support and a
+usable create/edit dialog in generated web applications**. Every fix was found
+and verified against a real hotel-booking model with OCL constraints, an
+association class (``ReservedRoom`` between ``Booking`` and ``Room``) and
+user-written method code. No metamodel or API-contract changes.
+
+Highlights
+----------
+
+- **OCL constraints are enforced in generated backends**: the Pydantic generator
+  previously leaked OCL syntax verbatim (``v.matches(...)``) with broken message
+  quoting — a ``SyntaxError`` that prevented freshly generated backends from even
+  starting. ``matches`` now translates to ``re.match`` validators, constraints
+  comparing two attributes (e.g. ``check_in <= check_out``) become
+  ``@model_validator(mode='after')`` validators, collection constraints emit an
+  explanatory ``# NOTE:`` instead of broken code, and every generated expression
+  is syntax-checked before it is written. The Django generator's ``clean()``
+  template received the same quoting fix.
+- **Association classes work end-to-end**: creating entities linked through an
+  association class crashed with ``NameError`` (the REST template emitted
+  join-table code for a table the SQLAlchemy generator correctly never creates).
+  All endpoints now go through the association class: links travel as
+  ``{"target": <pk>, ...association attributes}`` payloads, ``PUT`` reconciles
+  them, ``?detailed=true`` exposes the link rows, and the association class gets
+  working CRUD keyed by both foreign keys. Primary keys are respected everywhere
+  — classes whose id attribute is not named ``id`` (e.g. ``Room.number``) are
+  queried by their actual key, in the backend and in the dialog's selects alike.
+- **The generated create/edit dialog understands association classes**: when
+  selecting related entities, the association attributes (e.g. per-room
+  ``agreed_price``) unfold inline right under the checked option; long option
+  lists are searchable (checked options stay pinned through the filter); lookup
+  selects display the same field the table column is configured with (with a
+  readable ``name``-first default) while submitting real primary keys; and the
+  dialog itself was reorganized into a wider two-column layout with Details and
+  Relationships sections.
+- **Robust embedding of user method code**: method bodies written in the
+  editor's code box with mixed tabs and spaces produced an ``IndentationError``
+  that took the whole generated application down at startup. Method code is now
+  normalized and compile-gated before embedding (FastAPI, Python and Django
+  generators); a body that still does not compile is emitted as a commented stub
+  raising ``NotImplementedError`` instead of breaking the module.
+
+Fixes
+-----
+
+- Generated 4xx responses now carry the endpoint's actual message in ``detail``
+  (previously a generic "HTTP 400 error occurred" placeholder), so the dialog's
+  error banner shows e.g. *"Room with ID 15 not found"*.
+- To-one ends through an association class are optional at creation time,
+  resolving the chicken-and-egg between the two linked entities.
+
+Frontend (via the submodule bump)
+---------------------------------
+
+The frontend submodule moves to include a fix to the GUI autogeneration: lookup
+columns now default to a readable display attribute (an attribute named
+``name``, then the first non-id string attribute) instead of the raw primary
+key.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = besser
-version = 7.14.0
+version = 7.14.1
 author = Luxembourg Institute of Science and Technology
 description = BESSER
 long_description = file: README.md

--- a/tests/generators/pydantic/test_pydantic_ocl_validators.py
+++ b/tests/generators/pydantic/test_pydantic_ocl_validators.py
@@ -1,0 +1,513 @@
+"""
+Tests for the OCL -> Pydantic validator emission of the Pydantic generator.
+
+These tests cover the translation rules implemented in
+``besser/generators/pydantic_classes/ocl_utils.py`` and the corresponding
+template branches:
+
+* ``matches('<regex>')`` becomes a ``re.match`` call (OCL ``matches`` is not a
+  Python string method, so emitting it verbatim produced non-working code);
+* error messages are emitted through ``repr()`` so a regex containing quotes or
+  backslashes can never break the generated file's syntax;
+* constraints over two or more properties of the same class become a
+  ``@model_validator(mode='after')`` instead of being dropped;
+* constraints over collections/relationships leave a NOTE comment behind
+  instead of being dropped silently or emitting broken code;
+* whatever happens, the generated ``pydantic_classes.py`` compiles.
+"""
+
+import datetime
+import importlib.util
+import os
+import py_compile
+import sys
+import uuid
+
+import pytest
+
+from besser.BUML.metamodel.structural import (
+    Class, Constraint, DomainModel, Property,
+    BinaryAssociation, Multiplicity,
+    DateType, IntegerType,
+)
+from besser.generators.pydantic_classes import PydanticGenerator
+from besser.generators.pydantic_classes.ocl_utils import (
+    build_constraints_map, get_constraints_for_class, parse_ocl_constraint,
+)
+
+
+# ============================================================================
+# Helpers and fixtures
+# ============================================================================
+
+def make_constraint(context_class, expression, name="constraint"):
+    """Build an OCL Constraint bound to ``context_class``."""
+    return Constraint(
+        name=name,
+        context=context_class,
+        expression=expression,
+        language="OCL",
+    )
+
+
+def parse_single(domain_model, context_class, expression, name="constraint"):
+    """Parse one OCL expression and return the resulting validator descriptor."""
+    constraint = make_constraint(context_class, expression, name)
+    domain_model.constraints = {constraint}
+    return parse_ocl_constraint(constraint, domain_model)
+
+
+def generate(domain_model, output_dir, backend=True):
+    """Run the Pydantic generator and return (path, source)."""
+    PydanticGenerator(
+        model=domain_model, backend=backend, output_dir=str(output_dir)
+    ).generate()
+    path = os.path.join(str(output_dir), "pydantic_classes.py")
+    with open(path, "r", encoding="utf-8") as handle:
+        return path, handle.read()
+
+
+def load_generated(path):
+    """Import the generated module so its validators can be exercised."""
+    module_name = f"pydantic_classes_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+    return module
+
+
+@pytest.fixture
+def booking_class():
+    """A Booking class with two date attributes, for multi-property constraints."""
+    return Class(name="Booking", attributes={
+        Property(name="check_in", type=DateType),
+        Property(name="check_out", type=DateType),
+        Property(name="nights", type=IntegerType),
+    })
+
+
+@pytest.fixture
+def room_class():
+    """A Room class, used as the far end of a Booking association."""
+    return Class(name="Room", attributes={
+        Property(name="number", type=IntegerType),
+        Property(name="max_people", type=IntegerType),
+    })
+
+
+@pytest.fixture
+def booking_model(booking_class, room_class):
+    """A Booking/Room model with a 1:N association (booking -> rooms)."""
+    association = BinaryAssociation(
+        name="booking_room",
+        ends={
+            Property(name="booking", type=booking_class, multiplicity=Multiplicity(1, 1)),
+            Property(name="rooms", type=room_class, multiplicity=Multiplicity(0, 9999)),
+        }
+    )
+    return DomainModel(
+        name="BookingModel",
+        types={booking_class, room_class},
+        associations={association},
+    )
+
+
+# ============================================================================
+# matches() translation
+# ============================================================================
+
+class TestMatchesTranslation:
+    """``self.<prop>.matches('<regex>')`` must become a real Python expression."""
+
+    def test_matches_becomes_re_match(self, player_class, player_team_domain_model):
+        result = parse_single(
+            player_team_domain_model, player_class,
+            "context Player inv ValidName: self.name.matches('^[A-Z][a-z]+$')",
+            name="ValidName",
+        )
+
+        assert result is not None
+        assert not result.get('skipped')
+        assert result['property'] == 'name'
+        assert result['python_expression'] == "re.match(r'^[A-Z][a-z]+$', v) is not None"
+        assert result['uses_re'] is True
+        # The OCL operation must not leak into the generated Python.
+        assert '.matches(' not in result['python_expression']
+
+    def test_ocl_backslash_escapes_are_resolved(self, player_class, player_team_domain_model):
+        """``\\\\.`` in an OCL string literal is a single backslash in the regex."""
+        result = parse_single(
+            player_team_domain_model, player_class,
+            r"context Player inv ValidEmail: self.name.matches('^[a-z]+@[a-z]+\\.[a-z]{2,}$')",
+            name="ValidEmail",
+        )
+
+        assert result['python_expression'] == (
+            r"re.match(r'^[a-z]+@[a-z]+\.[a-z]{2,}$', v) is not None"
+        )
+
+    def test_matches_message_is_readable(self, player_class, player_team_domain_model):
+        result = parse_single(
+            player_team_domain_model, player_class,
+            "context Player inv ValidName: self.name.matches('^[A-Z][a-z]+$')",
+            name="ValidName",
+        )
+
+        assert result['message'] == "name must match '^[A-Z][a-z]+$'"
+        # message_repr must evaluate back to the message, unchanged.
+        assert eval(result['message_repr']) == result['message']  # noqa: S307
+
+    def test_generated_regex_validator_works(self, player_class, player_team_domain_model, tmpdir):
+        player_team_domain_model.constraints = {
+            make_constraint(
+                player_class,
+                "context Player inv ValidName: self.name.matches('^[A-Z][a-z]+$')",
+                name="ValidName",
+            )
+        }
+        path, source = generate(player_team_domain_model, tmpdir.mkdir("output"))
+
+        assert source.startswith("import re\n")
+        py_compile.compile(path, doraise=True)
+
+        module = load_generated(path)
+        player_create = module.PlayerCreate
+
+        valid = player_create(age=30, name="Alice", salary=1.0, active=True, jerseyNumber=7)
+        assert valid.name == "Alice"
+
+        with pytest.raises(Exception):
+            player_create(age=30, name="alice1", salary=1.0, active=True, jerseyNumber=7)
+
+    def test_no_re_import_when_unused(self, player_class, player_team_domain_model, tmpdir):
+        player_team_domain_model.constraints = {
+            make_constraint(
+                player_class, "context Player inv MinAge: self.age > 10", name="MinAge"
+            )
+        }
+        _, source = generate(player_team_domain_model, tmpdir.mkdir("output"))
+
+        assert "import re" not in source
+        assert "model_validator" not in source
+
+
+# ============================================================================
+# Message quoting
+# ============================================================================
+
+class TestMessageQuoting:
+    """Messages are emitted as Python literals, never interpolated into quotes."""
+
+    def test_regex_with_single_quote_does_not_break_the_file(
+        self, player_class, player_team_domain_model, tmpdir
+    ):
+        # An OCL string literal escapes an inner quote as \' ; the regex allows
+        # apostrophes in names ("O'Brien").
+        expression = (
+            r"context Player inv NameWithApostrophe: self.name.matches('^[A-Za-z\']+$')"
+        )
+        result = parse_single(
+            player_team_domain_model, player_class, expression, name="NameWithApostrophe"
+        )
+
+        assert result['python_expression'] == "re.match(r\"^[A-Za-z']+$\", v) is not None"
+        assert result['message'] == "name must match '^[A-Za-z']+$'"
+        assert eval(result['message_repr']) == result['message']  # noqa: S307
+
+        player_team_domain_model.constraints = {
+            make_constraint(player_class, expression, name="NameWithApostrophe")
+        }
+        path, source = generate(player_team_domain_model, tmpdir.mkdir("output"))
+
+        py_compile.compile(path, doraise=True)
+        assert "raise ValueError(\"name must match '^[A-Za-z']+$'\")" in source
+
+        module = load_generated(path)
+        player_create = module.PlayerCreate
+        assert player_create(
+            age=30, name="O'Brien", salary=1.0, active=True, jerseyNumber=7
+        ).name == "O'Brien"
+        with pytest.raises(Exception):
+            player_create(age=30, name="O Brien 3", salary=1.0, active=True, jerseyNumber=7)
+
+    def test_simple_operator_message_is_a_literal(self, player_class, player_team_domain_model, tmpdir):
+        player_team_domain_model.constraints = {
+            make_constraint(
+                player_class, "context Player inv MinAge: self.age > 10", name="MinAge"
+            )
+        }
+        path, source = generate(player_team_domain_model, tmpdir.mkdir("output"))
+
+        py_compile.compile(path, doraise=True)
+        assert "raise ValueError('age must be > 10')" in source
+
+    def test_string_value_with_quote_is_escaped(self, player_class, player_team_domain_model, tmpdir):
+        player_team_domain_model.constraints = {
+            make_constraint(
+                player_class,
+                r"context Player inv NotUnknown: self.name <> 'O\'Brien'",
+                name="NotUnknown",
+            )
+        }
+        path, _ = generate(player_team_domain_model, tmpdir.mkdir("output"))
+        py_compile.compile(path, doraise=True)
+
+
+# ============================================================================
+# Model-level (multi-property) validators
+# ============================================================================
+
+class TestModelValidator:
+    """Constraints over 2+ properties become model validators, not dropped."""
+
+    def test_two_properties_produce_a_model_expression(self, booking_class, booking_model):
+        result = parse_single(
+            booking_model, booking_class,
+            "context Booking inv CheckInBeforeCheckOut: self.check_in <= self.check_out",
+            name="CheckInBeforeCheckOut",
+        )
+
+        assert result is not None
+        assert not result.get('skipped')
+        assert result['model_expression'] == "self.check_in <= self.check_out"
+        assert result['validator_name'] == "CheckInBeforeCheckOut"
+        assert result['properties'] == ['check_in', 'check_out']
+        assert eval(result['message_repr']) == result['message']  # noqa: S307
+
+    def test_ocl_equality_operators_are_translated(self, booking_class, booking_model):
+        result = parse_single(
+            booking_model, booking_class,
+            "context Booking inv Differ: self.check_in <> self.check_out",
+            name="Differ",
+        )
+        assert result['model_expression'] == "self.check_in != self.check_out"
+
+        result = parse_single(
+            booking_model, booking_class,
+            "context Booking inv Same: self.check_in = self.check_out",
+            name="Same",
+        )
+        assert result['model_expression'] == "self.check_in == self.check_out"
+
+    def test_generated_model_validator_enforces_the_constraint(
+        self, booking_class, booking_model, tmpdir
+    ):
+        booking_model.constraints = {
+            make_constraint(
+                booking_class,
+                "context Booking inv CheckInBeforeCheckOut: self.check_in <= self.check_out",
+                name="CheckInBeforeCheckOut",
+            )
+        }
+        path, source = generate(booking_model, tmpdir.mkdir("output"))
+
+        py_compile.compile(path, doraise=True)
+        assert "from pydantic import BaseModel, field_validator, model_validator" in source
+        assert "@model_validator(mode='after')" in source
+        assert "def validate_CheckInBeforeCheckOut(self):" in source
+        assert "if not (self.check_in <= self.check_out):" in source
+
+        module = load_generated(path)
+        booking_create = module.BookingCreate
+
+        valid = booking_create(
+            check_in=datetime.date(2025, 5, 1),
+            check_out=datetime.date(2025, 5, 10),
+            nights=9,
+        )
+        assert valid.check_in < valid.check_out
+
+        with pytest.raises(Exception):
+            booking_create(
+                check_in=datetime.date(2025, 5, 10),
+                check_out=datetime.date(2025, 5, 1),
+                nights=9,
+            )
+
+    def test_constraint_name_becomes_a_valid_identifier(self, booking_class, booking_model, tmpdir):
+        booking_model.constraints = {
+            make_constraint(
+                booking_class,
+                "context Booking inv CheckRange: self.check_in <= self.check_out",
+                name="Booking.check_range",
+            )
+        }
+        constraints = build_constraints_map(
+            booking_model, include_model_level=True
+        )["Booking"]
+        assert constraints[0]['validator_name'] == "Booking_check_range"
+
+        path, source = generate(booking_model, tmpdir.mkdir("output"))
+        py_compile.compile(path, doraise=True)
+        assert "def validate_Booking_check_range(self):" in source
+
+    def test_duplicate_constraint_names_get_unique_validators(self, booking_class, booking_model):
+        # The DomainModel setter rejects duplicate names, so exercise the
+        # de-duplication of get_constraints_for_class on a raw constraint set.
+        constraints = {
+            make_constraint(
+                booking_class,
+                "context Booking inv Range: self.check_in <= self.check_out",
+                name="Range",
+            ),
+            make_constraint(
+                booking_class,
+                "context Booking inv Range: self.check_in <> self.check_out",
+                name="Range",
+            ),
+        }
+        parsed = get_constraints_for_class(
+            constraints, "Booking", booking_model, include_model_level=True
+        )
+        names = [c['validator_name'] for c in parsed if 'validator_name' in c]
+
+        assert len(names) == 2
+        assert len(names) == len(set(names))
+
+
+# ============================================================================
+# Skipped (untranslatable) constraints
+# ============================================================================
+
+class TestSkippedConstraints:
+    """Collection/relationship constraints leave a trace instead of vanishing."""
+
+    @pytest.mark.parametrize("expression", [
+        "context Booking inv Capacity: self.rooms->size() <= 5",
+        "context Booking inv Capacity: self.rooms->collect(r | r.max_people)->sum() > 0",
+        "context Booking inv Capacity: self.rooms->forAll(r | r.max_people > 0)",
+        "context Booking inv Capacity: self.rooms->isEmpty()",
+    ], ids=["size", "collect-sum", "forAll", "isEmpty"])
+    def test_collection_constraints_are_marked_skipped(
+        self, booking_class, booking_model, expression
+    ):
+        result = parse_single(booking_model, booking_class, expression, name="Capacity")
+        assert result == {'skipped': True, 'constraint_name': 'Capacity'} or result['skipped'] is True
+
+    def test_skip_emits_a_note_comment(self, booking_class, booking_model, tmpdir):
+        booking_model.constraints = {
+            make_constraint(
+                booking_class,
+                "context Booking inv NumberOfGuestsDoesNotExceedRoomCapacity: "
+                "self.nights->size() <= self.rooms->collect(r | r.max_people)->sum()",
+                name="NumberOfGuestsDoesNotExceedRoomCapacity",
+            )
+        }
+        path, source = generate(booking_model, tmpdir.mkdir("output"))
+
+        py_compile.compile(path, doraise=True)
+        assert (
+            "# NOTE: OCL constraint 'NumberOfGuestsDoesNotExceedRoomCapacity' involves "
+            "collections/relationships and is not enforced by this Create model."
+        ) in source
+        # Nothing was emitted that could reference the collection at runtime.
+        assert "->" not in source
+        assert "field_validator('nights')" not in source
+
+    def test_map_defaults_to_field_validators_only(self, booking_class, booking_model):
+        """Callers that only render per-field validators (Django) opt out by default."""
+        booking_model.constraints = {
+            make_constraint(
+                booking_class,
+                "context Booking inv Range: self.check_in <= self.check_out",
+                name="Range",
+            ),
+            make_constraint(
+                booking_class,
+                "context Booking inv Capacity: self.rooms->size() <= 5",
+                name="Capacity",
+            ),
+            make_constraint(
+                booking_class,
+                "context Booking inv MinNights: self.nights >= 1",
+                name="MinNights",
+            ),
+        }
+
+        default_map = build_constraints_map(booking_model)
+        assert [c['constraint_name'] for c in default_map["Booking"]] == ["MinNights"]
+
+        full_map = build_constraints_map(
+            booking_model, include_model_level=True, include_skipped=True
+        )
+        assert [c['constraint_name'] for c in full_map["Booking"]] == [
+            "Capacity", "MinNights", "Range"
+        ]
+
+    def test_untranslatable_expression_is_skipped_not_broken(
+        self, player_class, player_team_domain_model
+    ):
+        result = parse_single(
+            player_team_domain_model, player_class,
+            "context Player inv Weird: self.name.toUpper() = 'A'",
+            name="Weird",
+        )
+        assert result['skipped'] is True
+
+    def test_unknown_free_variable_is_skipped(self, player_class, player_team_domain_model):
+        result = parse_single(
+            player_team_domain_model, player_class,
+            "context Player inv Limit: self.age > MAX_AGE",
+            name="Limit",
+        )
+        assert result['skipped'] is True
+
+
+# ============================================================================
+# The generated file always compiles
+# ============================================================================
+
+class TestGeneratedFileAlwaysCompiles:
+    """Every emitted expression is compile-checked before it reaches the template."""
+
+    def test_all_four_constraint_shapes_in_one_model(self, booking_class, room_class, booking_model, tmpdir):
+        booking_model.constraints = {
+            make_constraint(
+                booking_class,
+                "context Booking inv CheckInBeforeCheckOut: self.check_in <= self.check_out",
+                name="CheckInBeforeCheckOut",
+            ),
+            make_constraint(
+                booking_class,
+                "context Booking inv MinNights: self.nights >= 1",
+                name="MinNights",
+            ),
+            make_constraint(
+                booking_class,
+                "context Booking inv Capacity: self.rooms->collect(r | r.max_people)->sum() > 0",
+                name="Capacity",
+            ),
+            make_constraint(
+                room_class,
+                r"context Room inv ValidNumber: self.number.matches('^[0-9]{1,4}$')",
+                name="ValidNumber",
+            ),
+        }
+        path, source = generate(booking_model, tmpdir.mkdir("output"))
+
+        py_compile.compile(path, doraise=True)
+        assert "@model_validator(mode='after')" in source
+        assert "re.match(r'^[0-9]{1,4}$', v) is not None" in source
+        assert "if not (v >= 1):" in source
+        assert "# NOTE: OCL constraint 'Capacity'" in source
+
+    @pytest.mark.parametrize("expression", [
+        "context Player inv A: self.name.matches('it''s broken')",
+        "context Player inv B: self.age > (10",
+        "context Player inv C: self.age ??? 10",
+        "context Player inv D: self.name.matches('\\\\')",
+        "context Player inv E: self.age > 10 and",
+    ], ids=["unbalanced-quotes", "unbalanced-paren", "garbage-operator",
+            "trailing-backslash-regex", "dangling-and"])
+    def test_malformed_expressions_never_emit_broken_code(
+        self, player_class, player_team_domain_model, expression, tmpdir
+    ):
+        player_team_domain_model.constraints = {
+            make_constraint(player_class, expression, name="Malformed")
+        }
+        path, _ = generate(player_team_domain_model, tmpdir.mkdir("output"))
+        py_compile.compile(path, doraise=True)

--- a/tests/generators/react/test_react_generator.py
+++ b/tests/generators/react/test_react_generator.py
@@ -2,11 +2,11 @@ import json
 import os
 import pytest
 from besser.BUML.metamodel.structural import (
-    Class, DomainModel, Property, StringType, IntegerType, FloatType,
+    AssociationClass, Class, DomainModel, Property, StringType, IntegerType, FloatType,
     BinaryAssociation, Multiplicity
 )
 from besser.BUML.metamodel.gui import GUIModel, Module, Screen, Text, DataBinding
-from besser.BUML.metamodel.gui.dashboard import Map, MapLayer, MapLayerType
+from besser.BUML.metamodel.gui.dashboard import Map, MapLayer, MapLayerType, Table
 from besser.generators.react import ReactGenerator
 
 
@@ -255,3 +255,213 @@ def test_react_no_map_no_leaflet_deps(domain_model, gui_model, tmpdir):
     assert not os.path.isfile(
         os.path.join(str(output_dir), "src", "components", "runtime", "MapBlock.tsx")
     ), "MapBlock.tsx must not be generated without a Map component"
+
+
+# ---------------------------------------------------------------------------
+# Association class attributes in the create/edit form
+# ---------------------------------------------------------------------------
+
+def _build_booking_models(with_association_class: bool):
+    """Booking -- Room N:M model with a table page, optionally with an association class."""
+    reference = Property(name="reference", type=StringType)
+    booking = Class(name="Booking", attributes={reference})
+
+    number = Property(name="number", type=StringType)
+    room = Class(name="Room", attributes={number})
+
+    booking_end = Property(name="bookings", type=booking, multiplicity=Multiplicity(0, "*"))
+    room_end = Property(name="rooms", type=room, multiplicity=Multiplicity(0, "*"))
+    booking_room = BinaryAssociation(name="booking_room", ends={booking_end, room_end})
+
+    types = {booking, room}
+    if with_association_class:
+        agreed_price = Property(name="agreed_price", type=FloatType)
+        additional_charges = Property(name="additional_charges", type=FloatType)
+        types.add(
+            AssociationClass(
+                name="ReservedRoom",
+                attributes={agreed_price, additional_charges},
+                association=booking_room,
+            )
+        )
+
+    domain_model = DomainModel(
+        name="BookingModel",
+        types=types,
+        associations={booking_room},
+    )
+
+    table = Table(
+        name="BookingTable",
+        title="Bookings",
+        action_buttons=True,
+        data_binding=DataBinding(name="booking_binding", domain_concept=booking),
+    )
+    screen = Screen(
+        name="Bookings",
+        description="Booking screen",
+        view_elements={table},
+        is_main_page=True,
+    )
+    module = Module(name="BookingModule", screens={screen})
+    gui_model = GUIModel(
+        name="BookingApp",
+        package="com.test.booking",
+        versionCode="1",
+        versionName="1.0",
+        modules={module},
+        description="Booking GUI",
+    )
+    return domain_model, gui_model
+
+
+@pytest.fixture
+def assoc_class_models():
+    """Booking -- Room N:M THROUGH the ReservedRoom association class."""
+    return _build_booking_models(with_association_class=True)
+
+
+@pytest.fixture
+def plain_nm_models():
+    """Booking -- Room plain N:M (no association class)."""
+    return _build_booking_models(with_association_class=False)
+
+
+def _form_columns(generator):
+    """Extract the formColumns metadata of the first table of the serialized GUI model."""
+    payload = json.loads(generator._build_generation_context()["components_json"])
+
+    def walk(nodes):
+        for node in nodes:
+            chart = node.get("chart") or {}
+            if "formColumns" in chart:
+                return chart["formColumns"]
+            found = walk(node.get("children") or [])
+            if found is not None:
+                return found
+        return None
+
+    for page in payload.get("pages", []):
+        found = walk(page.get("components", []))
+        if found is not None:
+            return found
+    return []
+
+
+def test_form_column_carries_association_class(assoc_class_models):
+    """A list lookup backed by an association class exposes its attributes."""
+    domain_model, gui_model = assoc_class_models
+    generator = ReactGenerator(model=domain_model, gui_model=gui_model)
+
+    form_columns = _form_columns(generator)
+    rooms = next(col for col in form_columns if col["field"] == "rooms")
+
+    assert rooms["column_type"] == "lookup"
+    assert rooms["type"] == "list"
+    assert rooms["association_class"] == {
+        "entity": "ReservedRoom",
+        "fields": [
+            {"name": "agreed_price", "type": "float", "required": True},
+            {"name": "additional_charges", "type": "float", "required": True},
+        ],
+    }
+
+    # Regular attribute columns are untouched
+    assert all(
+        "association_class" not in col for col in form_columns if col["field"] != "rooms"
+    )
+
+
+def test_form_column_without_association_class_unchanged(plain_nm_models):
+    """A plain N:M lookup keeps exactly the metadata it had before."""
+    domain_model, gui_model = plain_nm_models
+    generator = ReactGenerator(model=domain_model, gui_model=gui_model)
+
+    form_columns = _form_columns(generator)
+    rooms = next(col for col in form_columns if col["field"] == "rooms")
+
+    assert rooms == {
+        "column_type": "lookup",
+        "path": "rooms",
+        "field": "rooms",
+        "lookup_field": "number",
+        "entity": "Room",
+        "type": "list",
+        "required": False,
+    }
+    assert all("association_class" not in col for col in form_columns)
+
+
+def test_generated_page_embeds_association_class_metadata(assoc_class_models, tmp_path):
+    """The generated page passes the association class metadata to the table."""
+    domain_model, gui_model = assoc_class_models
+    generator = ReactGenerator(
+        model=domain_model, gui_model=gui_model, output_dir=str(tmp_path)
+    )
+    generator.generate()
+
+    pages_dir = os.path.join(str(tmp_path), "src", "pages")
+    page_content = ""
+    for page_file in os.listdir(pages_dir):
+        if page_file.endswith(".tsx"):
+            with open(os.path.join(pages_dir, page_file), "r", encoding="utf-8") as f:
+                page_content += f.read()
+
+    assert "association_class" in page_content
+    assert "ReservedRoom" in page_content
+    assert "agreed_price" in page_content
+
+
+def test_generated_table_component_renders_association_class_inputs(
+    assoc_class_models, tmp_path
+):
+    """The generated table component reads, renders and submits association class attributes."""
+    domain_model, gui_model = assoc_class_models
+    generator = ReactGenerator(
+        model=domain_model, gui_model=gui_model, output_dir=str(tmp_path)
+    )
+    generator.generate()
+
+    component_path = os.path.join(
+        str(tmp_path), "src", "components", "table", "TableComponent.tsx"
+    )
+    assert os.path.isfile(component_path), "TableComponent.tsx should be generated"
+    with open(component_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    # Metadata key coming from the serializer and its normalized column property
+    assert "association_class" in content
+    assert "associationClass" in content
+    # Per selected target inputs
+    assert "setLinkAttrValue(col.field, String(targetId), linkField.name" in content
+    # Edit prefill from the `<end>_links` payload
+    assert "_links`]" in content
+    # Submitted payload shape: [{ target: <id>, <association class attributes> }]
+    assert "{ target: parseInt(v, 10) }" in content
+
+
+def test_table_component_is_model_independent(assoc_class_models, plain_nm_models, tmp_path):
+    """The table component is data driven: models with and without an association
+    class generate byte-identical component code, so plain N:M rendering is unchanged."""
+    assoc_domain, assoc_gui = assoc_class_models
+    plain_domain, plain_gui = plain_nm_models
+
+    assoc_dir = os.path.join(str(tmp_path), "with_assoc")
+    plain_dir = os.path.join(str(tmp_path), "without_assoc")
+    ReactGenerator(model=assoc_domain, gui_model=assoc_gui, output_dir=assoc_dir).generate()
+    ReactGenerator(model=plain_domain, gui_model=plain_gui, output_dir=plain_dir).generate()
+
+    rel_path = os.path.join("src", "components", "table", "TableComponent.tsx")
+    with open(os.path.join(assoc_dir, rel_path), "rb") as f:
+        assoc_bytes = f.read()
+    with open(os.path.join(plain_dir, rel_path), "rb") as f:
+        plain_bytes = f.read()
+
+    assert assoc_bytes == plain_bytes
+
+    # ... and the plain model never emits the association class metadata
+    plain_pages_dir = os.path.join(plain_dir, "src", "pages")
+    for page_file in os.listdir(plain_pages_dir):
+        if page_file.endswith(".tsx"):
+            with open(os.path.join(plain_pages_dir, page_file), "r", encoding="utf-8") as f:
+                assert "association_class" not in f.read()

--- a/tests/generators/react/test_react_generator.py
+++ b/tests/generators/react/test_react_generator.py
@@ -266,7 +266,7 @@ def _build_booking_models(with_association_class: bool):
     reference = Property(name="reference", type=StringType)
     booking = Class(name="Booking", attributes={reference})
 
-    number = Property(name="number", type=StringType)
+    number = Property(name="number", type=StringType, is_id=True)
     room = Class(name="Room", attributes={number})
 
     booking_end = Property(name="bookings", type=booking, multiplicity=Multiplicity(0, "*"))
@@ -385,6 +385,7 @@ def test_form_column_without_association_class_unchanged(plain_nm_models):
         "path": "rooms",
         "field": "rooms",
         "lookup_field": "number",
+        "target_field": "number",
         "entity": "Room",
         "type": "list",
         "required": False,

--- a/tests/generators/rest_api/test_rest_api_assoc_class.py
+++ b/tests/generators/rest_api/test_rest_api_assoc_class.py
@@ -1,0 +1,345 @@
+"""End-to-end tests for the REST API generator on association classes and custom primary keys.
+
+The generated backend is loaded with ``importlib`` and driven through an ASGI transport
+(the installed starlette/httpx versions do not support the legacy ``TestClient(app=...)``
+pattern, see ``tests/utilities/web_modeling_editor/backend/test_api_integration.py``).
+
+The Create models that carry association class links are produced by the Pydantic
+generator. This module appends its own definitions of the affected models to the
+generated ``pydantic_classes.py`` so that the REST layer is exercised against the frozen
+contract (``<AssociationClass>LinkCreate`` with ``target`` plus the association class
+attributes) without depending on the Pydantic generator implementing it yet.
+"""
+
+import asyncio
+import importlib
+import os
+import py_compile
+import sys
+
+import httpx
+import pytest
+from httpx._transports.asgi import ASGITransport
+
+from besser.BUML.metamodel.structural import (
+    AssociationClass, BinaryAssociation, Class, DomainModel, FloatType,
+    IntegerType, Multiplicity, Property, StringType,
+)
+from besser.generators.pydantic_classes import PydanticGenerator
+from besser.generators.rest_api import RESTAPIGenerator
+from besser.generators.sql_alchemy import SQLAlchemyGenerator
+
+
+GENERATED_MODULES = ("main_api", "pydantic_classes", "sql_alchemy")
+
+# Create models rewritten on top of the generated ones, following the association class
+# link contract shared with the Pydantic generator.
+LINK_CONTRACT_STUB = '''
+
+class ReservationLinkCreate(BaseModel):
+    target: int  # Seat code
+    price: float
+
+
+class TripCreate(BaseModel):
+    id: int
+    reference: str
+    seats: Optional[List[ReservationLinkCreate]] = None
+    tags: Optional[List[int]] = None
+
+
+class ReservationCreate(BaseModel):
+    seats: int
+    trips: int
+    price: float
+'''
+
+
+def _trip_seat_model() -> DomainModel:
+    """Trip -- Seat N:M carrying a Reservation association class, plus a plain N:M.
+
+    ``Seat`` is keyed by ``code`` instead of ``id`` so that the generated queries have to
+    use the real primary key of the class.
+    """
+    trip = Class(
+        name="Trip",
+        attributes={
+            Property(name="id", type=IntegerType, is_id=True),
+            Property(name="reference", type=StringType),
+        },
+    )
+    seat = Class(
+        name="Seat",
+        attributes={
+            Property(name="code", type=IntegerType, is_id=True),
+            Property(name="label", type=StringType),
+        },
+    )
+    tag = Class(
+        name="Tag",
+        attributes={
+            Property(name="id", type=IntegerType, is_id=True),
+            Property(name="label", type=StringType),
+        },
+    )
+
+    trip_seat = BinaryAssociation(
+        name="trip_seat",
+        ends={
+            Property(name="trips", type=trip, multiplicity=Multiplicity(0, "*")),
+            Property(name="seats", type=seat, multiplicity=Multiplicity(0, "*")),
+        },
+    )
+    reservation = AssociationClass(
+        name="Reservation",
+        attributes={Property(name="price", type=FloatType)},
+        association=trip_seat,
+    )
+
+    trip_tag = BinaryAssociation(
+        name="trip_tag",
+        ends={
+            Property(name="tagged_trips", type=trip, multiplicity=Multiplicity(0, "*")),
+            Property(name="tags", type=tag, multiplicity=Multiplicity(0, "*")),
+        },
+    )
+
+    return DomainModel(
+        name="TripModel",
+        types={trip, seat, tag, reservation},
+        associations={trip_seat, trip_tag},
+    )
+
+
+@pytest.fixture(scope="module")
+def generated_backend(tmp_path_factory):
+    """Generate the backend of the Trip/Seat model and return its output directory."""
+    output_dir = tmp_path_factory.mktemp("rest_api_assoc_class")
+    model = _trip_seat_model()
+
+    RESTAPIGenerator(model=model, output_dir=str(output_dir), backend=True).generate()
+    SQLAlchemyGenerator(model=model, output_dir=str(output_dir)).generate()
+    PydanticGenerator(
+        model=model, output_dir=str(output_dir), backend=True, nested_creations=False
+    ).generate()
+
+    pydantic_file = output_dir / "pydantic_classes.py"
+    pydantic_file.write_text(
+        pydantic_file.read_text(encoding="utf-8") + LINK_CONTRACT_STUB, encoding="utf-8"
+    )
+    return output_dir
+
+
+@pytest.fixture(scope="module")
+def app(generated_backend):
+    """Import the generated FastAPI application and return it."""
+    saved_modules = {
+        name: sys.modules.pop(name) for name in GENERATED_MODULES if name in sys.modules
+    }
+    saved_cwd = os.getcwd()
+    saved_database_url = os.environ.get("DATABASE_URL")
+
+    database_path = (generated_backend / "test_api.db").as_posix()
+    os.environ["DATABASE_URL"] = f"sqlite:///{database_path}"
+    sys.path.insert(0, str(generated_backend))
+    os.chdir(generated_backend)
+    try:
+        importlib.invalidate_caches()
+        main_api = importlib.import_module("main_api")
+        yield main_api.app
+    finally:
+        os.chdir(saved_cwd)
+        sys.path.remove(str(generated_backend))
+        for name in GENERATED_MODULES:
+            sys.modules.pop(name, None)
+        sys.modules.update(saved_modules)
+        if saved_database_url is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = saved_database_url
+
+
+def request(app, method, url, **kwargs):
+    """Send a request to the ASGI application and return the response."""
+
+    async def _send():
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://testserver"
+        ) as client:
+            return await client.request(method, url, **kwargs)
+
+    return asyncio.run(_send())
+
+
+def create_trip(app, trip_id, reference="TR", seats=None, tags=None):
+    payload = {"id": trip_id, "reference": reference}
+    if seats is not None:
+        payload["seats"] = seats
+    if tags is not None:
+        payload["tags"] = tags
+    return request(app, "POST", "/trip/", json=payload)
+
+
+def create_seat(app, code, label="window"):
+    return request(app, "POST", "/seat/", json={"code": code, "label": label})
+
+
+def create_tag(app, tag_id, label="promo"):
+    return request(app, "POST", "/tag/", json={"id": tag_id, "label": label})
+
+
+def test_generated_main_api_is_valid_python(generated_backend):
+    """The generated application must at least compile."""
+    py_compile.compile(str(generated_backend / "main_api.py"), doraise=True)
+
+
+def test_association_class_replaces_secondary_table(generated_backend):
+    """The N:M code paths must go through the association class, not a secondary table."""
+    main_api = (generated_backend / "main_api.py").read_text(encoding="utf-8")
+
+    assert "trip_seat.insert()" not in main_api
+    assert "trip_seat.c." not in main_api
+    assert "Reservation.trips_id" in main_api
+    assert "Reservation.seats_id" in main_api
+    # The plain N:M association keeps using its secondary table
+    assert "trip_tag.insert()" in main_api
+    # Seat is keyed by `code`, never by a surrogate `id`
+    assert "Seat.id" not in main_api
+    assert "Seat.code" in main_api
+
+
+def test_create_with_association_class_links(app):
+    """Creating an entity with links stores the association class rows and their attributes."""
+    assert create_seat(app, 11).status_code == 200
+    assert create_seat(app, 12).status_code == 200
+
+    response = create_trip(
+        app, 1, seats=[{"target": 11, "price": 30.5}, {"target": 12, "price": 40.0}]
+    )
+    assert response.status_code == 200, response.text
+    assert sorted(response.json()["seats_ids"]) == [11, 12]
+
+    link = request(app, "GET", "/reservation/11/1/")
+    assert link.status_code == 200, link.text
+    assert link.json()["price"] == 30.5
+
+
+def test_create_rejects_unknown_link_target(app):
+    """A link pointing at a missing entity is reported instead of being silently dropped."""
+    response = create_trip(app, 2, seats=[{"target": 999, "price": 1.0}])
+    assert response.status_code == 404
+    assert "Seat with ID 999" in response.text
+
+
+def test_entity_with_non_id_primary_key(app):
+    """A class whose primary key is not named `id` is created and read back by that key."""
+    assert create_seat(app, 21, label="aisle").status_code == 200
+
+    response = request(app, "GET", "/seat/21/")
+    assert response.status_code == 200, response.text
+    assert response.json()["seat"]["label"] == "aisle"
+
+    assert request(app, "GET", "/seat/2100/").status_code == 404
+
+
+def test_get_returns_link_ids_and_detailed_links(app):
+    """GET endpoints expose the link target ids and, in detailed mode, the link rows."""
+    assert create_seat(app, 31).status_code == 200
+    assert create_trip(app, 3, seats=[{"target": 31, "price": 12.0}]).status_code == 200
+
+    response = request(app, "GET", "/trip/3/")
+    assert response.status_code == 200, response.text
+    assert response.json()["seats_ids"] == [31]
+
+    detailed = request(app, "GET", "/trip/?detailed=true")
+    assert detailed.status_code == 200, detailed.text
+    trip = next(item for item in detailed.json() if item["id"] == 3)
+    assert [seat["code"] for seat in trip["seats"]] == [31]
+    assert [link["price"] for link in trip["seats_links"]] == [12.0]
+
+
+def test_update_reconciles_association_class_links(app):
+    """PUT removes dropped links, adds new ones and updates the attributes of kept ones."""
+    for code in (41, 42, 43):
+        assert create_seat(app, code).status_code == 200
+    assert create_trip(app, 4, seats=[{"target": 41, "price": 5.0},
+                                      {"target": 42, "price": 6.0}]).status_code == 200
+
+    response = request(
+        app,
+        "PUT",
+        "/trip/4/",
+        json={
+            "id": 4,
+            "reference": "TR-updated",
+            "seats": [{"target": 42, "price": 66.0}, {"target": 43, "price": 7.0}],
+            # The plain N:M update path predates this fix and dereferences the field
+            # unconditionally, so it has to be sent even when it stays empty.
+            "tags": [],
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert sorted(response.json()["seats_ids"]) == [42, 43]
+
+    assert request(app, "GET", "/reservation/41/4/").status_code == 404
+    assert request(app, "GET", "/reservation/42/4/").json()["price"] == 66.0
+    assert request(app, "GET", "/reservation/43/4/").json()["price"] == 7.0
+
+
+def test_relationship_endpoints_of_association_class(app):
+    """The add/get/remove relationship endpoints write and read the association class rows."""
+    assert create_seat(app, 51).status_code == 200
+    assert create_trip(app, 5).status_code == 200
+
+    added = request(app, "POST", "/trip/5/seats/51/", json={"price": 99.5})
+    assert added.status_code == 200, added.text
+
+    duplicate = request(app, "POST", "/trip/5/seats/51/", json={"price": 1.0})
+    assert duplicate.status_code == 400
+
+    listed = request(app, "GET", "/trip/5/seats/")
+    assert listed.status_code == 200, listed.text
+    assert listed.json()["seats_count"] == 1
+    assert [link["price"] for link in listed.json()["seats_links"]] == [99.5]
+
+    removed = request(app, "DELETE", "/trip/5/seats/51/")
+    assert removed.status_code == 200, removed.text
+    assert request(app, "GET", "/trip/5/seats/").json()["seats_count"] == 0
+
+
+def test_association_class_crud_uses_both_foreign_keys(app):
+    """The association class is created, updated and deleted through its two foreign keys."""
+    assert create_seat(app, 61).status_code == 200
+    assert create_trip(app, 6).status_code == 200
+
+    created = request(app, "POST", "/reservation/", json={"seats": 61, "trips": 6, "price": 8.0})
+    assert created.status_code == 200, created.text
+
+    updated = request(app, "PUT", "/reservation/61/6/", json={"seats": 61, "trips": 6, "price": 9.0})
+    assert updated.status_code == 200, updated.text
+    assert request(app, "GET", "/reservation/61/6/").json()["price"] == 9.0
+
+    assert request(app, "DELETE", "/reservation/61/6/").status_code == 200
+    assert request(app, "GET", "/reservation/61/6/").status_code == 404
+
+
+def test_association_class_create_reports_missing_target(app):
+    """Creating an association class row with an unknown end is rejected."""
+    assert create_trip(app, 7).status_code == 200
+    response = request(app, "POST", "/reservation/", json={"seats": 998, "trips": 7, "price": 1.0})
+    assert response.status_code == 404
+    assert "Seat with ID 998" in response.text
+
+
+def test_plain_many_to_many_still_works(app):
+    """An N:M association without association class keeps using its secondary table."""
+    assert create_tag(app, 81).status_code == 200
+    assert create_tag(app, 82).status_code == 200
+
+    response = create_trip(app, 8, tags=[81, 82])
+    assert response.status_code == 200, response.text
+    assert sorted(response.json()["tag_ids"]) == [81, 82]
+
+    listed = request(app, "GET", "/trip/8/tags/")
+    assert listed.status_code == 200, listed.text
+    assert listed.json()["tags_count"] == 2

--- a/tests/generators/test_normalize_method_code.py
+++ b/tests/generators/test_normalize_method_code.py
@@ -1,0 +1,42 @@
+"""Tests for normalize_method_code: user method bodies embedded in generated files."""
+from besser.generators.structural_utils import normalize_method_code
+
+
+def test_mixed_tabs_and_spaces_compile():
+    # Real-world editor input: tab-indented lines, a stray "spaces+tab" blank
+    # line and one 4-space-indented line in the same body (previously an
+    # IndentationError that prevented the generated app from starting).
+    code = (
+        "def pay_invoice(self):\n"
+        "\tif self.paid:\n"
+        "\t\treturn False\n"
+        "    \t\n"
+        "\tself.paid = True\n"
+        "    self.booking.status = 'confirmed'\n"
+        "\treturn True\n"
+    )
+    out = normalize_method_code(code, "pay_invoice")
+    compile(out, "<test>", "exec")
+    assert "\t" not in out
+
+
+def test_broken_code_becomes_commented_stub():
+    out = normalize_method_code("def broken(self:\n  return", "broken")
+    compile(out, "<test>", "exec")
+    assert "NotImplementedError" in out
+    assert "# def broken(self:" in out
+
+
+def test_valid_code_passes_through_unchanged_semantics():
+    code = "def ok(self):\n    return 42\n"
+    out = normalize_method_code(code, "ok")
+    namespace = {}
+    exec(compile(out, "<test>", "exec"), namespace)
+    class _Obj:  # noqa: N801 - minimal stand-in instance
+        pass
+    assert namespace["ok"](_Obj()) == 42
+
+
+def test_empty_code_is_returned_as_is():
+    assert normalize_method_code("", "x") == ""
+    assert normalize_method_code(None, "x") == ""


### PR DESCRIPTION
## Summary

- **OCL constraints enforced in generated backends**: `matches()` translates to `re.match` validators, two-attribute constraints become model validators, collection constraints get an explanatory NOTE, and every generated expression is syntax-checked (previously freshly generated backends died with a SyntaxError). Django clean() got the same quoting fix.
- **Association classes end-to-end**: endpoints route through the association class (no more `NameError` on a nonexistent join table); links travel as `{target, ...attrs}` payloads with PUT reconciliation and `_links` in detailed GETs; real primary-key names respected everywhere (backend + dialog selects).
- **Create/edit dialog**: inline association panels under each checked option, searchable multi-selects, table-consistent display fields with a name-first default, two-column Details/Relationships layout, and real error messages in the banner.
- **User method code normalized + compile-gated** before embedding (FastAPI/Python/Django) - mixed tabs/spaces no longer produce an IndentationError at app startup; non-compiling bodies become commented stubs.
- Frontend submodule bump to f84488d0 (#189): autogenerated lookup columns default to a readable display attribute.

## Test plan

- [x] `python -m pytest tests/generators` — includes the new OCL (30), association-class API (13), react dialog (5) and method-code (4) suites
- [ ] Full docs build: `cd docs && make html` — v7.14.1 page renders
- [ ] E2E already performed against the hotel-booking benchmark model (OCL 422s, room/booking creation, per-room association attributes persisted, method-code app boot)