### PR TITLE
v7.15.0

### DIFF
--- a/besser/BUML/metamodel/state_machine/agent.py
+++ b/besser/BUML/metamodel/state_machine/agent.py
@@ -850,6 +850,8 @@ class RAG(NamedElement):
             llm_prompt: Optional[str] = None,
             k: int = 4,
             num_previous_messages: int = 0,
+            use_hybrid_rag: bool = False,
+            bm25_weight: float = 0.6,
     ):
         super().__init__(name)
         self.agent: 'Agent' = agent
@@ -859,6 +861,8 @@ class RAG(NamedElement):
         self.llm_prompt: Optional[str] = llm_prompt
         self.k: int = k
         self.num_previous_messages: int = num_previous_messages
+        self.use_hybrid_rag: bool = use_hybrid_rag
+        self.bm25_weight: float = bm25_weight
 
 
 # --- Reasoning extension primitives -------------------------------------- #
@@ -2005,6 +2009,8 @@ class Agent(StateMachine):
             llm_prompt: Optional[str] = None,
             k: int = 4,
             num_previous_messages: int = 0,
+            use_hybrid_rag: bool = False,
+            bm25_weight: float = 0.6,
     ) -> RAG:
         """Register a Retrieval-Augmented Generation configuration on the agent."""
 
@@ -2019,6 +2025,8 @@ class Agent(StateMachine):
             llm_prompt=llm_prompt,
             k=k,
             num_previous_messages=num_previous_messages,
+            use_hybrid_rag=use_hybrid_rag,
+            bm25_weight=bm25_weight,
         )
         self.rags.append(rag)
         return rag

