### PR TITLE
v7.16.0

### DIFF
--- a/besser/BUML/metamodel/structural/structural.py
+++ b/besser/BUML/metamodel/structural/structural.py
@@ -2262,6 +2262,7 @@ class DomainModel(Model):
         self._validate_constraints(errors)
         self._validate_circular_inheritance(errors)
         self._validate_attribute_shadowing(errors)
+        self._validate_member_name_collisions(errors)
 
         result = {"success": len(errors) == 0, "errors": errors, "warnings": warnings}
         if errors and raise_exception:
@@ -2372,6 +2373,24 @@ class DomainModel(Model):
                     errors.append(
                         f"Class '{cls.name}' defines attribute '{attr.name}' "
                         f"which already exists in a parent class."
+                    )
+
+    def _validate_member_name_collisions(self, errors: list[str]):
+        """Validate that a method does not share its name with a feature of the class.
+
+        Generated code reaches both through the same name, so one of them wins
+        and the other becomes unreachable: a body reading ``self.check_out -
+        self.check_in`` subtracts two methods instead of two dates.
+        """
+        for cls in self.get_classes():
+            feature_names = {attr.name for attr in cls.all_attributes()}
+            feature_names |= {end.name for end in cls.association_ends()}
+            for method in cls.methods:
+                if method.name in feature_names:
+                    errors.append(
+                        f"Class '{cls.name}' defines method '{method.name}' with the name "
+                        f"of one of its attributes or association ends. A generated object "
+                        f"can only carry one of them under that name."
                     )
 
     def __repr__(self):

--- a/besser/generators/java_classes/java_generator.py
+++ b/besser/generators/java_classes/java_generator.py
@@ -6,8 +6,9 @@ from besser.generators import GeneratorInterface
 
 class JavaGenerator(GeneratorInterface):
 
-    def __init__(self, model: DomainModel, output_dir: str = None):
+    def __init__(self, model: DomainModel, output_dir: str = None, package_name: str = None):
         super().__init__(model, output_dir)
