### PR TITLE
v7.16.1

### DIFF
--- a/besser/utilities/web_modeling_editor/backend/routers/validation_router.py
+++ b/besser/utilities/web_modeling_editor/backend/routers/validation_router.py
@@ -208,10 +208,14 @@ async def validate_diagram(input_data: DiagramInput):
         # Construction validation errors (from BUML creation setters)
         logger.warning("Construction validation error: %s", e)
         validation_errors.extend(str(e).splitlines())
-    except Exception as e:
+    except Exception:
+        # Anything reaching here is a bug rather than a problem with the diagram,
+        # and its message describes our internals - a missing key, a repr, a path
+        # - none of which helps the person drawing the diagram. The traceback goes
+        # to the log, the caller gets a sentence. The OCL check below and the
+        # @handle_endpoint_errors decorator already behave this way.
         logger.exception("Unexpected error during diagram conversion/validation")
-        error_msg = str(e).strip()
-        validation_errors.append(error_msg if error_msg else "An unexpected error occurred during validation.")
+        validation_errors.append("An unexpected error occurred during validation.")
 
     # Step 2: If BUML model created successfully AND it's a diagram with OCL support
     ocl_results = None

--- a/docs/source/releases/v7.rst
+++ b/docs/source/releases/v7.rst
@@ -4,6 +4,7 @@ Version 7
 .. toctree::
    :maxdepth: 1
 
+   v7/v7.16.1
    v7/v7.16.0
    v7/v7.15.0
    v7/v7.14.2

--- a/docs/source/releases/v7/v7.16.0.rst
+++ b/docs/source/releases/v7/v7.16.0.rst
@@ -3,8 +3,9 @@ Version 7.16.0
 
 Minor release: **a substantially better Java generator, and a round of fixes to
 the generated web app driven by running a full acceptance suite against it**.
-The Java work was contributed by palfner-sse (BESSER #595, #596) and reviewed
-and completed by the BESSER team. The rest came out of driving the
+The Java work was contributed by `Klausmp <https://github.com/Klausmp>`_ and
+`palfner-sse <https://github.com/palfner-sse>`_ (BESSER #595, #596) and
+reviewed and completed by the BESSER team. The rest came out of driving the
 `Agentic-Low-Code-Benchmark <https://github.com/BESSER-PEARL/Agentic-Low-Code-Benchmark>`_
 hotel-booking suite through the generated interface, which surfaced a set of
 defects that only appear once an application is actually used.

--- a/docs/source/releases/v7/v7.16.1.rst
+++ b/docs/source/releases/v7/v7.16.1.rst
@@ -1,0 +1,26 @@
+Version 7.16.1
+==============
+
+Patch release: **the diagram validation endpoint no longer returns the text of
+an unexpected exception to the caller**. No metamodel, API contract or generator
+changes; the validation messages a diagram earns are unchanged.
+
+Highlights
+----------
+
+- **Unexpected errors no longer describe the server**: ``/validate-diagram``
+  caught every exception and put its message into the response's ``errors``
+  list. For a ``ValueError`` or a ``ConversionError`` that is the point — those
+  are the messages the metamodel setters and the JSON converters raise for the
+  person drawing the diagram, and they still come through unchanged. Anything
+  else reaching that handler is a bug rather than a problem with the diagram,
+  and its message describes our internals: a missing key, an object repr, a path
+  on the server, returned to anyone able to post a diagram. The traceback now
+  goes to the log and the caller receives a single sentence, which is what the
+  OCL check in the same function and the ``@handle_endpoint_errors`` decorator
+  already did. Reported by CodeQL as ``py/stack-trace-exposure``.
+
+- **Release notes credit**: the v7.16.0 notes now name
+  `Klausmp <https://github.com/Klausmp>`_ alongside
+  `palfner-sse <https://github.com/palfner-sse>`_ for the Java generator work —
+  the two substantive commits of BESSER #596 are authored by the former account.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = besser
-version = 7.16.0
+version = 7.16.1
 author = Luxembourg Institute of Science and Technology
 description = BESSER
 long_description = file: README.md

--- a/tests/utilities/web_modeling_editor/backend/test_api_integration.py
+++ b/tests/utilities/web_modeling_editor/backend/test_api_integration.py
@@ -1695,3 +1695,31 @@ class TestFeedbackEndpoint:
         """Missing required fields returns 422."""
         response = client.post("/besser_api/feedback", json={})
         assert response.status_code == 422
+
+
+def test_validation_does_not_return_internal_error_text(monkeypatch):
+    """A bug in conversion must not describe our internals to the caller.
+
+    The validation errors a diagram earns are meant to be read by the person who
+    drew it. An unexpected exception is a different thing: its message carries a
+    repr, a key, a path, and returning it verbatim hands that to anyone who can
+    post a diagram.
+    """
+    from besser.utilities.web_modeling_editor.backend.routers import validation_router
+
+    def explode(*args, **kwargs):
+        raise RuntimeError("/srv/besser/internal.py line 42: secret_token='abc123'")
+
+    monkeypatch.setattr(validation_router, "process_class_diagram", explode)
+
+    response = client.post("/besser_api/validate-diagram", json={
+        "title": "Diagram",
+        "model": {"type": "ClassDiagram", "elements": {}, "relationships": {}},
+    })
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["isValid"] is False
+    assert body["errors"] == ["An unexpected error occurred during validation."]
+    assert "secret_token" not in response.text
+    assert "internal.py" not in response.text


### PR DESCRIPTION
## Summary

- `/validate-diagram` no longer returns the text of an unexpected exception. The `ValueError` and `ConversionError` paths are untouched — those are the validation messages the metamodel and the converters raise for the person drawing the diagram, and returning them is what the endpoint is for. Anything else reaching the handler is a bug whose message describes our internals, so the traceback goes to the log and the caller gets a sentence, matching `@handle_endpoint_errors` and the OCL check in the same function. Reported by CodeQL as `py/stack-trace-exposure`.
- Carries the v7.16.0 release-notes correction crediting @Klausmp alongside @palfner-sse for the Java generator work.

## Test plan

- [x] Full suite: 1537 passed, 9 skipped, 3 xfailed
- [x] New regression test raises `RuntimeError("/srv/besser/internal.py line 42: secret_token='abc123'")` from the converter and asserts neither the path nor the token reaches the response — fails on the previous code, passes on this one
- [ ] Docs build: `cd docs && make html` — the v7.16.1 page renders