--- a/besser/generators/agents/templates/baf_agent_template.py.j2
+++ b/besser/generators/agents/templates/baf_agent_template.py.j2
@@ -175,6 +175,7 @@ rules = json.loads(r'''{{ config['personalizationrules'] | tojson(indent=2) }}''
 
 {% set platform_name = config['agentPlatform'] if config and 'agentPlatform' in config else None %}
 {% if platform_name == 'websocket' %}
+# Set use_ui=True to launch the built-in Streamlit chat interface automatically on startup.
 platform = agent.use_websocket_platform(use_ui=False)
 {% elif platform_name == 'telegram' %}
 platform = agent.use_telegram_platform()
@@ -285,6 +286,7 @@ tts = OpenAIText2Speech(agent=agent, model_name="gpt-4o-mini-tts")
     num_previous_messages={{ rag.num_previous_messages if rag.num_previous_messages is not none else 0 }}{% if rag.use_hybrid_rag %},
     bm25_weight={{ rag.bm25_weight if rag.bm25_weight is not none else 0.6 }}{% endif %}
 )
+# Place your documents (PDF, TXT, etc.) in the './{{ rag_slug }}' folder before running.
 {{ rag_var }}.load_pdfs('./{{ rag_slug }}')
 
 {% endfor %}

--- a/besser/generators/agents/templates/baf_agent_template.py.j2
+++ b/besser/generators/agents/templates/baf_agent_template.py.j2
@@ -21,8 +21,10 @@ from baf.nlp.text2speech.openai_text2speech import OpenAIText2Speech
 {% if agent.rags and agent.rags|length > 0 %}
 {% set has_openai_rag_ns = namespace(value=false) %}
 {% set has_ollama_rag_ns = namespace(value=false) %}
+{% set has_hybrid_rag_ns = namespace(value=false) %}
 {% for rag in agent.rags %}
 {% if rag.vector_store and rag.vector_store.embedding_provider == 'ollama' %}{% set has_ollama_rag_ns.value = true %}{% else %}{% set has_openai_rag_ns.value = true %}{% endif %}
+{% if rag.use_hybrid_rag %}{% set has_hybrid_rag_ns.value = true %}{% endif %}
 {% endfor %}
 {% if has_openai_rag_ns.value %}from langchain_community.embeddings import OpenAIEmbeddings
 {% endif %}
@@ -31,7 +33,9 @@ from baf.nlp.text2speech.openai_text2speech import OpenAIText2Speech
 from langchain_community.vectorstores import Chroma
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from baf import nlp
-from baf.nlp.rag.rag import RAG
+{% if has_hybrid_rag_ns.value %}from baf.nlp.rag.rag import RAG, HybridRAG
+{% else %}from baf.nlp.rag.rag import RAG
+{% endif %}
 {% endif %}
 {% set reasoning_states_ns = namespace(items=[]) %}
 {% for state in agent.states %}
@@ -271,14 +275,15 @@ tts = OpenAIText2Speech(agent=agent, model_name="gpt-4o-mini-tts")
 )
 {% endif %}
 {{ splitter_var }} = RecursiveCharacterTextSplitter(chunk_size={{ chunk_size }}, chunk_overlap={{ chunk_overlap }})
-{{ rag_var }} = RAG(
+{{ rag_var }} = {{ 'HybridRAG' if rag.use_hybrid_rag else 'RAG' }}(
     agent=agent,
     vector_store={{ vector_var }},
     splitter={{ splitter_var }},
     llm_name='{{ ((rag.llm_name if rag.llm_name else (agent.default_llm_name if agent.default_llm_name else '')) | string) | replace('\\', '\\\\') | replace("'", "\\'") }}',
     llm_prompt={% if rag.llm_prompt %}'{{ rag.llm_prompt | replace('\\', '\\\\') | replace("'", "\\'") }}'{% else %}None{% endif %},
     k={{ rag.k if rag.k is not none else 4 }},
-    num_previous_messages={{ rag.num_previous_messages if rag.num_previous_messages is not none else 0 }}
+    num_previous_messages={{ rag.num_previous_messages if rag.num_previous_messages is not none else 0 }}{% if rag.use_hybrid_rag %},
+    bm25_weight={{ rag.bm25_weight if rag.bm25_weight is not none else 0.6 }}{% endif %}
 )
 {{ rag_var }}.load_pdfs('./{{ rag_slug }}')
 

--- a/besser/utilities/buml_code_builder/agent_model_builder.py
+++ b/besser/utilities/buml_code_builder/agent_model_builder.py
@@ -169,6 +169,8 @@ def agent_model_to_code(model: Agent, file_path: str, model_var_name: str = "age
                 f.write(f"    llm_prompt={repr(getattr(rag, 'llm_prompt', None))},\n")
                 f.write(f"    k={rag.k},\n")
                 f.write(f"    num_previous_messages={rag.num_previous_messages},\n")
+                f.write(f"    use_hybrid_rag={getattr(rag, 'use_hybrid_rag', False)},\n")
+                f.write(f"    bm25_weight={getattr(rag, 'bm25_weight', 0.6)},\n")
                 f.write(")\n\n")
 
         # Emit explicit LLM definitions via Agent.new_llm — every consumer

--- a/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/buml_to_json/agent_diagram_converter.py
@@ -476,6 +476,8 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                         rag_llm_prompt = ""
                         rag_k = 4
                         rag_num_previous_messages = 0
+                        rag_use_hybrid_rag = False
+                        rag_bm25_weight = 0.6
                         rag_vector_store_var = None
                         if (
                             node.value.args
@@ -506,6 +508,16 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                             elif kw.arg == "num_previous_messages":
                                 if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, int):
                                     rag_num_previous_messages = kw.value.value
+                            elif kw.arg == "use_hybrid_rag":
+                                if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, bool):
+                                    rag_use_hybrid_rag = kw.value.value
+                            elif kw.arg == "bm25_weight":
+                                if (
+                                    isinstance(kw.value, ast.Constant)
+                                    and isinstance(kw.value.value, (int, float))
+                                    and not isinstance(kw.value.value, bool)
+                                ):
+                                    rag_bm25_weight = float(kw.value.value)
                             elif kw.arg == "vector_store" and isinstance(kw.value, ast.Name):
                                 rag_vector_store_var = kw.value.id
 
@@ -534,6 +546,8 @@ def agent_buml_to_json(content: str) -> Dict[str, Any]:
                                 "k": rag_k,
                                 "num_previous_messages": rag_num_previous_messages,
                                         "numPreviousMessages": rag_num_previous_messages,
+                                "use_hybrid_rag": rag_use_hybrid_rag,
+                                "bm25_weight": rag_bm25_weight,
                                 "embedding_provider": rag_embedding_provider,
                                 "embedding_base_url": rag_embedding_base_url,
                                 "embedding_model": rag_embedding_model,

--- a/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
+++ b/besser/utilities/web_modeling_editor/backend/services/converters/json_to_buml/agent_diagram_processor.py
@@ -470,6 +470,15 @@ def process_agent_diagram(json_data):
             if rag_num_previous_messages < 0:
                 rag_num_previous_messages = 0
 
+            rag_use_hybrid = bool(element.get("use_hybrid_rag", False))
+            raw_bm25 = element.get("bm25_weight")
+            try:
+                rag_bm25_weight = float(raw_bm25) if raw_bm25 is not None else 0.6
+            except (TypeError, ValueError):
+                rag_bm25_weight = 0.6
+            if not (0 < rag_bm25_weight < 1):
+                rag_bm25_weight = 0.6
+
             rag_config = agent.new_rag(
                 name=rag_name,
                 vector_store=vector_store,
@@ -478,6 +487,8 @@ def process_agent_diagram(json_data):
                 llm_prompt=rag_llm_prompt,
                 k=rag_k,
                 num_previous_messages=rag_num_previous_messages,
+                use_hybrid_rag=rag_use_hybrid,
+                bm25_weight=rag_bm25_weight,
             )
             rag_dbs_by_id[element_id] = rag_config
             rag_dbs_by_name[rag_name] = rag_config

--- a/docs/source/buml_language/model_types/agent.rst
+++ b/docs/source/buml_language/model_types/agent.rst
@@ -107,6 +107,24 @@ every RAG query, useful for enforcing domain-specific constraints or tone:
         llm_prompt='Answer only from the provided documents.',
     )
 
+Retrieval can combine the vector store with a BM25 keyword index (hybrid
+retrieval). Set ``use_hybrid_rag=True`` and, optionally, ``bm25_weight`` — the
+weight of the BM25 results between 0 and 1, the vector results getting the
+remainder (default ``0.6``). The generated agent then uses BAF's ``HybridRAG``
+instead of ``RAG``; in the web editor these are the *Hybrid RAG (BM25)* and
+*BM25 weight* fields of the RAG element:
+
+.. code-block:: python
+
+    kb = agent.new_rag(
+        name='Knowledge Base',
+        vector_store=vector_store,
+        splitter=splitter,
+        llm_name='gpt-4o-mini',
+        use_hybrid_rag=True,
+        bm25_weight=0.6,
+    )
+
 Multiple LLMs
 ~~~~~~~~~~~~~
 

--- a/docs/source/releases/v7.rst
+++ b/docs/source/releases/v7.rst
@@ -4,6 +4,7 @@ Version 7
 .. toctree::
    :maxdepth: 1
 
+   v7/v7.15.0
    v7/v7.14.2
    v7/v7.14.1
    v7/v7.14.0

--- a/docs/source/releases/v7/v7.15.0.rst
+++ b/docs/source/releases/v7/v7.15.0.rst
@@ -1,0 +1,37 @@
+Version 7.15.0
+==============
+
+Minor release: **hybrid retrieval (vector + BM25) for agent RAG, and a chatbot
+agent template in the editor**. Both were contributed by Natarajan Chidambaram
+(BESSER #582, editor #177 and #179) and reviewed and completed by the BESSER
+team. No breaking changes: the new RAG parameters default to the previous
+behavior, and existing diagrams load unchanged.
+
+Highlights
+----------
+
+- **Hybrid RAG**: ``agent.new_rag()`` accepts ``use_hybrid_rag`` (default
+  ``False``) and ``bm25_weight`` (default ``0.6``, strictly between 0 and 1).
+  With hybrid retrieval enabled, the generated agent instantiates BAF's
+  ``HybridRAG`` instead of ``RAG`` — the retrieved chunks combine vector
+  similarity with a BM25 keyword index, weighted by ``bm25_weight`` for BM25 and
+  the remainder for the vector store. This requires BESSER Agentic Framework
+  4.5.1 or later. The two settings travel through every layer: the RAG element
+  of the agent diagram gained a *Hybrid RAG (BM25)* toggle and a *BM25 weight*
+  field (localized like the rest of the popup), the JSON ↔ B-UML converters and
+  the B-UML code builder round-trip them, and the agent modeling guide documents
+  them.
+- **Chatbot agent template**: the editor's template gallery offers a new
+  *Chatbot Agent* pattern — the agent behind the BESSER website chatbot. It
+  greets, lets the user upload documents into a knowledge base, answers from
+  that knowledge base with hybrid retrieval enabled by default (BM25 weight
+  0.6), constrains the LLM to the uploaded content through its default prompt,
+  and falls back to a polite "I don't know" outside the knowledge base.
+- **Editor housekeeping** (from the reviews): the two frontend contributions
+  carried a regenerated ``package-lock.json`` that broke ``npm ci``; the lockfile
+  is back to the maintained one, and the new RAG labels go through the
+  translation layer.
+
+Deploy the backend and the frontend together: the agent generator, converters
+and metamodel changed on the backend, and the RAG element popup and template
+gallery changed on the frontend.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = besser
-version = 7.14.2
+version = 7.15.0
 author = Luxembourg Institute of Science and Technology
 description = BESSER
 long_description = file: README.md

--- a/tests/generators/agents/test_baf_generator.py
+++ b/tests/generators/agents/test_baf_generator.py
@@ -226,3 +226,36 @@ def test_baf_generator_single_rag_still_uses_explicit_instance(tmp_path):
     assert "rag_message = session.run_rag(session.event.message)" not in code
 
 
+
+
+def test_baf_generator_hybrid_rag(tmp_path):
+    """A RAG with use_hybrid_rag emits HybridRAG with its bm25_weight (and the
+    matching import); a plain RAG keeps emitting RAG without it."""
+    agent = Agent("hybrid_rag_agent")
+    agent.platforms.append(WebSocketPlatform())
+    LLMOpenAI(agent=agent, name="gpt-4o-mini", parameters={})
+    docs_vs, docs_splitter = _make_rag("docs")
+    agent.new_rag(
+        name="docs_rag", vector_store=docs_vs, splitter=docs_splitter, llm_name="gpt-4o-mini",
+        use_hybrid_rag=True, bm25_weight=0.7,
+    )
+    state = agent.new_state(name="ask", initial=True)
+    state.set_body(Body("ask_body", actions=[RAGReply("docs_rag")]))
+
+    BAFGenerator(model=agent, output_dir=str(tmp_path), generation_mode=GenerationMode.CODE_ONLY).generate()
+    with open(os.path.join(str(tmp_path), f"{agent.name}.py"), "r", encoding="utf-8") as f:
+        code = f.read()
+
+    assert "from baf.nlp.rag.rag import RAG, HybridRAG" in code
+    assert "docs_rag = HybridRAG(" in code
+    assert "bm25_weight=0.7" in code
+
+
+def test_baf_generator_plain_rag_has_no_hybrid_import(multi_rag_agent_model, tmp_path):
+    BAFGenerator(model=multi_rag_agent_model, output_dir=str(tmp_path), generation_mode=GenerationMode.CODE_ONLY).generate()
+    with open(os.path.join(str(tmp_path), f"{multi_rag_agent_model.name}.py"), "r", encoding="utf-8") as f:
+        code = f.read()
+
+    assert "from baf.nlp.rag.rag import RAG\n" in code
+    assert "HybridRAG" not in code
+    assert "bm25_weight" not in code

--- a/tests/utilities/web_modeling_editor/backend/services/converters/test_agent_converter_roundtrip.py
+++ b/tests/utilities/web_modeling_editor/backend/services/converters/test_agent_converter_roundtrip.py
@@ -44,6 +44,8 @@ def _build_reasoning_agent() -> Agent:
         llm_prompt="Answer only using the docs corpus.",
         k=6,
         num_previous_messages=3,
+        use_hybrid_rag=True,
+        bm25_weight=0.7,
     )
     initial = agent.new_state("initial", initial=True)
     initial.set_body(Body("initial_body", actions=[RAGReply("docs_rag", prompt="Use only cited docs.")]))
@@ -100,6 +102,9 @@ def test_agent_roundtrip_preserves_multi_llm_and_reasoning(tmp_path):
     assert rags["docs_rag"].llm_prompt == "Answer only using the docs corpus."
     assert rags["docs_rag"].k == 6
     assert rags["docs_rag"].num_previous_messages == 3
+    # Hybrid retrieval settings survive BUML -> JSON -> BUML
+    assert rags["docs_rag"].use_hybrid_rag is True
+    assert rags["docs_rag"].bm25_weight == 0.7
 
     # RAGReply action prompt survives the converters.
     initial_state = next(s for s in restored.states if s.name == "initial")


### PR DESCRIPTION
Minor release: **hybrid retrieval (vector + BM25) for agent RAG, and a chatbot agent template in the editor**. Both were contributed by Natarajan Chidambaram (BESSER #582, editor #177 and #179) and reviewed and completed by the BESSER team. No breaking changes: the new RAG parameters default to the previous behavior, and existing diagrams load unchanged.

## Highlights

- **Hybrid RAG**: `agent.new_rag()` accepts `use_hybrid_rag` (default `False`) and `bm25_weight` (default `0.6`, strictly between 0 and 1). With hybrid retrieval enabled, the generated agent instantiates BAF's `HybridRAG` instead of `RAG` — retrieved chunks combine vector similarity with a BM25 keyword index, weighted by `bm25_weight` for BM25 and the remainder for the vector store (requires BESSER Agentic Framework ≥ 4.5.1). The settings travel through every layer: the RAG element of the agent diagram gained a *Hybrid RAG (BM25)* toggle and a *BM25 weight* field (localized), the JSON ↔ B-UML converters and the B-UML code builder round-trip them, and the agent modeling guide documents them.
- **Chatbot agent template**: the editor's template gallery offers a new *Chatbot Agent* pattern — the agent behind the BESSER website chatbot: it greets, lets the user upload documents into a knowledge base, answers from it with hybrid retrieval enabled by default, constrains the LLM to the uploaded content through its default prompt, and falls back politely outside the knowledge base.
- **Editor housekeeping**: the two frontend contributions carried a regenerated `package-lock.json` that broke `npm ci`; the lockfile is back to the maintained one, and the new RAG labels go through the translation layer.

Deploy the backend and the frontend together.