+        self.package_name = package_name
 
     def generate(self):
         templates_path = os.path.join(os.path.dirname(
@@ -15,13 +16,7 @@ class JavaGenerator(GeneratorInterface):
         env = Environment(loader=FileSystemLoader(
             templates_path), trim_blocks=True, lstrip_blocks=True, extensions=['jinja2.ext.do'])
 
-        if self.output_dir is not None:
-            if 'tmp' in self.output_dir or 'AppData' in self.output_dir:
-                package_name = None
-            else:
-                package_name = self.output_dir
-        else:
-            package_name = None
+        package_name = self.package_name
 
         for enum_obj in self.model.get_enumerations():
             file_path = self.build_generation_path(file_name=enum_obj.name + ".java")

--- a/besser/generators/java_classes/java_generator.py
+++ b/besser/generators/java_classes/java_generator.py
@@ -1,8 +1,8 @@
 import os
+
 from jinja2 import Environment, FileSystemLoader
 from besser.BUML.metamodel.structural import DomainModel
 from besser.generators import GeneratorInterface
-
 
 class JavaGenerator(GeneratorInterface):
 
@@ -10,22 +10,30 @@ class JavaGenerator(GeneratorInterface):
         super().__init__(model, output_dir)
 
     def generate(self):
+        templates_path = os.path.join(os.path.dirname(
+            os.path.abspath(__file__)), "templates")
+        env = Environment(loader=FileSystemLoader(
+            templates_path), trim_blocks=True, lstrip_blocks=True, extensions=['jinja2.ext.do'])
+
+        if self.output_dir is not None:
+            if 'tmp' in self.output_dir or 'AppData' in self.output_dir:
+                package_name = None
+            else:
+                package_name = self.output_dir
+        else:
+            package_name = None
+
+        for enum_obj in self.model.get_enumerations():
+            file_path = self.build_generation_path(file_name=enum_obj.name + ".java")
+            template = env.get_template('java_enum_template.py.j2')
+            with open(file_path, mode="w") as f:
+                f.write(template.render(enum_obj=enum_obj, package_name=package_name))
+                print("Code generated in the location: " + file_path)
+
         processed_associations = []
         for class_obj in self.model.classes_sorted_by_inheritance():
-            file_path = self.build_generation_path(file_name=class_obj.name+".java")
-            templates_path = os.path.join(os.path.dirname(
-                os.path.abspath(__file__)), "templates")
-            env = Environment(loader=FileSystemLoader(
-                templates_path), trim_blocks=True, lstrip_blocks=True, extensions=['jinja2.ext.do'])
+            file_path = self.build_generation_path(file_name=class_obj.name + ".java")
             template = env.get_template('java_template.py.j2')
-            package_name = ""
-            if self.output_dir is not None:
-                if 'tmp' in self.output_dir or 'AppData' in self.output_dir:
-                    package_name = None
-                else:
-                    package_name = self.output_dir
-            else:
-                package_name = None
             with open(file_path, mode="w") as f:
                 generated_code = template.render(class_obj=class_obj,
                                                  processed_associations=processed_associations,

--- a/besser/generators/java_classes/templates/java_enum_template.py.j2
+++ b/besser/generators/java_classes/templates/java_enum_template.py.j2
@@ -1,0 +1,22 @@
+{#
+  java_enum_template.py.j2
+  -------------------------
+  Jinja2 template that generates a single Java enum file from a BESSER B-UML Enumeration object.
+
+  Context variables (passed by JavaGenerator):
+    enum_obj     : Enumeration  - The B-UML enumeration to generate.
+    package_name : str | None   - Java package declaration; None or empty means no package statement.
+
+  What is generated:
+    - Package declaration (if package_name is set)
+    - public enum declaration with all EnumerationLiteral names as constants
+#}
+{% if package_name %}
+package {{ package_name }};
+{% endif %}
+public enum {{ enum_obj.name }} {
+{% for literal in enum_obj.literals %}
+    {{ literal.name }}{% if not loop.last %},{% endif %}
+
+{% endfor %}
+}

--- a/besser/generators/java_classes/templates/java_enum_template.py.j2
+++ b/besser/generators/java_classes/templates/java_enum_template.py.j2
@@ -1,16 +1,3 @@
-{#
-  java_enum_template.py.j2
-  -------------------------
-  Jinja2 template that generates a single Java enum file from a BESSER B-UML Enumeration object.
-
-  Context variables (passed by JavaGenerator):
-    enum_obj     : Enumeration  - The B-UML enumeration to generate.
-    package_name : str | None   - Java package declaration; None or empty means no package statement.
-
-  What is generated:
-    - Package declaration (if package_name is set)
-    - public enum declaration with all EnumerationLiteral names as constants
-#}
 {% if package_name %}
 package {{ package_name }};
 {% endif %}

--- a/besser/generators/java_classes/templates/java_fields.py.j2
+++ b/besser/generators/java_classes/templates/java_fields.py.j2
@@ -1,3 +1,26 @@
+{#
+  java_fields.py.j2
+  ------------------
+  Jinja2 macro library imported by java_template.py.j2.
+
+  Macros:
+    get_field(attr_type)
+      Maps a B-UML primitive type name to its Java equivalent.
+      Returns "None" (string) for unknown or non-primitive types — callers must
+      check for "None" and fall back to the original type name for class references.
+
+      Mappings:
+        str      -> String
+        int      -> int
+        float    -> float
+        date     -> LocalDate
+        datetime -> LocalDateTime
+        time     -> LocalTime
+        bool     -> boolean
+        text     -> String
+        uuid     -> UUID
+        *        -> None
+#}
 {% macro get_field(attr_type) %}
     {%- if attr_type == "str" -%}
 String

--- a/besser/generators/java_classes/templates/java_fields.py.j2
+++ b/besser/generators/java_classes/templates/java_fields.py.j2
@@ -1,26 +1,3 @@
-{#
-  java_fields.py.j2
-  ------------------
-  Jinja2 macro library imported by java_template.py.j2.
-
-  Macros:
-    get_field(attr_type)
-      Maps a B-UML primitive type name to its Java equivalent.
-      Returns "None" (string) for unknown or non-primitive types — callers must
-      check for "None" and fall back to the original type name for class references.
-
-      Mappings:
-        str      -> String
-        int      -> int
-        float    -> float
-        date     -> LocalDate
-        datetime -> LocalDateTime
-        time     -> LocalTime
-        bool     -> boolean
-        text     -> String
-        uuid     -> UUID
-        *        -> None
-#}
 {% macro get_field(attr_type) %}
     {%- if attr_type == "str" -%}
 String

--- a/besser/generators/java_classes/templates/java_fields.py.j2
+++ b/besser/generators/java_classes/templates/java_fields.py.j2
@@ -18,6 +18,6 @@ String
     {%- elif attr_type == "uuid" -%}
 UUID
     {%- else -%}
-None
+{{ attr_type }}
     {%- endif -%}
 {% endmacro %}

--- a/besser/generators/java_classes/templates/java_template.py.j2
+++ b/besser/generators/java_classes/templates/java_template.py.j2
@@ -1,4 +1,3 @@
-// This is a template example to list the name of the classes
 {% if package_name %}
 package {{ package_name }};
 {% endif %}
@@ -77,15 +76,11 @@ public class {{ class_obj.name }} {{ extends }}{
             {% set class2_name = ns.end2.type.name %}
             {# Generate field for end2 (the other class) if navigable - supports bidirectional associations #}
             {% if ns.end1.multiplicity.max > 1 and ns.end2.multiplicity.max > 1 and ns.end2.is_navigable %}
-                {% if ns.end1.multiplicity.min != 1 and ns.end2.multiplicity.min == 1 or
-                    ns.end1.multiplicity.min == 1 and ns.end2.multiplicity.min == 1 or
-                    ns.end1.multiplicity.min != 1 and ns.end2.multiplicity.min != 1 %}
     private List<{{ class2_name }}> {{ ns.end2.name }};
-                    {% do assocs.append('List<'+class2_name+'>') %}
-                    {% do assocs.append(ns.end2.name) %}
-                    {% do assocs_card_over_1.append(class2_name) %}
-                    {% do assocs_card_over_1.append(ns.end2.name) %}
-                {% endif %}
+                {% do assocs.append('List<'+class2_name+'>') %}
+                {% do assocs.append(ns.end2.name) %}
+                {% do assocs_card_over_1.append(class2_name) %}
+                {% do assocs_card_over_1.append(ns.end2.name) %}
             {% elif ns.end1.multiplicity.max == 1 and ns.end2.multiplicity.max > 1 and ns.end2.is_navigable %}
     private List<{{ class2_name }}> {{ ns.end2.name }};
                 {% do assocs.append('List<'+class2_name+'>') %}
@@ -107,27 +102,16 @@ public class {{ class_obj.name }} {{ extends }}{
     {% endif %}
 {% endfor %}
 
-    public {{ class_obj.name }} (
-{%- for i in range(attribs|length) -%}
-    {%- if i == attribs|length - 1 -%}
-    {{ attribs[i]}}
-    {%- else -%}
-        {%- if i % 2 == 0 -%}
-    {{ attribs[i]}} {% else -%}
-    {{ attribs[i] }}, {% endif -%}
-    {%- endif -%}
-{%- endfor -%}
-{%- if inheritance|length > 1 -%}
-    {%- for i in range(parent_attribs|length) -%}
-        {%- if i == parent_attribs|length - 1 -%}
-    {{ parent_attribs[i]}}
-        {%- else -%}
-            {%- if i % 2 == 0 -%}
-    , {{ parent_attribs[i]}} {% else -%}
-    {{ parent_attribs[i] }}{% endif -%}
-        {%- endif -%}
-    {%- endfor -%}
-{% endif %}) {
+{% set params = [] %}
+{% for i in range(0, attribs|length, 2) %}
+    {% do params.append(attribs[i] + ' ' + attribs[i+1]) %}
+{% endfor %}
+{% if inheritance|length > 1 %}
+    {% for i in range(0, parent_attribs|length, 2) %}
+        {% do params.append(parent_attribs[i] + ' ' + parent_attribs[i+1]) %}
+    {% endfor %}
+{% endif %}
+    public {{ class_obj.name }} ({{ params | join(', ') }}) {
 {% if inheritance|length > 1 %}
         super(
     {%- for i in range(parent_attribs|length) %}
@@ -152,31 +136,19 @@ public class {{ class_obj.name }} {{ extends }}{
     }
 
 {% if assocs_card_over_1 != [] %}
-    public {{ class_obj.name }} (
-{%- for i in range(attribs|length) -%}
-    {%- if i == attribs|length - 1 -%}
-    {{ attribs[i]}}
-    {%- else -%}
-        {%- if i % 2 == 0 -%}
-    {{ attribs[i]}} {% else -%}
-    {{ attribs[i] }}, {% endif -%}
-    {%- endif -%}
-{%- endfor -%}
-{%- if inheritance|length > 1 -%}
-    {%- for i in range(parent_attribs|length) -%}
-        {%- if i == parent_attribs|length - 1 -%}
-    {{ parent_attribs[i]}}
-        {%- else -%}
-            {%- if i % 2 == 0 -%}
-    , {{ parent_attribs[i]}} {% else -%}
-    {{ parent_attribs[i] }}{% endif -%}
-        {%- endif -%}
-    {%- endfor -%}
+{% set params2 = [] %}
+{% for i in range(0, attribs|length, 2) %}
+    {% do params2.append(attribs[i] + ' ' + attribs[i+1]) %}
+{% endfor %}
+{% if inheritance|length > 1 %}
+    {% for i in range(0, parent_attribs|length, 2) %}
+        {% do params2.append(parent_attribs[i] + ' ' + parent_attribs[i+1]) %}
+    {% endfor %}
 {% endif %}
-{%- for i in range(0, assocs_card_over_1|length, 2) -%}
-    {{ ", " if i > 0 or attribs|length > 0 or inheritance|length > 1 else "" }}ArrayList<{{ assocs_card_over_1[i] }}> {{ assocs_card_over_1[i+1] }}
-{%- endfor -%}
-) {
+{% for i in range(0, assocs_card_over_1|length, 2) %}
+    {% do params2.append('List<' + assocs_card_over_1[i] + '> ' + assocs_card_over_1[i+1]) %}
+{% endfor %}
+    public {{ class_obj.name }} ({{ params2 | join(', ') }}) {
 {% if inheritance|length > 1 %}
         super(
     {%- for i in range(parent_attribs|length) %}
@@ -202,25 +174,27 @@ public class {{ class_obj.name }} {{ extends }}{
 {%- endif %}
 
 {% for i in range(0, attribs|length, 2) %}
+{% set fname = attribs[i+1][0]|upper ~ attribs[i+1][1:] %}
 
-    public {{ attribs[i] }} get{{ attribs[i+1].capitalize() }}() {
+    public {{ attribs[i] }} get{{ fname }}() {
         return this.{{ attribs[i+1] }};
     }
 
-    public void set{{ attribs[i+1].capitalize() }}({{ attribs[i] }} {{ attribs[i+1] }}) {
+    public void set{{ fname }}({{ attribs[i] }} {{ attribs[i+1] }}) {
         this.{{ attribs[i+1] }} = {{ attribs[i+1] }};
     }
 {% endfor %}
 {% for i in range(0, assocs|length, 2) %}
+{% set aname = assocs[i+1][0]|upper ~ assocs[i+1][1:] %}
 
     {% if assocs[i][:4] == "List" %}
     {% set element_type = assocs[i][5:-1] %}
-    public {{ assocs[i] }} get{{ assocs[i+1].capitalize() }}() {
+    public {{ assocs[i] }} get{{ aname }}() {
         return this.{{ assocs[i+1] }};
     }
 
     {% if assocs[i+1] in self_assoc_names %}
-    public void addTo{{ assocs[i+1].capitalize() }}({{ element_type }} {{ element_type|lower }}) {
+    public void addTo{{ aname }}({{ element_type }} {{ element_type|lower }}) {
         this.{{ assocs[i+1] }}.add({{ element_type|lower }});
     }
     {% else %}
@@ -229,11 +203,11 @@ public class {{ class_obj.name }} {{ extends }}{
     }
     {% endif %}
     {% else %}
-    public {{ assocs[i] }} get{{ assocs[i+1].capitalize() }}() {
+    public {{ assocs[i] }} get{{ aname }}() {
         return this.{{ assocs[i+1] }};
     }
 
-    public void set{{ assocs[i+1].capitalize() }}({{ assocs[i] }} {{ assocs[i+1] }}) {
+    public void set{{ aname }}({{ assocs[i] }} {{ assocs[i+1] }}) {
         this.{{ assocs[i+1] }} = {{ assocs[i+1] }};
     }
     {% endif %}
@@ -243,7 +217,7 @@ public class {{ class_obj.name }} {{ extends }}{
     {% if assocs[i][:4] == "List" %}
         {% set element_type = assocs[i][5:-1] %}
         {% if assocs[i+1] in self_assoc_names %}
-            {% do generated_assoc_methods.append('addTo' + assocs[i+1].capitalize()) %}
+            {% do generated_assoc_methods.append('addTo' ~ assocs[i+1][0]|upper ~ assocs[i+1][1:]) %}
         {% else %}
             {% do generated_assoc_methods.append('add' + element_type) %}
         {% endif %}
@@ -253,14 +227,12 @@ public class {{ class_obj.name }} {{ extends }}{
     {% if method.name not in generated_assoc_methods %}
         {% set ns = namespace(return_type="void") %}
         {% if method.type %}
-            {% set jf = java_fields.get_field(method.type.name) | trim %}
-            {% set ns.return_type = method.type.name if jf == "None" else jf %}
+            {% set ns.return_type = java_fields.get_field(method.type.name) | trim %}
         {% endif %}
 
     {{ method.visibility }} {{ ns.return_type }} {{ method.name }}(
         {%- for param in method.parameters -%}
-            {%- set jf_param = java_fields.get_field(param.type.name) | trim -%}
-            {{ param.type.name if jf_param == "None" else jf_param }} {{ param.name }}{% if not loop.last %}, {% endif %}
+            {{ java_fields.get_field(param.type.name) | trim }} {{ param.name }}{% if not loop.last %}, {% endif %}
         {%- endfor -%}
     ) {
     }

--- a/besser/generators/java_classes/templates/java_template.py.j2
+++ b/besser/generators/java_classes/templates/java_template.py.j2
@@ -1,31 +1,3 @@
-{#
-  java_template.py.j2
-  --------------------
-  Jinja2 template that generates a single Java class file from a BESSER B-UML class object.
-
-  Context variables (passed by JavaGenerator):
-    class_obj               : Class         - The B-UML class to generate.
-    processed_associations  : list[str]     - Names of associations already generated in a previous class to avoid duplicates.
-    package_name            : str | None    - Java package declaration; None or empty means no package statement.
-
-  What is generated per class:
-    - Package declaration (if package_name is set)
-    - Import statements (java.time.*, java.util.UUID, List, ArrayList) based on used types
-    - Class declaration with optional extends for single inheritance
-    - Private fields for all attributes and navigable association ends
-    - Default constructor (initialises List fields to new ArrayList<>())
-    - Overloaded constructor accepting List association fields as parameters (only when List fields exist)
-    - Getters and setters for all attribute fields
-    - Getters and add-methods for association fields (addTo<Name> for self-associations, add<Type> for others)
-    - Method stubs for all methods defined on the class (skips methods already generated as association adders)
-
-  Enhancements vs original BESSER generator:
-    - Respects is_navigable on association ends — only generates fields for navigable ends
-    - Supports bidirectional associations: generates back-references (e.g., many-to-one relationships)
-    - Each class generates fields for all its association ends (doesn't skip already-processed associations)
-    - Generates method stubs from class_obj.methods
-    - Fixes leading comma bug in overloaded constructor when attribs is empty
-#}
 // This is a template example to list the name of the classes
 {% if package_name %}
 package {{ package_name }};

--- a/besser/generators/java_classes/templates/java_template.py.j2
+++ b/besser/generators/java_classes/templates/java_template.py.j2
@@ -223,6 +223,10 @@ public class {{ class_obj.name }} {{ extends }}{
         {% endif %}
     {% endif %}
 {% endfor %}
+{# A stub has to compile whatever it returns. An empty body is only valid for
+   void, so anything else fails the whole file with "missing return statement";
+   throwing also keeps a missing implementation from passing for a real answer,
+   the way `return null` would. #}
 {% for method in class_obj.methods %}
     {% if method.name not in generated_assoc_methods %}
         {% set ns = namespace(return_type="void") %}
@@ -235,6 +239,8 @@ public class {{ class_obj.name }} {{ extends }}{
             {{ java_fields.get_field(param.type.name) | trim }} {{ param.name }}{% if not loop.last %}, {% endif %}
         {%- endfor -%}
     ) {
+        // TODO: implement {{ method.name }}
+        throw new UnsupportedOperationException("{{ method.name }} is not implemented");
     }
     {% endif %}
 {% endfor %}

--- a/besser/generators/java_classes/templates/java_template.py.j2
+++ b/besser/generators/java_classes/templates/java_template.py.j2
@@ -1,3 +1,31 @@
+{#
+  java_template.py.j2
+  --------------------
+  Jinja2 template that generates a single Java class file from a BESSER B-UML class object.
+
+  Context variables (passed by JavaGenerator):
+    class_obj               : Class         - The B-UML class to generate.
+    processed_associations  : list[str]     - Names of associations already generated in a previous class to avoid duplicates.
+    package_name            : str | None    - Java package declaration; None or empty means no package statement.
+
+  What is generated per class:
+    - Package declaration (if package_name is set)
+    - Import statements (java.time.*, java.util.UUID, List, ArrayList) based on used types
+    - Class declaration with optional extends for single inheritance
+    - Private fields for all attributes and navigable association ends
+    - Default constructor (initialises List fields to new ArrayList<>())
+    - Overloaded constructor accepting List association fields as parameters (only when List fields exist)
+    - Getters and setters for all attribute fields
+    - Getters and add-methods for association fields (addTo<Name> for self-associations, add<Type> for others)
+    - Method stubs for all methods defined on the class (skips methods already generated as association adders)
+
+  Enhancements vs original BESSER generator:
+    - Respects is_navigable on association ends — only generates fields for navigable ends
+    - Supports bidirectional associations: generates back-references (e.g., many-to-one relationships)
+    - Each class generates fields for all its association ends (doesn't skip already-processed associations)
+    - Generates method stubs from class_obj.methods
+    - Fixes leading comma bug in overloaded constructor when attribs is empty
+#}
 // This is a template example to list the name of the classes
 {% if package_name %}
 package {{ package_name }};
@@ -51,17 +79,19 @@ public class {{ class_obj.name }} {{ extends }}{
         {% set is_self_assoc = (ends_list[0].type.name == ends_list[1].type.name) %}
         {% if is_self_assoc %}
             {% for end in ends_list %}
-                {% if end.multiplicity.max > 1 %}
+                {% if end.is_navigable %}
+                    {% if end.multiplicity.max > 1 %}
     private List<{{ end.type.name }}> {{ end.name }};
-                    {% do assocs.append('List<'+end.type.name+'>') %}
-                    {% do assocs.append(end.name) %}
-                    {% do assocs_card_over_1.append(end.type.name) %}
-                    {% do assocs_card_over_1.append(end.name) %}
-                    {% do self_assoc_names.append(end.name) %}
-                {% else %}
+                        {% do assocs.append('List<'+end.type.name+'>') %}
+                        {% do assocs.append(end.name) %}
+                        {% do assocs_card_over_1.append(end.type.name) %}
+                        {% do assocs_card_over_1.append(end.name) %}
+                        {% do self_assoc_names.append(end.name) %}
+                    {% else %}
     private {{ end.type.name }} {{ end.name }};
-                    {% do assocs.append(end.type.name) %}
-                    {% do assocs.append(end.name) %}
+                        {% do assocs.append(end.type.name) %}
+                        {% do assocs.append(end.name) %}
+                    {% endif %}
                 {% endif %}
             {% endfor %}
             {% do processed_associations.append(association.name) %}
@@ -73,30 +103,34 @@ public class {{ class_obj.name }} {{ extends }}{
             {% endfor %}
             {% set class1_name = ns.end1.type.name %}
             {% set class2_name = ns.end2.type.name %}
-            {% if ns.end1.multiplicity.max > 1 and ns.end2.multiplicity.max > 1%}
+            {# Generate field for end2 (the other class) if navigable - supports bidirectional associations #}
+            {% if ns.end1.multiplicity.max > 1 and ns.end2.multiplicity.max > 1 and ns.end2.is_navigable %}
                 {% if ns.end1.multiplicity.min != 1 and ns.end2.multiplicity.min == 1 or
                     ns.end1.multiplicity.min == 1 and ns.end2.multiplicity.min == 1 or
                     ns.end1.multiplicity.min != 1 and ns.end2.multiplicity.min != 1 %}
-    private List<{{ class2_name }}> {{ class2_name.lower() }}s;
+    private List<{{ class2_name }}> {{ ns.end2.name }};
                     {% do assocs.append('List<'+class2_name+'>') %}
-                    {% do assocs.append(class2_name.lower() + 's') %}
+                    {% do assocs.append(ns.end2.name) %}
                     {% do assocs_card_over_1.append(class2_name) %}
-                    {% do assocs_card_over_1.append(class2_name.lower() + 's') %}
-                    {% do processed_associations.append(association.name) %}
+                    {% do assocs_card_over_1.append(ns.end2.name) %}
                 {% endif %}
-            {% elif ns.end1.multiplicity.max == 1 and ns.end2.multiplicity.max > 1 %}
-    private List<{{ class2_name }}> {{ class2_name.lower() }}s;
+            {% elif ns.end1.multiplicity.max == 1 and ns.end2.multiplicity.max > 1 and ns.end2.is_navigable %}
+    private List<{{ class2_name }}> {{ ns.end2.name }};
                 {% do assocs.append('List<'+class2_name+'>') %}
-                {% do assocs.append(class2_name.lower() + 's') %}
+                {% do assocs.append(ns.end2.name) %}
                 {% do assocs_card_over_1.append(class2_name) %}
-                {% do assocs_card_over_1.append(class2_name.lower() + 's') %}
-                {% do processed_associations.append(association.name) %}
-            {% elif ns.end1.multiplicity.max == 1 and ns.end2.multiplicity.max == 1 %}
-    private {{ class2_name }} {{ class2_name.lower() }};
+                {% do assocs_card_over_1.append(ns.end2.name) %}
+            {% elif ns.end1.multiplicity.max == 1 and ns.end2.multiplicity.max == 1 and ns.end2.is_navigable %}
+    private {{ class2_name }} {{ ns.end2.name }};
                 {% do assocs.append(class2_name) %}
-                {% do assocs.append(class2_name.lower()) %}
-                {% do processed_associations.append(association.name) %}
+                {% do assocs.append(ns.end2.name) %}
+            {% elif ns.end1.multiplicity.max > 1 and ns.end2.multiplicity.max == 1 and ns.end2.is_navigable %}
+                {# Bidirectional: many-to-one association, generate back-reference to the one side #}
+    private {{ class2_name }} {{ ns.end2.name }};
+                {% do assocs.append(class2_name) %}
+                {% do assocs.append(ns.end2.name) %}
             {% endif %}
+            {# Don't mark as processed to support bidirectional associations - each class handles its own end #}
         {% endif %}
     {% endif %}
 {% endfor %}
@@ -168,7 +202,7 @@ public class {{ class_obj.name }} {{ extends }}{
     {%- endfor -%}
 {% endif %}
 {%- for i in range(0, assocs_card_over_1|length, 2) -%}
-    ,{{" "}}ArrayList<{{ assocs_card_over_1[i] }}> {{ assocs_card_over_1[i+1] }}
+    {{ ", " if i > 0 or attribs|length > 0 or inheritance|length > 1 else "" }}ArrayList<{{ assocs_card_over_1[i] }}> {{ assocs_card_over_1[i+1] }}
 {%- endfor -%}
 ) {
 {% if inheritance|length > 1 %}
@@ -229,6 +263,34 @@ public class {{ class_obj.name }} {{ extends }}{
 
     public void set{{ assocs[i+1].capitalize() }}({{ assocs[i] }} {{ assocs[i+1] }}) {
         this.{{ assocs[i+1] }} = {{ assocs[i+1] }};
+    }
+    {% endif %}
+{% endfor %}
+{% set generated_assoc_methods = [] %}
+{% for i in range(0, assocs|length, 2) %}
+    {% if assocs[i][:4] == "List" %}
+        {% set element_type = assocs[i][5:-1] %}
+        {% if assocs[i+1] in self_assoc_names %}
+            {% do generated_assoc_methods.append('addTo' + assocs[i+1].capitalize()) %}
+        {% else %}
+            {% do generated_assoc_methods.append('add' + element_type) %}
+        {% endif %}
+    {% endif %}
+{% endfor %}
+{% for method in class_obj.methods %}
+    {% if method.name not in generated_assoc_methods %}
+        {% set ns = namespace(return_type="void") %}
+        {% if method.type %}
+            {% set jf = java_fields.get_field(method.type.name) | trim %}
+            {% set ns.return_type = method.type.name if jf == "None" else jf %}
+        {% endif %}
+
+    {{ method.visibility }} {{ ns.return_type }} {{ method.name }}(
+        {%- for param in method.parameters -%}
+            {%- set jf_param = java_fields.get_field(param.type.name) | trim -%}
+            {{ param.type.name if jf_param == "None" else jf_param }} {{ param.name }}{% if not loop.last %}, {% endif %}
+        {%- endfor -%}
+    ) {
     }
     {% endif %}
 {% endfor %}

--- a/besser/generators/pydantic_classes/pydantic_classes_generator.py
+++ b/besser/generators/pydantic_classes/pydantic_classes_generator.py
@@ -84,7 +84,11 @@ class PydanticGenerator(GeneratorInterface):
             assoc_link_meta.append({
                 "link_class": link_class,
                 "attributes": [
-                    {"name": attr.name, "type_name": attr.type.name}
+                    {
+                        "name": attr.name,
+                        "type_name": attr.type.name,
+                        "optional": attr.is_optional,
+                    }
                     for attr in sort_by_timestamp(cls.attributes)
                 ],
             })

--- a/besser/generators/pydantic_classes/templates/pydantic_classes_template.py.j2
+++ b/besser/generators/pydantic_classes/templates/pydantic_classes_template.py.j2
@@ -51,7 +51,8 @@ class {{ enum.name }}(Enum):
 class {{ link.link_class }}(BaseModel):
     target: int  # primary key of the linked entity
 {% for attr in link.attributes %}
-    {{ attr.name }}: {{ 'Any' if attr.type_name == 'any' else attr.type_name }}
+{% set link_attr_type = 'Any' if attr.type_name == 'any' else attr.type_name %}
+    {{ attr.name }}: {{ ('Optional[' ~ link_attr_type ~ '] = None') if attr.optional else link_attr_type }}
 {% endfor %}
 
 {% endfor %}

--- a/besser/generators/react/serialization.py
+++ b/besser/generators/react/serialization.py
@@ -1250,14 +1250,27 @@ class GuiSerializationMixin:
     def _select_display_field(attributes: List[Any]) -> str:
         """Pick the attribute shown for a related record in lookup selects.
 
-        Preference order: an attribute literally named ``name``, then the first
-        string attribute that is not the id, then the first non-id attribute,
-        then the first attribute.
+        The label has to let someone tell two records apart, so an attribute the
+        model marks as a business identifier wins, and an ``email`` outranks a
+        ``name``: two people called Jane are indistinguishable in a dropdown,
+        two email addresses are not.
+
+        Preference order: an attribute marked ``is_external_id``, then one named
+        ``email``, then one named ``name``, then the first string attribute that
+        is not the id, then the first non-id attribute, then the first attribute.
         """
         if not attributes:
             return ""
-        if any(attr.name == "name" for attr in attributes):
-            return "name"
+        external_id = next(
+            (attr for attr in attributes
+             if getattr(attr, "is_external_id", False) and not getattr(attr, "is_id", False)),
+            None,
+        )
+        if external_id is not None:
+            return external_id.name
+        for preferred in ("email", "name"):
+            if any(attr.name == preferred for attr in attributes):
+                return preferred
         string_attr = next(
             (attr for attr in attributes
              if not getattr(attr, "is_id", False) and attr.name != "id"

--- a/besser/generators/react/templates/src/components/MethodButton.tsx.j2
+++ b/besser/generators/react/templates/src/components/MethodButton.tsx.j2
@@ -87,6 +87,10 @@ export const MethodButton: React.FC<MethodButtonProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [showModal, setShowModal] = useState(false);
   const [showSuccessToast, setShowSuccessToast] = useState(false);
+  // A method that guards itself - refusing a second bill, a departure before
+  // arrival - reports that by returning false. It ran, but it did not act, and
+  // saying "completed successfully" would tell the user the opposite.
+  const [declined, setDeclined] = useState(false);
   const [showErrorToast, setShowErrorToast] = useState(false);
   const [showResultModal, setShowResultModal] = useState(false);
   const [resultMessage, setResultMessage] = useState("");
@@ -275,6 +279,8 @@ export const MethodButton: React.FC<MethodButtonProps> = ({
       console.log(`[MethodButton] Method executed successfully:`, response.data);
       setResult(response.data);
       const formattedResult = formatMethodResult(response.data);
+      const wasDeclined = /^false$/i.test(String(formattedResult).trim());
+      setDeclined(wasDeclined);
       if (formattedResult) {
         setResultMessage(formattedResult);
         setShowResultModal(true);
@@ -295,9 +301,11 @@ export const MethodButton: React.FC<MethodButtonProps> = ({
         setShowModal(false);
       }
       
-      // Show brief success confirmation
-      setShowSuccessToast(true);
-      setTimeout(() => setShowSuccessToast(false), 3000);
+      // Show brief success confirmation, unless the method declined to act
+      if (!wasDeclined) {
+        setShowSuccessToast(true);
+        setTimeout(() => setShowSuccessToast(false), 3000);
+      }
     } catch (err: any) {
       console.error(`[MethodButton] Error executing method:`, err);
       
@@ -698,8 +706,13 @@ export const MethodButton: React.FC<MethodButtonProps> = ({
               color: "#1e293b",
               fontSize: "18px",
             }}>
-              Method Result
+              {declined ? "Not applied" : "Method Result"}
             </h4>
+            {declined && (
+              <p style={{ margin: "0 0 12px", color: "#92400e", fontSize: "14px" }}>
+                {`${label || methodName} did not apply: the conditions it checks were not met, so nothing changed.`}
+              </p>
+            )}
             <pre style={{
               margin: 0,
               padding: "12px",

--- a/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
+++ b/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
@@ -1177,6 +1177,12 @@ export const TableComponent: React.FC<Props> = ({
                                       type="checkbox"
                                       checked={isChecked}
                                       onChange={() => {}} // Handled by parent div onClick
+                                      // The record this option stands for. Its label is a
+                                      // display attribute that need not be unique, so the
+                                      // key is what identifies the option to anything
+                                      // driving the form.
+                                      value={String(optionValue)}
+                                      data-option-id={String(optionValue)}
                                       style={{
                                         width: "16px",
                                         height: "16px",

--- a/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
+++ b/besser/generators/react/templates/src/components/table/TableComponent.tsx.j2
@@ -33,6 +33,8 @@ interface TableColumn {
   targetField?: string;
   relationshipKey?: string;
   associationClass?: AssociationClassMeta;
+  // The model's default for the attribute (e.g. an enumeration literal); preselected for new records
+  defaultValue?: any;
 }
 
 interface TableOptions {
@@ -212,6 +214,7 @@ export const TableComponent: React.FC<Props> = ({
           entity: col.entity,
           options: col.options,
           required: col.required ?? false,
+          defaultValue: (col as any).defaultValue ?? (col as any).default_value,
           lookupField: col.column_type === "lookup" ? lookupField : undefined,
           targetField: col.column_type === "lookup" ? targetField : undefined,
           relationshipKey: relationshipKey,
@@ -597,6 +600,11 @@ export const TableComponent: React.FC<Props> = ({
           // For new records, initialize appropriately
           if (col.columnType === 'lookup' && col.type === 'list') {
             initialValues[col.field] = [];
+          } else if (col.columnType !== 'lookup' && col.defaultValue !== undefined && col.defaultValue !== null) {
+            // Preselect the model's default (e.g. booking_status = pending_payment)
+            initialValues[col.field] = (col.type === 'bool' || col.type === 'boolean')
+              ? (typeof col.defaultValue === 'boolean' ? col.defaultValue : String(col.defaultValue).toLowerCase() === 'true')
+              : String(col.defaultValue);
           } else {
             initialValues[col.field] = "";
           }
@@ -956,6 +964,11 @@ export const TableComponent: React.FC<Props> = ({
                       }
                     } else {
                       const value = formValues[col.field];
+                      if (col.type === 'enum' && (value === undefined || value === null || value === '')) {
+                        // No literal chosen: leave the field out so the backend applies the
+                        // attribute's default (or reports it missing) instead of rejecting ""
+                        return;
+                      }
                       if (col.type === 'list') {
                         // Convert comma-separated string to array
                         processedValues[col.field] = typeof value === 'string' 

--- a/besser/generators/sql_alchemy/sql_alchemy_generator.py
+++ b/besser/generators/sql_alchemy/sql_alchemy_generator.py
@@ -3,7 +3,7 @@ from jinja2 import Environment, FileSystemLoader
 from besser.BUML.metamodel.structural import DomainModel, AssociationClass
 from besser.generators import GeneratorInterface
 from besser.utilities.utils import sort_by_timestamp
-from besser.generators.structural_utils import get_foreign_keys, get_pk_py_types
+from besser.generators.structural_utils import get_foreign_keys, normalize_method_code, get_pk_py_types
 
 class SQLAlchemyGenerator(GeneratorInterface):
     """
@@ -230,6 +230,7 @@ class SQLAlchemyGenerator(GeneratorInterface):
         templates_path = os.path.join(os.path.dirname(
             os.path.abspath(__file__)), "templates")
         env = Environment(loader=FileSystemLoader(templates_path))
+        env.globals.update(normalize_code=normalize_method_code)
         template = env.get_template('sql_alchemy_template.py.j2')
         with open(file_path, mode="w", encoding="utf-8") as f:
             generated_code = template.render(

--- a/besser/generators/sql_alchemy/templates/helpers.py.j2
+++ b/besser/generators/sql_alchemy/templates/helpers.py.j2
@@ -42,6 +42,9 @@
         {%- if secondary %}, secondary={{ secondary }}{% endif %}, back_populates="{{other_end.name}}"
         {%- if fk_needed %}{% if fk_needed %}, foreign_keys=[{{ fk_expr }}]{% endif %}{% endif %})
     {%- else -%}
-{{class.name}}.{{end.name}}: Mapped_["{{end.type.name}}"] = relationship("{{end.type.name}}", back_populates="{{other_end.name}}"{% if fk_needed %}, foreign_keys=[{{ fk_expr }}]{% endif %})
+{#- uselist is spelled out because these relationships are assigned after the class
+    body: SQLAlchemy never sees the Mapped_["X"] annotation and would otherwise infer
+    a collection from the foreign-key direction, turning a 0..1 end into a list. #}
+{{class.name}}.{{end.name}}: Mapped_["{{end.type.name}}"] = relationship("{{end.type.name}}", back_populates="{{other_end.name}}", uselist=False{% if fk_needed %}, foreign_keys=[{{ fk_expr }}]{% endif %})
     {%- endif -%}
 {%- endmacro %}

--- a/besser/generators/sql_alchemy/templates/sql_alchemy_template.py.j2
+++ b/besser/generators/sql_alchemy/templates/sql_alchemy_template.py.j2
@@ -214,6 +214,18 @@ class {{ asso_class.name }}(Base):
     null it out - without the cascade a delete fails with an AssertionError). #}
 {{ end.type.name }}.{{ asso_class.name.lower() }}s: Mapped_[List_["{{ asso_class.name }}"]] = relationship("{{ asso_class.name }}", back_populates="{{ end.name }}", cascade="all, delete-orphan")
     {%- endfor %}
+{#- The association ends are also reachable directly, under the names the model gives
+    them, so that method bodies and OCL constraints written against the diagram (for
+    example self.rooms) resolve. Writes go through the link rows above, so these are
+    read-only views over the same table. #}
+    {%- for end in asso_class.association.ends %}
+        {%- set other_end = (asso_class.association.ends | reject('equalto', end) | list)[0] %}
+        {%- if end.multiplicity.max > 1 %}
+{{ other_end.type.name }}.{{ end.name }}: Mapped_[List_["{{ end.type.name }}"]] = relationship("{{ end.type.name }}", secondary={{ asso_class.name }}.__table__, viewonly=True)
+        {%- else %}
+{{ other_end.type.name }}.{{ end.name }}: Mapped_["{{ end.type.name }}"] = relationship("{{ end.type.name }}", secondary={{ asso_class.name }}.__table__, viewonly=True, uselist=False)
+        {%- endif %}
+    {%- endfor %}
 {%- endfor %}
 
 # Database connection (override the default with the DATABASE_URL environment variable)

--- a/besser/generators/sql_alchemy/templates/sql_alchemy_template.py.j2
+++ b/besser/generators/sql_alchemy/templates/sql_alchemy_template.py.j2
@@ -148,6 +148,17 @@ class {{ class.name }}(
         "concrete": True,
     }
     {%- endif %}
+{#- The methods the class declares belong on the class: a body that calls another
+    method of the same object (self.calculate_price()) only resolves if they do.
+    A method named after a column is skipped rather than emitted - defining both
+    would leave the column unreadable, so self.check_out - self.check_in would
+    subtract two methods instead of two dates. #}
+    {%- set column_names = class.all_attributes() | map(attribute='name') | list
+                         + class.association_ends() | map(attribute='name') | list %}
+    {%- for method in class.methods if method.code and method.name not in column_names %}
+
+{{ normalize_code(method.code, method.name) | indent(4, first=true) }}
+    {%- endfor %}
 {% endfor %}
 
 {#- Association Classes #}

--- a/besser/utilities/web_modeling_editor/backend/tools/generate_web_app_from_json.py
+++ b/besser/utilities/web_modeling_editor/backend/tools/generate_web_app_from_json.py
@@ -34,10 +34,25 @@ def load_project_data(json_path: Path) -> Dict[str, Any]:
     raise ValueError("Expected a JSON object with a 'project' key or top-level project payload.")
 
 
-def _get_diagram(diagrams: Dict[str, Any], key: str) -> Optional[Dict[str, Any]]:
+def _get_diagram(
+    diagrams: Dict[str, Any], key: str, current_indices: Optional[Dict[str, int]] = None
+) -> Optional[Dict[str, Any]]:
+    """The active diagram of a type.
+
+    A project holds a list per diagram type and names the active one in
+    ``currentDiagramIndices``. Older exports stored a single diagram per type
+    directly, so both shapes are accepted.
+    """
     diagram = diagrams.get(key)
     if diagram is None:
         return None
+    if isinstance(diagram, list):
+        if not diagram:
+            return None
+        index = (current_indices or {}).get(key, 0)
+        if not 0 <= index < len(diagram):
+            index = 0
+        diagram = diagram[index]
     if isinstance(diagram, dict):
         return diagram
     try:
@@ -49,9 +64,10 @@ def _get_diagram(diagrams: Dict[str, Any], key: str) -> Optional[Dict[str, Any]]
 def generate_web_app(json_path: Path, output_dir: Path, include_agent: bool = True, verbose: bool = False) -> Path:
     project = load_project_data(json_path)
     diagrams = project.get("diagrams", {}) if isinstance(project, dict) else {}
+    current_indices = project.get("currentDiagramIndices", {}) if isinstance(project, dict) else {}
 
-    class_diagram = _get_diagram(diagrams, "ClassDiagram")
-    gui_diagram = _get_diagram(diagrams, "GUINoCodeDiagram")
+    class_diagram = _get_diagram(diagrams, "ClassDiagram", current_indices)
+    gui_diagram = _get_diagram(diagrams, "GUINoCodeDiagram", current_indices)
 
     if not class_diagram or not gui_diagram:
         available = ", ".join(sorted(diagrams.keys())) if diagrams else "none"
@@ -69,7 +85,7 @@ def generate_web_app(json_path: Path, output_dir: Path, include_agent: bool = Tr
 
     agent_model = None
     if include_agent:
-        agent_diagram = _get_diagram(diagrams, "AgentDiagram")
+        agent_diagram = _get_diagram(diagrams, "AgentDiagram", current_indices)
         if agent_diagram:
             if verbose:
                 logger.info("Detected AgentDiagram. Generating agent output.")

--- a/docs/source/releases/v7.rst
+++ b/docs/source/releases/v7.rst
@@ -4,6 +4,7 @@ Version 7
 .. toctree::
    :maxdepth: 1
 
+   v7/v7.16.0
    v7/v7.15.0
    v7/v7.14.2
    v7/v7.14.1

--- a/docs/source/releases/v7/v7.16.0.rst
+++ b/docs/source/releases/v7/v7.16.0.rst
@@ -1,0 +1,85 @@
+Version 7.16.0
+==============
+
+Minor release: **a substantially better Java generator, and a round of fixes to
+the generated web app driven by running a full acceptance suite against it**.
+The Java work was contributed by palfner-sse (BESSER #595, #596) and reviewed
+and completed by the BESSER team. The rest came out of driving the
+`Agentic-Low-Code-Benchmark <https://github.com/BESSER-PEARL/Agentic-Low-Code-Benchmark>`_
+hotel-booking suite through the generated interface, which surfaced a set of
+defects that only appear once an application is actually used.
+
+One change can reject a model that was previously accepted: a class may no
+longer declare a method with the name of one of its attributes or association
+ends. See *Model validation* below.
+
+Highlights
+----------
+
+- **Java generator**: enumerations are generated as Java ``enum`` files and used
+  as the type of the attributes, parameters and return values that reference
+  them; bidirectional associations emit a field on both sides; navigability is
+  honoured, so a non-navigable end no longer produces a field; methods declared
+  in the model are emitted as stubs; and the package name is now an explicit
+  ``package_name`` parameter of ``JavaGenerator`` rather than being guessed from
+  the output path. Method stubs throw ``UnsupportedOperationException`` so the
+  generated sources compile whatever a method returns, and the test suite now
+  compiles its output with ``javac`` when a JDK is available.
+
+- **A 0..1 association end is a single object again**: relationships are
+  assigned after the class body, so SQLAlchemy never sees the ``Mapped_``
+  annotation and inferred a collection from the foreign-key direction. An
+  optional end read back as ``[]`` rather than ``None``, which made a guard as
+  ordinary as ``if self.invoice is not None`` always true — a booking could
+  never produce its bill.
+
+- **Association ends keep the names the diagram gives them**: an association
+  class exposed only its link rows, so ``self.rooms`` — the end name the model
+  uses, and the one its own OCL constraints navigate — raised ``AttributeError``
+  at runtime. The ends are now reachable under their model names as read-only
+  views over the link table, with writes still going through the association
+  class.
+
+- **A class's methods are on the class**: model methods existed only as bodies
+  inlined into the endpoints exposing them, so a method calling another method
+  of the same object failed on an object that, per the diagram, has it.
+
+- **An optional association-class attribute stays optional**: the link payload
+  declared every attribute of the association class as required whatever the
+  model said, so the request the form built was rejected for a value the
+  interface never asked for.
+
+- **A declined method is no longer reported as a success**: a method that guards
+  itself — refusing a second bill, a departure before arrival — reports that by
+  returning false, and the page announced "Operation completed successfully" all
+  the same. The confirmation is withheld and the result popup names the outcome.
+
+- **Lookup options identify the record**: the attribute shown for a related
+  record preferred one literally named ``name``, so two guests called Jane were
+  indistinguishable in a dropdown. An attribute the model marks as a business
+  identifier now wins, an email outranks a name, and every multi-select option
+  carries the key of the record it stands for.
+
+Model validation
+----------------
+
+``DomainModel.validate()`` reports a method that shares its name with an
+attribute or an association end of the same class. Generated code reaches both
+through that one name, so one wins and the other becomes unreachable: a body
+reading ``self.check_out - self.check_in`` subtracted two methods instead of two
+dates, and the failure surfaced at runtime with nothing pointing back to the
+diagram. A model that does this now fails validation and has to rename one of
+the two.
+
+Other fixes
+-----------
+
+- The standalone web app tool
+  (``besser.utilities.web_modeling_editor.backend.tools.generate_web_app_from_json``)
+  reads the project export the editor writes today. A project keeps a list of
+  diagrams per type and names the active one in ``currentDiagramIndices``, which
+  the generation router already honoured; the tool still expected a single
+  diagram per type and failed on every current export.
+- The generated create form preselects the default values declared on the
+  attributes, so an enumeration with a default arrives selected instead of
+  empty.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = besser
-version = 7.15.0
+version = 7.16.0
 author = Luxembourg Institute of Science and Technology
 description = BESSER
 long_description = file: README.md

--- a/tests/BUML/metamodel/structural/test_structural.py
+++ b/tests/BUML/metamodel/structural/test_structural.py
@@ -781,3 +781,34 @@ def test_no_attribute_shadowing_validation():
 
     result = domain_model.validate(raise_exception=False)
     assert result["success"] is True
+
+
+def test_method_sharing_a_name_with_an_attribute_is_reported():
+    """A method cannot share its name with a feature of the same class.
+
+    Generated code reaches both through that one name, so one wins and the other
+    becomes unreachable - a body reading self.check_out - self.check_in then
+    subtracts two methods instead of two dates. The diagram is where that has to
+    be caught.
+    """
+    booking = Class(
+        name="Booking",
+        attributes={Property(name="check_in", type=StringType)},
+        methods={Method(name="check_in")},
+    )
+    domain_model = DomainModel(name="TestModel", types={booking})
+
+    result = domain_model.validate(raise_exception=False)
+    assert result["success"] is False
+    assert any("check_in" in e and "Booking" in e for e in result["errors"])
+
+
+def test_a_method_named_differently_from_every_attribute_is_accepted():
+    booking = Class(
+        name="Booking",
+        attributes={Property(name="check_in", type=StringType)},
+        methods={Method(name="register_arrival")},
+    )
+    domain_model = DomainModel(name="TestModel", types={booking})
+
+    assert domain_model.validate(raise_exception=False)["success"] is True

--- a/tests/generators/conftest.py
+++ b/tests/generators/conftest.py
@@ -253,3 +253,68 @@ def library_model_with_inheritance():
         generalizations={gen_History_BookType, gen_Horror_BookType, gen_Science_BookType},
     )
     return model
+
+
+@pytest.fixture
+def custom_role_name_model():
+    """Library-Book where the Book end is named 'ownedBooks' and the Library end 'owner'."""
+    library = Class(name="Library")
+    book = Class(name="Book")
+    library.attributes = {Property(name="name", type=StringType)}
+    book.attributes = {Property(name="title", type=StringType)}
+    assoc = BinaryAssociation(
+        name="Owns",
+        ends={
+            Property(name="ownedBooks", type=book, multiplicity=Multiplicity(0, 9999), is_navigable=True),
+            Property(name="owner", type=library, multiplicity=Multiplicity(1, 1), is_navigable=True),
+        },
+    )
+    return DomainModel(name="Custom_Role_Model", types={library, book}, associations={assoc}, generalizations={})
+
+
+@pytest.fixture
+def non_navigable_assoc_model():
+    """Library-Book where the back-reference end (library) is not navigable."""
+    library = Class(name="Library")
+    book = Class(name="Book")
+    library.attributes = {Property(name="name", type=StringType)}
+    book.attributes = {Property(name="title", type=StringType)}
+    assoc = BinaryAssociation(
+        name="Has",
+        ends={
+            Property(name="books", type=book, multiplicity=Multiplicity(0, 9999), is_navigable=True),
+            Property(name="library", type=library, multiplicity=Multiplicity(1, 1), is_navigable=False),
+        },
+    )
+    return DomainModel(name="NonNav_Model", types={library, book}, associations={assoc}, generalizations={})
+
+
+@pytest.fixture
+def self_assoc_non_navigable_model():
+    """Employee self-association where the 'reports' end is not navigable."""
+    employee = Class(name="Employee")
+    employee.attributes = {Property(name="name", type=StringType)}
+    assoc = BinaryAssociation(
+        name="Manages",
+        ends={
+            Property(name="manager", type=employee, multiplicity=Multiplicity(0, 1), is_navigable=True),
+            Property(name="reports", type=employee, multiplicity=Multiplicity(0, 9999), is_navigable=False),
+        },
+    )
+    return DomainModel(name="SelfAssoc_NonNav_Model", types={employee}, associations={assoc}, generalizations={})
+
+
+@pytest.fixture
+def no_attrib_list_assoc_model():
+    """Container with no attributes but a one-to-many List association to Item."""
+    container = Class(name="Container")
+    item = Class(name="Item")
+    item.attributes = {Property(name="label", type=StringType)}
+    assoc = BinaryAssociation(
+        name="Contains",
+        ends={
+            Property(name="items", type=item, multiplicity=Multiplicity(0, 9999), is_navigable=True),
+            Property(name="container", type=container, multiplicity=Multiplicity(1, 1), is_navigable=True),
+        },
+    )
+    return DomainModel(name="NoAttrib_Model", types={container, item}, associations={assoc}, generalizations={})

--- a/tests/generators/java/test_java_generator.py
+++ b/tests/generators/java/test_java_generator.py
@@ -1,5 +1,12 @@
 import os
+import shutil
+
 import pytest
+from besser.BUML.metamodel.structural import (
+    Class, DomainModel, Property, BinaryAssociation, Multiplicity,
+    Method, Parameter,
+    StringType, IntegerType, FloatType,
+)
 from besser.generators.java_classes import JavaGenerator
 
 
@@ -16,6 +23,103 @@ def library_model(simple_library_book_model):
 def self_assoc_model(employee_self_assoc_model):
     """Alias the shared Employee self-association fixture."""
     return employee_self_assoc_model
+
+
+@pytest.fixture
+def non_tmp_output_dir():
+    """A directory in CWD whose path contains no 'tmp' — needed for package-name tests."""
+    d = os.path.join(os.path.abspath("."), "java_test_pkg_output")
+    os.makedirs(d, exist_ok=True)
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.fixture
+def custom_role_name_model():
+    """Library-Book where the Book end is named 'ownedBooks' (not 'books').
+
+    Verifies that the generator uses end.name rather than classname.lower()+'s'.
+    """
+    library = Class(name="Library")
+    book = Class(name="Book")
+    library.attributes = {Property(name="name", type=StringType)}
+    book.attributes = {Property(name="title", type=StringType)}
+    assoc = BinaryAssociation(
+        name="Owns",
+        ends={
+            Property(name="ownedBooks", type=book, multiplicity=Multiplicity(0, 9999), is_navigable=True),
+            Property(name="owner", type=library, multiplicity=Multiplicity(1, 1), is_navigable=True),
+        },
+    )
+    return DomainModel(name="Custom_Role_Model", types={library, book}, associations={assoc}, generalizations={})
+
+
+@pytest.fixture
+def model_with_methods():
+    """Book class with a typed return method and a parameterised void method."""
+    book = Class(name="Book")
+    book.attributes = {Property(name="title", type=StringType)}
+    get_info = Method(name="getInfo", visibility="public", type=StringType)
+    set_price = Method(name="setPrice", visibility="public", parameters=[Parameter(name="price", type=FloatType)])
+    book.methods = {get_info, set_price}
+    return DomainModel(name="Method_Model", types={book}, associations={}, generalizations={})
+
+
+@pytest.fixture
+def non_navigable_assoc_model():
+    """Library-Book where the back-reference end (library) is not navigable."""
+    library = Class(name="Library")
+    book = Class(name="Book")
+    library.attributes = {Property(name="name", type=StringType)}
+    book.attributes = {Property(name="title", type=StringType)}
+    assoc = BinaryAssociation(
+        name="Has",
+        ends={
+            Property(name="books", type=book, multiplicity=Multiplicity(0, 9999), is_navigable=True),
+            Property(name="library", type=library, multiplicity=Multiplicity(1, 1), is_navigable=False),
+        },
+    )
+    return DomainModel(name="NonNav_Model", types={library, book}, associations={assoc}, generalizations={})
+
+
+@pytest.fixture
+def self_assoc_non_navigable_model():
+    """Employee self-association where the 'reports' end is not navigable."""
+    employee = Class(name="Employee")
+    employee.attributes = {Property(name="name", type=StringType)}
+    assoc = BinaryAssociation(
+        name="Manages",
+        ends={
+            Property(name="manager", type=employee, multiplicity=Multiplicity(0, 1), is_navigable=True),
+            Property(name="reports", type=employee, multiplicity=Multiplicity(0, 9999), is_navigable=False),
+        },
+    )
+    return DomainModel(name="SelfAssoc_NonNav_Model", types={employee}, associations={assoc}, generalizations={})
+
+
+@pytest.fixture
+def no_attrib_list_assoc_model():
+    """Container class with no attributes but a one-to-many List association.
+
+    Exercises the overloaded constructor comma-fix: the first ArrayList param
+    must not be preceded by a comma when the class has no regular attributes.
+    """
+    container = Class(name="Container")
+    item = Class(name="Item")
+    item.attributes = {Property(name="label", type=StringType)}
+    assoc = BinaryAssociation(
+        name="Contains",
+        ends={
+            Property(name="items", type=item, multiplicity=Multiplicity(0, 9999), is_navigable=True),
+            Property(name="container", type=container, multiplicity=Multiplicity(1, 1), is_navigable=True),
+        },
+    )
+    return DomainModel(name="NoAttrib_Model", types={container, item}, associations={assoc}, generalizations={})
+
+
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8") as f:
+        return f.read()
 
 
 def test_normal_association(library_model, tmpdir):
@@ -72,3 +176,170 @@ def test_self_association_getters_setters(self_assoc_model, tmpdir):
     # Should have setter for single field and add method for list field
     assert "setManager(" in code
     assert "addTo" in code or "add" in code
+
+
+def test_enum_file_generated(library_model_with_enum, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=library_model_with_enum, output_dir=str(output_dir)).generate()
+
+    assert os.path.isfile(os.path.join(str(output_dir), "MemberType.java"))
+
+
+def test_enum_declaration(library_model_with_enum, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=library_model_with_enum, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "MemberType.java"))
+    assert "public enum MemberType" in code
+
+
+def test_enum_literals_present(library_model_with_enum, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=library_model_with_enum, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "MemberType.java"))
+    for literal in ("ADULT", "SENIOR", "STUDENT", "CHILD"):
+        assert literal in code
+
+
+def test_class_files_generated_alongside_enum(library_model_with_enum, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=library_model_with_enum, output_dir=str(output_dir)).generate()
+
+    for name in ("Library.java", "Book.java", "Author.java"):
+        assert os.path.isfile(os.path.join(str(output_dir), name))
+
+
+def test_association_field_uses_role_name(custom_role_name_model, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=custom_role_name_model, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Library.java"))
+    assert "private List<Book> ownedBooks;" in code
+    assert "private List<Book> books;" not in code  # regression: old code used classname.lower()+'s'
+
+
+def test_getter_uses_role_name(custom_role_name_model, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=custom_role_name_model, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Library.java"))
+    assert "getOwnedbooks()" in code  # Jinja2 capitalize() lowercases all but first letter
+
+
+def test_bidirectional_many_to_one_backref_field(library_model, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=library_model, output_dir=str(output_dir)).generate()
+
+    # Book (many side) should get a back-reference field to Library (one side)
+    book_code = _read(os.path.join(str(output_dir), "Book.java"))
+    assert "private Library library;" in book_code
+
+
+def test_bidirectional_backref_field_uses_role_name(custom_role_name_model, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=custom_role_name_model, output_dir=str(output_dir)).generate()
+
+    book_code = _read(os.path.join(str(output_dir), "Book.java"))
+    assert "private Library owner;" in book_code
+    assert "private Library library;" not in book_code  # regression: old code used classname.lower()
+
+
+def test_method_stubs_generated(model_with_methods, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=model_with_methods, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Book.java"))
+    assert "getInfo" in code
+    assert "setPrice" in code
+
+
+def test_method_stub_return_type_mapped(model_with_methods, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=model_with_methods, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Book.java"))
+    assert "public String getInfo(" in code
+
+
+def test_method_stub_parameter_type_mapped(model_with_methods, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=model_with_methods, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Book.java"))
+    assert "float price" in code
+
+
+def test_non_navigable_end_generates_no_field(non_navigable_assoc_model, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=non_navigable_assoc_model, output_dir=str(output_dir)).generate()
+
+    # Non-navigable end must not produce a field in Book
+    book_code = _read(os.path.join(str(output_dir), "Book.java"))
+    assert "private Library library;" not in book_code
+
+
+def test_navigable_end_still_generates_field(non_navigable_assoc_model, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=non_navigable_assoc_model, output_dir=str(output_dir)).generate()
+
+    library_code = _read(os.path.join(str(output_dir), "Library.java"))
+    assert "private List<Book> books;" in library_code
+
+
+def test_self_assoc_non_navigable_end_excluded(self_assoc_non_navigable_model, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=self_assoc_non_navigable_model, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Employee.java"))
+    assert "private Employee manager;" in code
+    assert "private List<Employee> reports;" not in code  # non-navigable end excluded
+
+
+def test_constructor_no_leading_comma_when_no_attributes(no_attrib_list_assoc_model, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=no_attrib_list_assoc_model, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Container.java"))
+    # Overloaded constructor must not have a leading comma before the first ArrayList param
+    assert "(, ArrayList" not in code
+    assert "ArrayList<Item>" in code
+
+
+def test_no_package_emitted_in_tmp_dir(library_model, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=library_model, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Library.java"))
+    assert "package " not in code
+
+
+def test_package_emitted_for_non_tmp_dir(library_model, non_tmp_output_dir):
+    JavaGenerator(model=library_model, output_dir=non_tmp_output_dir).generate()
+
+    code = _read(os.path.join(non_tmp_output_dir, "Library.java"))
+    assert "package " in code
+
+
+def test_inheritance_extends_keyword(library_model_with_inheritance, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=library_model_with_inheritance, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Horror.java"))
+    assert "extends BookType" in code
+
+
+def test_inheritance_super_call_in_constructor(library_model_with_inheritance, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=library_model_with_inheritance, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Horror.java"))
+    assert "super(" in code
+
+
+def test_all_subclasses_generated(library_model_with_inheritance, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=library_model_with_inheritance, output_dir=str(output_dir)).generate()
+
+    for name in ("Horror.java", "History.java", "Science.java", "BookType.java"):
+        assert os.path.isfile(os.path.join(str(output_dir), name))

--- a/tests/generators/java/test_java_generator.py
+++ b/tests/generators/java/test_java_generator.py
@@ -1,4 +1,7 @@
 import os
+import shutil
+import subprocess
+from pathlib import Path
 
 import pytest
 from besser.BUML.metamodel.structural import (
@@ -364,3 +367,36 @@ def test_primary_constructor_no_leading_comma_for_bare_subclass(bare_subclass_mo
     code = _read(os.path.join(str(output_dir), "Car.java"))
     assert "(, " not in code
     assert "extends Vehicle" in code
+
+
+def test_method_stub_body_compiles(model_with_methods, tmpdir):
+    """A stub has to compile whatever it returns.
+
+    An empty body is only valid for void: anything else fails the file it is in
+    with "missing return statement", so a single typed method took its whole
+    class down. Throwing also stops a missing implementation from passing for a
+    real answer, the way `return null` would.
+    """
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=model_with_methods, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Book.java"))
+    assert "// TODO: implement getInfo" in code
+    assert 'throw new UnsupportedOperationException("getInfo is not implemented");' in code
+    # Every declared method gets a body, not just the typed ones.
+    assert code.count("UnsupportedOperationException") == code.count("// TODO: implement")
+
+
+def test_generated_java_compiles(model_with_methods, tmpdir):
+    """Compile the output when a JDK is on the machine, since that is the only
+    check that catches a template emitting Java no compiler accepts."""
+    javac = shutil.which("javac")
+    if javac is None:
+        pytest.skip("no JDK available")
+
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=model_with_methods, output_dir=str(output_dir)).generate()
+
+    sources = [str(p) for p in Path(str(output_dir)).glob("*.java")]
+    result = subprocess.run([javac, *sources], capture_output=True, text=True, cwd=str(output_dir))
+    assert result.returncode == 0, result.stderr

--- a/tests/generators/java/test_java_generator.py
+++ b/tests/generators/java/test_java_generator.py
@@ -1,16 +1,12 @@
 import os
-import shutil
 
 import pytest
 from besser.BUML.metamodel.structural import (
     Class, DomainModel, Property, BinaryAssociation, Multiplicity,
-    Method, Parameter,
+    Generalization, Method, Parameter,
     StringType, IntegerType, FloatType,
 )
 from besser.generators.java_classes import JavaGenerator
-
-
-# Use shared fixtures from tests/conftest.py
 
 
 @pytest.fixture
@@ -26,35 +22,6 @@ def self_assoc_model(employee_self_assoc_model):
 
 
 @pytest.fixture
-def non_tmp_output_dir():
-    """A directory in CWD whose path contains no 'tmp' — needed for package-name tests."""
-    d = os.path.join(os.path.abspath("."), "java_test_pkg_output")
-    os.makedirs(d, exist_ok=True)
-    yield d
-    shutil.rmtree(d, ignore_errors=True)
-
-
-@pytest.fixture
-def custom_role_name_model():
-    """Library-Book where the Book end is named 'ownedBooks' (not 'books').
-
-    Verifies that the generator uses end.name rather than classname.lower()+'s'.
-    """
-    library = Class(name="Library")
-    book = Class(name="Book")
-    library.attributes = {Property(name="name", type=StringType)}
-    book.attributes = {Property(name="title", type=StringType)}
-    assoc = BinaryAssociation(
-        name="Owns",
-        ends={
-            Property(name="ownedBooks", type=book, multiplicity=Multiplicity(0, 9999), is_navigable=True),
-            Property(name="owner", type=library, multiplicity=Multiplicity(1, 1), is_navigable=True),
-        },
-    )
-    return DomainModel(name="Custom_Role_Model", types={library, book}, associations={assoc}, generalizations={})
-
-
-@pytest.fixture
 def model_with_methods():
     """Book class with a typed return method and a parameterised void method."""
     book = Class(name="Book")
@@ -66,55 +33,39 @@ def model_with_methods():
 
 
 @pytest.fixture
-def non_navigable_assoc_model():
-    """Library-Book where the back-reference end (library) is not navigable."""
-    library = Class(name="Library")
+def model_with_void_method():
+    """Book class with a no-arg void method."""
     book = Class(name="Book")
-    library.attributes = {Property(name="name", type=StringType)}
     book.attributes = {Property(name="title", type=StringType)}
-    assoc = BinaryAssociation(
-        name="Has",
-        ends={
-            Property(name="books", type=book, multiplicity=Multiplicity(0, 9999), is_navigable=True),
-            Property(name="library", type=library, multiplicity=Multiplicity(1, 1), is_navigable=False),
-        },
-    )
-    return DomainModel(name="NonNav_Model", types={library, book}, associations={assoc}, generalizations={})
+    book.methods = {Method(name="save", visibility="public")}
+    return DomainModel(name="Void_Method_Model", types={book}, associations={}, generalizations={})
 
 
 @pytest.fixture
-def self_assoc_non_navigable_model():
-    """Employee self-association where the 'reports' end is not navigable."""
-    employee = Class(name="Employee")
-    employee.attributes = {Property(name="name", type=StringType)}
+def many_to_many_mixed_min_model():
+    """Student-Course many-to-many: student end min=1, course end min=0."""
+    student = Class(name="Student")
+    course = Class(name="Course")
+    student.attributes = {Property(name="studentId", type=StringType)}
+    course.attributes = {Property(name="title", type=StringType)}
     assoc = BinaryAssociation(
-        name="Manages",
+        name="Enrollment",
         ends={
-            Property(name="manager", type=employee, multiplicity=Multiplicity(0, 1), is_navigable=True),
-            Property(name="reports", type=employee, multiplicity=Multiplicity(0, 9999), is_navigable=False),
+            Property(name="students", type=student, multiplicity=Multiplicity(1, 9999), is_navigable=True),
+            Property(name="courses", type=course, multiplicity=Multiplicity(0, 9999), is_navigable=True),
         },
     )
-    return DomainModel(name="SelfAssoc_NonNav_Model", types={employee}, associations={assoc}, generalizations={})
+    return DomainModel(name="M2M_Mixed_Min_Model", types={student, course}, associations={assoc}, generalizations={})
 
 
 @pytest.fixture
-def no_attrib_list_assoc_model():
-    """Container class with no attributes but a one-to-many List association.
-
-    Exercises the overloaded constructor comma-fix: the first ArrayList param
-    must not be preceded by a comma when the class has no regular attributes.
-    """
-    container = Class(name="Container")
-    item = Class(name="Item")
-    item.attributes = {Property(name="label", type=StringType)}
-    assoc = BinaryAssociation(
-        name="Contains",
-        ends={
-            Property(name="items", type=item, multiplicity=Multiplicity(0, 9999), is_navigable=True),
-            Property(name="container", type=container, multiplicity=Multiplicity(1, 1), is_navigable=True),
-        },
-    )
-    return DomainModel(name="NoAttrib_Model", types={container, item}, associations={assoc}, generalizations={})
+def bare_subclass_model():
+    """Subclass with no own attributes inheriting from a parent that has attributes."""
+    vehicle = Class(name="Vehicle")
+    vehicle.attributes = {Property(name="speed", type=IntegerType)}
+    car = Class(name="Car")
+    gen = Generalization(general=vehicle, specific=car)
+    return DomainModel(name="Bare_Subclass_Model", types={vehicle, car}, associations={}, generalizations={gen})
 
 
 def _read(path: str) -> str:
@@ -156,7 +107,6 @@ def test_self_association_generates_both_fields(self_assoc_model, tmpdir):
     with open(employee_file, "r", encoding="utf-8") as f:
         code = f.read()
 
-    # Both ends of the self-association should produce fields
     assert "private Employee manager;" in code or "private List<Employee> manager;" in code
     assert "private List<Employee> subordinates;" in code or "private Employee subordinates;" in code
 
@@ -170,10 +120,8 @@ def test_self_association_getters_setters(self_assoc_model, tmpdir):
     with open(employee_file, "r", encoding="utf-8") as f:
         code = f.read()
 
-    # Should have getter for manager (single) and subordinates (list)
     assert "getManager()" in code
     assert "getSubordinates()" in code
-    # Should have setter for single field and add method for list field
     assert "setManager(" in code
     assert "addTo" in code or "add" in code
 
@@ -210,13 +158,29 @@ def test_class_files_generated_alongside_enum(library_model_with_enum, tmpdir):
         assert os.path.isfile(os.path.join(str(output_dir), name))
 
 
+def test_enum_attribute_field_uses_enum_type(library_model_with_enum, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=library_model_with_enum, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Author.java"))
+    assert "private MemberType member;" in code
+
+
+def test_enum_attribute_field_not_none(library_model_with_enum, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=library_model_with_enum, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Author.java"))
+    assert "private None" not in code
+
+
 def test_association_field_uses_role_name(custom_role_name_model, tmpdir):
     output_dir = tmpdir.mkdir("output")
     JavaGenerator(model=custom_role_name_model, output_dir=str(output_dir)).generate()
 
     code = _read(os.path.join(str(output_dir), "Library.java"))
     assert "private List<Book> ownedBooks;" in code
-    assert "private List<Book> books;" not in code  # regression: old code used classname.lower()+'s'
+    assert "private List<Book> books;" not in code
 
 
 def test_getter_uses_role_name(custom_role_name_model, tmpdir):
@@ -224,14 +188,13 @@ def test_getter_uses_role_name(custom_role_name_model, tmpdir):
     JavaGenerator(model=custom_role_name_model, output_dir=str(output_dir)).generate()
 
     code = _read(os.path.join(str(output_dir), "Library.java"))
-    assert "getOwnedbooks()" in code  # Jinja2 capitalize() lowercases all but first letter
+    assert "getOwnedBooks()" in code
 
 
 def test_bidirectional_many_to_one_backref_field(library_model, tmpdir):
     output_dir = tmpdir.mkdir("output")
     JavaGenerator(model=library_model, output_dir=str(output_dir)).generate()
 
-    # Book (many side) should get a back-reference field to Library (one side)
     book_code = _read(os.path.join(str(output_dir), "Book.java"))
     assert "private Library library;" in book_code
 
@@ -242,7 +205,7 @@ def test_bidirectional_backref_field_uses_role_name(custom_role_name_model, tmpd
 
     book_code = _read(os.path.join(str(output_dir), "Book.java"))
     assert "private Library owner;" in book_code
-    assert "private Library library;" not in book_code  # regression: old code used classname.lower()
+    assert "private Library library;" not in book_code
 
 
 def test_method_stubs_generated(model_with_methods, tmpdir):
@@ -274,7 +237,6 @@ def test_non_navigable_end_generates_no_field(non_navigable_assoc_model, tmpdir)
     output_dir = tmpdir.mkdir("output")
     JavaGenerator(model=non_navigable_assoc_model, output_dir=str(output_dir)).generate()
 
-    # Non-navigable end must not produce a field in Book
     book_code = _read(os.path.join(str(output_dir), "Book.java"))
     assert "private Library library;" not in book_code
 
@@ -293,7 +255,7 @@ def test_self_assoc_non_navigable_end_excluded(self_assoc_non_navigable_model, t
 
     code = _read(os.path.join(str(output_dir), "Employee.java"))
     assert "private Employee manager;" in code
-    assert "private List<Employee> reports;" not in code  # non-navigable end excluded
+    assert "private List<Employee> reports;" not in code
 
 
 def test_constructor_no_leading_comma_when_no_attributes(no_attrib_list_assoc_model, tmpdir):
@@ -301,24 +263,24 @@ def test_constructor_no_leading_comma_when_no_attributes(no_attrib_list_assoc_mo
     JavaGenerator(model=no_attrib_list_assoc_model, output_dir=str(output_dir)).generate()
 
     code = _read(os.path.join(str(output_dir), "Container.java"))
-    # Overloaded constructor must not have a leading comma before the first ArrayList param
-    assert "(, ArrayList" not in code
-    assert "ArrayList<Item>" in code
+    assert "(, " not in code
+    assert "List<Item> items" in code
 
 
-def test_no_package_emitted_in_tmp_dir(library_model, tmpdir):
+def test_explicit_package_name_emitted(library_model, tmpdir):
     output_dir = tmpdir.mkdir("output")
-    JavaGenerator(model=library_model, output_dir=str(output_dir)).generate()
+    JavaGenerator(model=library_model, output_dir=str(output_dir), package_name="com.example").generate()
+
+    code = _read(os.path.join(str(output_dir), "Library.java"))
+    assert "package com.example;" in code
+
+
+def test_no_package_when_package_name_is_none(library_model, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=library_model, output_dir=str(output_dir), package_name=None).generate()
 
     code = _read(os.path.join(str(output_dir), "Library.java"))
     assert "package " not in code
-
-
-def test_package_emitted_for_non_tmp_dir(library_model, non_tmp_output_dir):
-    JavaGenerator(model=library_model, output_dir=non_tmp_output_dir).generate()
-
-    code = _read(os.path.join(non_tmp_output_dir, "Library.java"))
-    assert "package " in code
 
 
 def test_inheritance_extends_keyword(library_model_with_inheritance, tmpdir):
@@ -343,3 +305,62 @@ def test_all_subclasses_generated(library_model_with_inheritance, tmpdir):
 
     for name in ("Horror.java", "History.java", "Science.java", "BookType.java"):
         assert os.path.isfile(os.path.join(str(output_dir), name))
+
+
+def test_many_to_many_mixed_min_generates_field_on_owning_side(many_to_many_mixed_min_model, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=many_to_many_mixed_min_model, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Student.java"))
+    assert "private List<Course> courses;" in code
+
+
+def test_many_to_many_mixed_min_generates_field_on_other_side(many_to_many_mixed_min_model, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=many_to_many_mixed_min_model, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Course.java"))
+    assert "private List<Student> students;" in code
+
+
+def test_overloaded_constructor_uses_list_interface(no_attrib_list_assoc_model, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=no_attrib_list_assoc_model, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Container.java"))
+    assert "List<Item> items" in code
+    assert "ArrayList<Item> items" not in code
+
+
+def test_enum_literals_no_blank_lines_between(library_model_with_enum, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=library_model_with_enum, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "MemberType.java"))
+    enum_body = code.split("{", 1)[1].rsplit("}", 1)[0]
+    assert "\n\n" not in enum_body
+
+
+def test_void_method_stub_signature(model_with_void_method, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=model_with_void_method, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Book.java"))
+    assert "public void save()" in code
+
+
+def test_non_navigable_book_retains_own_attributes(non_navigable_assoc_model, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=non_navigable_assoc_model, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Book.java"))
+    assert "private String title;" in code
+
+
+def test_primary_constructor_no_leading_comma_for_bare_subclass(bare_subclass_model, tmpdir):
+    output_dir = tmpdir.mkdir("output")
+    JavaGenerator(model=bare_subclass_model, output_dir=str(output_dir)).generate()
+
+    code = _read(os.path.join(str(output_dir), "Car.java"))
+    assert "(, " not in code
+    assert "extends Vehicle" in code

--- a/tests/generators/react/test_react_generator.py
+++ b/tests/generators/react/test_react_generator.py
@@ -556,3 +556,28 @@ def test_form_columns_carry_attribute_defaults_and_the_form_preselects_them(tmp_
     assert "Preselect the model's default" in component
     # An enum left unselected is omitted from the payload instead of sent as ""
     assert "col.type === 'enum' && (value === undefined || value === null || value === '')" in component
+
+
+def test_lookup_options_identify_a_record_rather_than_describe_it():
+    """A dropdown label has to tell two records apart. A business identifier wins,
+    and an email beats a name: two guests called Jane look identical in a select."""
+    from besser.generators.react.serialization import GuiSerializationMixin
+
+    def prop(name, type_=StringType, **kwargs):
+        return Property(name=name, type=type_, **kwargs)
+
+    person = [prop("id", IntegerType, is_id=True), prop("name"), prop("email"), prop("phone_number")]
+    assert GuiSerializationMixin._select_display_field(person) == "email"
+
+    # An attribute the model marks as the business key outranks both.
+    tagged = [prop("id", IntegerType, is_id=True), prop("name"), prop("email"),
+              prop("passport", is_external_id=True)]
+    assert GuiSerializationMixin._select_display_field(tagged) == "passport"
+
+    # Without an email, a name is still the friendliest label available.
+    room = [prop("number", IntegerType, is_id=True), prop("name"), prop("description")]
+    assert GuiSerializationMixin._select_display_field(room) == "name"
+
+    # With neither, fall back to the first non-id string attribute.
+    plain = [prop("number", IntegerType, is_id=True), prop("description")]
+    assert GuiSerializationMixin._select_display_field(plain) == "description"

--- a/tests/generators/react/test_react_generator.py
+++ b/tests/generators/react/test_react_generator.py
@@ -7,6 +7,7 @@ from besser.BUML.metamodel.structural import (
 )
 from besser.BUML.metamodel.gui import GUIModel, Module, Screen, Text, DataBinding
 from besser.BUML.metamodel.gui.dashboard import Map, MapLayer, MapLayerType, Table
+import besser.generators.react
 from besser.generators.react import ReactGenerator
 
 
@@ -581,3 +582,19 @@ def test_lookup_options_identify_a_record_rather_than_describe_it():
     # With neither, fall back to the first non-id string attribute.
     plain = [prop("number", IntegerType, is_id=True), prop("description")]
     assert GuiSerializationMixin._select_display_field(plain) == "description"
+
+
+def test_a_method_that_declines_is_not_reported_as_a_success():
+    """A method that guards itself reports a refusal by returning false. Telling
+    the user the operation completed successfully says the opposite of what
+    happened, so the confirmation is withheld and the popup names the outcome."""
+    component = os.path.join(
+        os.path.dirname(besser.generators.react.__file__),
+        "templates", "src", "components", "MethodButton.tsx.j2",
+    )
+    with open(component, encoding="utf-8") as f:
+        code = f.read()
+
+    assert "const wasDeclined = /^false$/i.test(String(formattedResult).trim());" in code
+    assert "if (!wasDeclined) {" in code
+    assert 'declined ? "Not applied" : "Method Result"' in code

--- a/tests/generators/react/test_react_generator.py
+++ b/tests/generators/react/test_react_generator.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from besser.BUML.metamodel.structural import (
     AssociationClass, Class, DomainModel, Property, StringType, IntegerType, FloatType,
-    BinaryAssociation, Multiplicity
+    BinaryAssociation, Multiplicity, Enumeration, EnumerationLiteral, BooleanType
 )
 from besser.BUML.metamodel.gui import GUIModel, Module, Screen, Text, DataBinding
 from besser.BUML.metamodel.gui.dashboard import Map, MapLayer, MapLayerType, Table
@@ -517,3 +517,42 @@ def test_data_binding_row_key_fields(assoc_class_models):
         "Room": ["number"],                         # declared is_id attribute
         "ReservedRoom": ["bookings_id", "rooms_id"],  # /reservedroom/{bookings_id}/{rooms_id}/
     }
+
+
+# ---------------------------------------------------------------------------
+# Attribute defaults: preselected in the create form
+# ---------------------------------------------------------------------------
+
+def test_form_columns_carry_attribute_defaults_and_the_form_preselects_them(tmp_path):
+    """An enumeration attribute with a model default (booking_status =
+    pending_payment) must reach the form column as defaultValue, and the
+    generated table must initialize a new record with it - an empty "" was
+    posted before, which the backend rejects for an enumeration."""
+    status = Enumeration(name="BookingStatus", literals={
+        EnumerationLiteral(name="pending_payment"), EnumerationLiteral(name="confirmed"),
+    })
+    booking = Class(name="Booking", attributes={
+        Property(name="reference", type=StringType),
+        Property(name="booking_status", type=status, default_value="pending_payment"),
+        Property(name="paid", type=BooleanType, default_value=False),
+    })
+    domain_model = DomainModel(name="DefaultsModel", types={booking, status})
+    table = Table(name="BookingTable", title="Bookings", action_buttons=True,
+                  data_binding=DataBinding(name="booking_binding", domain_concept=booking))
+    screen = Screen(name="Bookings", description="Bookings", view_elements={table}, is_main_page=True)
+    gui_model = GUIModel(name="DefaultsApp", package="com.test.defaults", versionCode="1", versionName="1.0",
+                         modules={Module(name="M", screens={screen})}, description="Defaults GUI")
+    generator = ReactGenerator(model=domain_model, gui_model=gui_model, output_dir=str(tmp_path))
+
+    columns = {col["field"]: col for col in _form_columns(generator)}
+    assert columns["booking_status"]["type"] == "enum"
+    assert columns["booking_status"]["defaultValue"] == "pending_payment"
+    assert columns["paid"]["defaultValue"] is False
+
+    generator.generate()
+    with open(os.path.join(str(tmp_path), "src", "components", "table", "TableComponent.tsx"), encoding="utf-8") as f:
+        component = f.read()
+    assert "defaultValue: (col as any).defaultValue ?? (col as any).default_value" in component
+    assert "Preselect the model's default" in component
+    # An enum left unselected is omitted from the payload instead of sent as ""
+    assert "col.type === 'enum' && (value === undefined || value === null || value === '')" in component

--- a/tests/generators/rest_api/test_rest_api_backend_delegation.py
+++ b/tests/generators/rest_api/test_rest_api_backend_delegation.py
@@ -48,3 +48,37 @@ def test_backend_generator_honors_the_port_argument(library_book_author_model, t
     ).generate()
     with open(os.path.join(output_dir, "main_api.py"), encoding="utf-8") as f:
         assert "port=9002" in f.read()
+
+
+def test_optional_link_attribute_is_optional_in_the_payload(tmp_path):
+    """The form that submits an association-class link leaves an optional
+    attribute blank, so demanding it in the payload rejects a request the UI
+    considers complete."""
+    from besser.BUML.metamodel.structural import (
+        AssociationClass, BinaryAssociation, Class, DomainModel, FloatType,
+        IntegerType, Multiplicity, Property,
+    )
+    from besser.generators.pydantic_classes import PydanticGenerator
+
+    trip = Class(name="Trip", attributes={Property(name="id", type=IntegerType, is_id=True)})
+    seat = Class(name="Seat", attributes={Property(name="code", type=IntegerType, is_id=True)})
+    trip_seat = BinaryAssociation(name="trip_seat", ends={
+        Property(name="trips", type=trip, multiplicity=Multiplicity(0, "*")),
+        Property(name="seats", type=seat, multiplicity=Multiplicity(0, "*")),
+    })
+    reservation = AssociationClass(
+        name="Reservation",
+        attributes={
+            Property(name="price", type=FloatType),
+            Property(name="surcharge", type=FloatType, is_optional=True),
+        },
+        association=trip_seat,
+    )
+    model = DomainModel(name="TripModel", types={trip, seat, reservation}, associations={trip_seat})
+
+    PydanticGenerator(model=model, output_dir=str(tmp_path), backend=True).generate()
+    code = (tmp_path / "pydantic_classes.py").read_text(encoding="utf-8")
+
+    assert "class ReservationLinkCreate(BaseModel):" in code
+    assert "    surcharge: Optional[float] = None" in code
+    assert "    price: float\n" in code

--- a/tests/generators/sqlalchemy/test_sqlalchemy_generator.py
+++ b/tests/generators/sqlalchemy/test_sqlalchemy_generator.py
@@ -518,3 +518,52 @@ def test_optional_single_ended_association_maps_to_a_scalar(tmpdir):
     assert billed.invoice.id == 10
     assert unbilled.invoice is None
     session.close()
+
+
+def test_class_methods_are_emitted_on_the_entity(tmpdir):
+    """A method body that calls another method of the same object only resolves
+    if the methods live on the class, not only inside the endpoints that expose
+    them. A method named after a column is skipped: defining both would leave the
+    column unreadable."""
+    from besser.BUML.metamodel.structural import (
+        Class, DateType, DomainModel, FloatType, IntegerType, Method, Property,
+    )
+
+    booking = Class(
+        name="Booking",
+        attributes={
+            Property(name="id", type=IntegerType, is_id=True),
+            Property(name="price", type=FloatType),
+            Property(name="check_in", type=DateType),
+        },
+        methods={
+            Method(name="total", code="def total(self):\n    return self.price * 2\n"),
+            Method(name="bill", code="def bill(self):\n    return self.total()\n"),
+            # Shares its name with the column above.
+            Method(name="check_in", code="def check_in(self):\n    return True\n"),
+        },
+    )
+    model = DomainModel(name="BookingModel", types={booking})
+
+    output_dir = tmpdir.mkdir("methods")
+    SQLAlchemyGenerator(model=model, output_dir=str(output_dir)).generate(dbms="sqlite")
+    with open(os.path.join(str(output_dir), "sql_alchemy.py"), encoding="utf-8") as f:
+        code = f.read()
+
+    assert "    def total(self):" in code
+    assert "    def bill(self):" in code
+    assert "    def check_in(self):" not in code
+
+    module = _load_generated_module(os.path.join(str(output_dir), "sql_alchemy.py"), "methods_module")
+    engine = create_engine("sqlite:///:memory:")
+    module.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    session.add(module.Booking(id=1, price=10.0, check_in=datetime.date(2026, 10, 1)))
+    session.commit()
+
+    stored = session.query(module.Booking).one()
+    # The one calling the other is the point of putting them on the class.
+    assert stored.bill() == 20.0
+    # The column kept its name.
+    assert stored.check_in == datetime.date(2026, 10, 1)
+    session.close()

--- a/tests/generators/sqlalchemy/test_sqlalchemy_generator.py
+++ b/tests/generators/sqlalchemy/test_sqlalchemy_generator.py
@@ -401,3 +401,120 @@ def test_association_class_links_are_deleted_with_their_entities(tmpdir):
     # Link -> entity: no cascade, deleting a link never deletes the entity
     assert 'Reservation.trips: Mapped_["Trip"] = relationship("Trip", back_populates="reservations")' in code
     assert 'Reservation.seats: Mapped_["Seat"] = relationship("Seat", back_populates="reservations")' in code
+
+
+def _load_generated_module(file_path, module_name):
+    """Import a generated sql_alchemy.py without letting it open its own database."""
+    with open(file_path, "r", encoding="utf-8") as f:
+        code = f.read()
+    code = re.sub(
+        r"# Database connection.*?Base\.metadata\.create_all\(engine, checkfirst=True\)",
+        "engine = create_engine('sqlite:///:memory:', echo=False)",
+        code,
+        flags=re.DOTALL,
+    )
+    patched_path = os.path.join(os.path.dirname(file_path), f"{module_name}.py")
+    with open(patched_path, "w", encoding="utf-8") as f:
+        f.write(code)
+    spec = importlib.util.spec_from_file_location(module_name, patched_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_association_class_ends_are_reachable_under_their_model_names(tmpdir):
+    """An association class must not hide the association: method bodies and OCL
+    constraints are written against the end names from the diagram (self.seats),
+    so those must resolve on the entity, not only the link rows."""
+    from besser.BUML.metamodel.structural import (
+        AssociationClass, BinaryAssociation, Class, DomainModel, FloatType,
+        IntegerType, Multiplicity, Property, StringType,
+    )
+
+    trip = Class(name="Trip", attributes={
+        Property(name="id", type=IntegerType, is_id=True),
+        Property(name="reference", type=StringType),
+    })
+    seat = Class(name="Seat", attributes={Property(name="code", type=IntegerType, is_id=True)})
+    trip_seat = BinaryAssociation(name="trip_seat", ends={
+        Property(name="trips", type=trip, multiplicity=Multiplicity(0, "*")),
+        Property(name="seats", type=seat, multiplicity=Multiplicity(0, "*")),
+    })
+    reservation = AssociationClass(
+        name="Reservation", attributes={Property(name="price", type=FloatType)}, association=trip_seat,
+    )
+    model = DomainModel(name="TripModel", types={trip, seat, reservation}, associations={trip_seat})
+
+    output_dir = tmpdir.mkdir("assoc_ends")
+    SQLAlchemyGenerator(model=model, output_dir=str(output_dir)).generate(dbms="sqlite")
+    with open(os.path.join(str(output_dir), "sql_alchemy.py"), encoding="utf-8") as f:
+        code = f.read()
+
+    # The direct navigations are views over the link table: writes go through the
+    # association-class rows, so they must not compete for the same foreign keys.
+    assert ('Trip.seats: Mapped_[List_["Seat"]] = relationship("Seat", '
+            'secondary=Reservation.__table__, viewonly=True)') in code
+    assert ('Seat.trips: Mapped_[List_["Trip"]] = relationship("Trip", '
+            'secondary=Reservation.__table__, viewonly=True)') in code
+
+    module = _load_generated_module(os.path.join(str(output_dir), "sql_alchemy.py"), "assoc_ends_module")
+    engine = create_engine("sqlite:///:memory:")
+    module.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    a_trip = module.Trip(id=1, reference="TRIP-1")
+    a_seat = module.Seat(code=12)
+    session.add_all([a_trip, a_seat])
+    session.commit()
+    session.add(module.Reservation(trips_id=1, seats_id=12, price=25.0))
+    session.commit()
+    session.expire_all()
+
+    assert [s.code for s in session.query(module.Trip).one().seats] == [12]
+    assert [t.id for t in session.query(module.Seat).one().trips] == [1]
+    session.close()
+
+
+def test_optional_single_ended_association_maps_to_a_scalar(tmpdir):
+    """A 0..1 end must read back as the object or None. These relationships are
+    assigned after the class body, so SQLAlchemy never sees the Mapped_ annotation
+    and infers a collection from the foreign-key direction unless uselist says
+    otherwise - and `if self.invoice is not None` is then always true."""
+    from besser.BUML.metamodel.structural import (
+        BinaryAssociation, Class, DomainModel, FloatType, IntegerType,
+        Multiplicity, Property,
+    )
+
+    booking = Class(name="Booking", attributes={Property(name="id", type=IntegerType, is_id=True)})
+    invoice = Class(name="Invoice", attributes={
+        Property(name="id", type=IntegerType, is_id=True),
+        Property(name="amount", type=FloatType),
+    })
+    booking_invoice = BinaryAssociation(name="booking_invoice", ends={
+        Property(name="booking", type=booking, multiplicity=Multiplicity(1, 1)),
+        Property(name="invoice", type=invoice, multiplicity=Multiplicity(0, 1)),
+    })
+    model = DomainModel(name="BillingModel", types={booking, invoice},
+                        associations={booking_invoice})
+
+    output_dir = tmpdir.mkdir("one_to_one")
+    SQLAlchemyGenerator(model=model, output_dir=str(output_dir)).generate(dbms="sqlite")
+    with open(os.path.join(str(output_dir), "sql_alchemy.py"), encoding="utf-8") as f:
+        code = f.read()
+    assert "uselist=False" in code
+
+    module = _load_generated_module(os.path.join(str(output_dir), "sql_alchemy.py"), "one_to_one_module")
+    engine = create_engine("sqlite:///:memory:")
+    module.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    session.add_all([module.Booking(id=1), module.Booking(id=2)])
+    session.commit()
+    session.add(module.Invoice(id=10, amount=99.0, booking_id=1))
+    session.commit()
+    session.expire_all()
+
+    billed = session.query(module.Booking).filter(module.Booking.id == 1).one()
+    unbilled = session.query(module.Booking).filter(module.Booking.id == 2).one()
+    assert billed.invoice.id == 10
+    assert unbilled.invoice is None
+    session.close()

--- a/tests/utilities/web_modeling_editor/backend/test_generate_web_app_from_json.py
+++ b/tests/utilities/web_modeling_editor/backend/test_generate_web_app_from_json.py
@@ -1,0 +1,32 @@
+"""The standalone web-app generator has to read the export format the editor writes."""
+
+from besser.utilities.web_modeling_editor.backend.tools.generate_web_app_from_json import (
+    _get_diagram,
+)
+
+
+def test_active_diagram_is_taken_from_a_list_of_diagrams():
+    """A project keeps a list per diagram type and names the active one.
+
+    Reading the list as if it were the diagram made the tool fail on every current
+    export with "'list' object has no attribute 'get'".
+    """
+    diagrams = {"ClassDiagram": [{"title": "first"}, {"title": "second"}]}
+
+    assert _get_diagram(diagrams, "ClassDiagram", {"ClassDiagram": 1}) == {"title": "second"}
+    # No index recorded, or one pointing outside the list: fall back to the first.
+    assert _get_diagram(diagrams, "ClassDiagram", {}) == {"title": "first"}
+    assert _get_diagram(diagrams, "ClassDiagram", {"ClassDiagram": 7}) == {"title": "first"}
+
+
+def test_a_single_diagram_per_type_is_still_accepted():
+    """Older exports stored the diagram directly instead of a one-element list."""
+    diagrams = {"ClassDiagram": {"title": "only"}}
+
+    assert _get_diagram(diagrams, "ClassDiagram", {}) == {"title": "only"}
+    assert _get_diagram(diagrams, "ClassDiagram") == {"title": "only"}
+
+
+def test_missing_and_empty_diagram_types_read_as_absent():
+    assert _get_diagram({}, "GUINoCodeDiagram", {}) is None
+    assert _get_diagram({"GUINoCodeDiagram": []}, "GUINoCodeDiagram", {}) is None


### PR DESCRIPTION
## Summary

- **Java generator** (#596, palfner-sse): enums generated as Java `enum` files and used as attribute/parameter/return types, bidirectional associations emit a field on both sides, navigability honoured, method stubs, and an explicit `package_name` parameter instead of guessing from the output path. Stubs throw `UnsupportedOperationException` so the sources compile whatever a method returns.
- **Generated web app**, from running the Agentic-Low-Code-Benchmark hotel-booking suite through the interface: a `0..1` end maps to a scalar instead of a list, association ends stay reachable under their model names, a class's methods are emitted on the class, optional association-class attributes stay optional in the payload, a declined method is no longer announced as a success, and lookup options identify the record rather than describing it.
- **Model validation**: `DomainModel.validate()` reports a method sharing its name with an attribute or association end. This rejects models that were previously accepted.
- The standalone web app tool reads the project export format the editor writes today.

## Test plan

- [x] Full suite: 1536 passed, 9 skipped, 3 xfailed
- [x] Generated Java compiled with javac 21 — clean
- [x] Benchmark hotel-booking suite against the generated app through its UI: 64/68 scenarios, the 4 remaining being capabilities the platform does not have (OCL over collections, derived attributes)
- [ ] Docs build: `cd docs && make html` — the v7.16.0 page renders