### PR TITLE
fix(generators): deleting an entity deletes its association-class links

### DIFF
--- a/besser/generators/backend/templates/router.py.j2
+++ b/besser/generators/backend/templates/router.py.j2
@@ -973,18 +973,31 @@ async def delete_{{ class.name | lower}}({{ ac_ends[0].name }}_id: {{ pk_types.g
     ).first()
     if db_{{ class.name | lower}} is None:
         raise HTTPException(status_code=404, detail="{{ class.name }} not found")
+    # Snapshot the columns before deleting: the live object may carry loaded
+    # back-references, which would make the JSON encoder recurse endlessly.
+    deleted_{{ class.name | lower}} = {
+        attr.key: getattr(db_{{ class.name | lower}}, attr.key)
+        for attr in db_{{ class.name | lower}}.__mapper__.column_attrs
+    }
     database.delete(db_{{ class.name | lower}})
     database.commit()
-    return db_{{ class.name | lower}}
+    return deleted_{{ class.name | lower}}
 {% else %}
 @router.delete("/{{ class.name | lower}}/{% raw %}{{% endraw %}{{ class.name | lower}}_id{% raw %}}{% endraw %}/", response_model=None, tags=["{{ class.name }}"])
 async def delete_{{ class.name | lower}}({{ class.name | lower}}_id: {{ pk_types.get(class.name, 'int') }}, database: Session = Depends(get_db)):
     db_{{ class.name | lower}} = database.query({{ class.name }}).filter({{ class.name }}.{{ pk }} == {{ class.name | lower}}_id).first()
     if db_{{ class.name | lower}} is None:
         raise HTTPException(status_code=404, detail="{{ class.name }} not found")
+    # Snapshot the columns before deleting: cascading the association-class
+    # links loads relationship collections whose back-references would make
+    # the JSON encoder recurse endlessly on the live object.
+    deleted_{{ class.name | lower}} = {
+        attr.key: getattr(db_{{ class.name | lower}}, attr.key)
+        for attr in db_{{ class.name | lower}}.__mapper__.column_attrs
+    }
     database.delete(db_{{ class.name | lower}})
     database.commit()
-    return db_{{ class.name | lower}}
+    return deleted_{{ class.name | lower}}
 {% endif %}
 {% endif %}
 

--- a/besser/generators/react/serialization.py
+++ b/besser/generators/react/serialization.py
@@ -831,11 +831,32 @@ class GuiSerializationMixin:
             {
                 "entity": getattr(domain, "name", None),
                 "endpoint": endpoint,
+                "row_key_fields": self._row_key_fields(domain),
                 "label_field": label_field_value,
                 "data_field": data_field_value,
                 "filter": str(data_filter) if data_filter else None,
             }
         )
+
+    @staticmethod
+    def _row_key_fields(domain) -> Optional[List[str]]:
+        """The row fields that address one entity in the generated REST API.
+
+        An association class is keyed by the foreign keys of its two ends
+        (``/<class>/{<end>_id}/{<end>_id}/``, ends in name order — the same
+        order the backend generator uses); any other class by its declared
+        ``is_id`` attribute, falling back to the surrogate ``id``.
+        """
+        if domain is None:
+            return None
+        if isinstance(domain, AssociationClass):
+            ends = sorted(domain.association.ends, key=lambda end: end.name)
+            return [f"{end.name}_id" for end in ends]
+        attributes = list(domain.all_attributes()) if hasattr(domain, "all_attributes") else list(
+            getattr(domain, "attributes", None) or []
+        )
+        id_attr = next((attr.name for attr in sort_by_timestamp(attributes) if getattr(attr, "is_id", False)), None)
+        return [id_attr or "id"]
 
     def _serialize_chart_series(self, series_list) -> Optional[List[Dict[str, Any]]]:
         """Serialize chart series with their data bindings."""

--- a/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
+++ b/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
@@ -692,8 +692,17 @@ export const TableComponent: React.FC<Props> = ({
     return endpoint;
   };
 
-  // Helper to get row id
+  // The path segment(s) that address a row in the REST API. The binding names
+  // the key fields: the declared primary key (e.g. Room.number) or, for an
+  // association class, both foreign keys in the backend's route order.
   const getRowId = (row: any) => {
+    const keyFields: string[] | undefined = dataBinding?.row_key_fields ?? dataBinding?.rowKeyFields;
+    if (row && Array.isArray(keyFields) && keyFields.length > 0) {
+      const parts = keyFields.map((field) => row[field]);
+      if (parts.every((part) => part !== undefined && part !== null)) {
+        return parts.join("/");
+      }
+    }
     return row?.id ?? row?.ID ?? row?.Id ?? Object.values(row)[0];
   };
 

--- a/besser/generators/sql_alchemy/templates/sql_alchemy_template.py.j2
+++ b/besser/generators/sql_alchemy/templates/sql_alchemy_template.py.j2
@@ -209,7 +209,10 @@ class {{ asso_class.name }}(Base):
 #--- Relationships for association class {{ asso_class.name }}
     {%- for end in asso_class.association.ends %}
 {{ asso_class.name }}.{{ end.name }}: Mapped_["{{ end.type.name }}"] = relationship("{{ end.type.name }}", back_populates="{{ asso_class.name.lower() }}s")
-{{ end.type.name }}.{{ asso_class.name.lower() }}s: Mapped_[List_["{{ asso_class.name }}"]] = relationship("{{ asso_class.name }}", back_populates="{{ end.name }}")
+{#- The link rows are owned by the linked entities: deleting one must delete its
+    links (the FK is part of the link's composite primary key, so SQLAlchemy cannot
+    null it out - without the cascade a delete fails with an AssertionError). #}
+{{ end.type.name }}.{{ asso_class.name.lower() }}s: Mapped_[List_["{{ asso_class.name }}"]] = relationship("{{ asso_class.name }}", back_populates="{{ end.name }}", cascade="all, delete-orphan")
     {%- endfor %}
 {%- endfor %}
 

--- a/tests/generators/backend/test_backend_assoc_class.py
+++ b/tests/generators/backend/test_backend_assoc_class.py
@@ -302,3 +302,51 @@ def test_plain_many_to_many_still_works(app):
     listed = request(app, "GET", "/trip/8/tags/")
     assert listed.status_code == 200, listed.text
     assert listed.json()["tags_count"] == 2
+
+
+def test_delete_entity_cascades_its_association_class_links(app):
+    """Deleting an entity deletes the association-class rows that link it.
+
+    The link's FK is part of its composite primary key, so without the
+    delete-orphan cascade SQLAlchemy tried to null it out and the request
+    crashed; the other end of the link must survive untouched.
+    """
+    assert create_seat(app, 91, label="cascade").status_code == 200
+    assert create_trip(app, 19, seats=[{"target": 91, "price": 15.0}]).status_code == 200
+    assert request(app, "GET", "/reservation/91/19/").status_code == 200
+
+    response = request(app, "DELETE", "/trip/19/")
+    assert response.status_code == 200, response.text
+    # The response is the deleted row's columns (never the live ORM object,
+    # whose loaded back-references would recurse in the JSON encoder)
+    assert response.json()["id"] == 19
+    assert "seats" not in response.json()
+
+    assert request(app, "GET", "/trip/19/").status_code == 404
+    assert request(app, "GET", "/reservation/91/19/").status_code == 404
+    assert request(app, "GET", "/seat/91/").status_code == 200
+
+
+def test_delete_other_end_cascades_links_too(app):
+    """The cascade applies from both ends of the association class."""
+    assert create_seat(app, 92).status_code == 200
+    assert create_trip(app, 20, seats=[{"target": 92, "price": 1.0}]).status_code == 200
+
+    response = request(app, "DELETE", "/seat/92/")
+    assert response.status_code == 200, response.text
+    assert response.json()["code"] == 92
+    assert request(app, "GET", "/reservation/92/20/").status_code == 404
+    assert request(app, "GET", "/trip/20/").json()["seats_ids"] == []
+
+
+def test_delete_association_class_row_returns_its_columns(app):
+    assert create_seat(app, 93).status_code == 200
+    assert create_trip(app, 21, seats=[{"target": 93, "price": 7.5}]).status_code == 200
+
+    response = request(app, "DELETE", "/reservation/93/21/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"seats_id": 93, "trips_id": 21, "price": 7.5}
+    assert request(app, "GET", "/reservation/93/21/").status_code == 404
+    # Both linked entities are untouched
+    assert request(app, "GET", "/seat/93/").status_code == 200
+    assert request(app, "GET", "/trip/21/").status_code == 200

--- a/tests/generators/react/test_react_generator.py
+++ b/tests/generators/react/test_react_generator.py
@@ -466,3 +466,54 @@ def test_table_component_is_model_independent(assoc_class_models, plain_nm_model
         if page_file.endswith(".tsx"):
             with open(os.path.join(plain_pages_dir, page_file), "r", encoding="utf-8") as f:
                 assert "association_class" not in f.read()
+
+
+# ---------------------------------------------------------------------------
+# Row keys: how the generated table addresses one row in the REST API
+# ---------------------------------------------------------------------------
+
+def _row_key_fields_by_entity(generator):
+    """Map each table binding's entity to its serialized row_key_fields."""
+    payload = json.loads(generator._build_generation_context()["components_json"])
+    found = {}
+
+    def walk(node):
+        if isinstance(node, dict):
+            if "row_key_fields" in node and "entity" in node:
+                found[node["entity"]] = node["row_key_fields"]
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(payload)
+    return found
+
+
+def test_data_binding_row_key_fields(assoc_class_models):
+    """A table addresses rows by the declared primary key, and an association
+    class by both foreign keys in the backend's route order - never by
+    guessing the first column of the row."""
+    domain_model, _ = assoc_class_models
+    classes = {cls.name: cls for cls in domain_model.get_classes()}
+    tables = {
+        Table(name="BookingTable", title="Bookings", action_buttons=True,
+              data_binding=DataBinding(name="booking_binding", domain_concept=classes["Booking"])),
+        Table(name="RoomTable", title="Rooms", action_buttons=True,
+              data_binding=DataBinding(name="room_binding", domain_concept=classes["Room"])),
+        Table(name="ReservedRoomTable", title="Links", action_buttons=True,
+              data_binding=DataBinding(name="link_binding", domain_concept=classes["ReservedRoom"])),
+    }
+    screen = Screen(name="Admin", description="Admin screen", view_elements=tables, is_main_page=True)
+    gui_model = GUIModel(
+        name="BookingApp", package="com.test.booking", versionCode="1", versionName="1.0",
+        modules={Module(name="AdminModule", screens={screen})}, description="Booking GUI",
+    )
+    generator = ReactGenerator(model=domain_model, gui_model=gui_model)
+
+    assert _row_key_fields_by_entity(generator) == {
+        "Booking": ["id"],                          # surrogate key
+        "Room": ["number"],                         # declared is_id attribute
+        "ReservedRoom": ["bookings_id", "rooms_id"],  # /reservedroom/{bookings_id}/{rooms_id}/
+    }

--- a/tests/generators/sqlalchemy/test_sqlalchemy_generator.py
+++ b/tests/generators/sqlalchemy/test_sqlalchemy_generator.py
@@ -363,3 +363,41 @@ def test_reserved_underscore_aliases():
     error_message = str(exc_info.value)
     assert "Boolean_" in error_message
     assert "reserved" in error_message.lower()
+
+
+def test_association_class_links_are_deleted_with_their_entities(tmpdir):
+    """Deleting an entity must cascade to its association-class rows: their FK
+    is part of the composite primary key, so without delete-orphan SQLAlchemy
+    tries to null it out and the delete fails with an AssertionError."""
+    from besser.BUML.metamodel.structural import (
+        AssociationClass, BinaryAssociation, Class, DomainModel, FloatType,
+        IntegerType, Multiplicity, Property, StringType,
+    )
+
+    trip = Class(name="Trip", attributes={
+        Property(name="id", type=IntegerType, is_id=True),
+        Property(name="reference", type=StringType),
+    })
+    seat = Class(name="Seat", attributes={Property(name="code", type=IntegerType, is_id=True)})
+    trip_seat = BinaryAssociation(name="trip_seat", ends={
+        Property(name="trips", type=trip, multiplicity=Multiplicity(0, "*")),
+        Property(name="seats", type=seat, multiplicity=Multiplicity(0, "*")),
+    })
+    reservation = AssociationClass(
+        name="Reservation", attributes={Property(name="price", type=FloatType)}, association=trip_seat,
+    )
+    model = DomainModel(name="TripModel", types={trip, seat, reservation}, associations={trip_seat})
+
+    output_dir = tmpdir.mkdir("assoc_cascade")
+    SQLAlchemyGenerator(model=model, output_dir=str(output_dir)).generate(dbms="sqlite")
+    with open(os.path.join(str(output_dir), "sql_alchemy.py"), encoding="utf-8") as f:
+        code = f.read()
+
+    # Entity -> links: owned, deleted with the entity (from both ends)
+    assert ('Trip.reservations: Mapped_[List_["Reservation"]] = relationship("Reservation", '
+            'back_populates="trips", cascade="all, delete-orphan")') in code
+    assert ('Seat.reservations: Mapped_[List_["Reservation"]] = relationship("Reservation", '
+            'back_populates="seats", cascade="all, delete-orphan")') in code
+    # Link -> entity: no cascade, deleting a link never deletes the entity
+    assert 'Reservation.trips: Mapped_["Trip"] = relationship("Trip", back_populates="reservations")' in code
+    assert 'Reservation.seats: Mapped_["Seat"] = relationship("Seat", back_populates="reservations")' in code


### PR DESCRIPTION
## What

Deleting an entity that has association-class links (e.g. a `Booking` with `ReservedRoom` rows) crashed the generated backend, and the generated table could not delete a link row at all.

- **sql_alchemy**: entity → links relationships of every association class now carry `cascade="all, delete-orphan"` (both ends). Their FK is part of the link's composite PK, so without the cascade SQLAlchemy raised *"Dependency rule tried to blank-out primary key column"* on delete.
- **backend routers**: `DELETE` returns a column snapshot of the deleted row instead of the live ORM object — the cascade loads back-references that made the JSON encoder recurse endlessly.
- **react**: the table binding now names its `row_key_fields` (declared `is_id` attribute, or both FKs in the backend's route order for an association class) and `getRowId` builds the path from them. Previously it guessed the first column of the row, which for a `ReservedRoom` was the price → `DELETE /reservedroom/88.0/`.

## Tests

End-to-end cascade from both ends + link deletion (backend, ASGI-driven), `row_key_fields` serialization (react), cascade emission (sqlalchemy). Verified live against the hotel-booking model: create booking with two rooms → delete a link → delete the booking → no orphan rows.